### PR TITLE
Fix latest version of bls-wallet-signer

### DIFF
--- a/signer/package.json
+++ b/signer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bls-wallet-signer",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "description": "Client-side tool for signing bls transaction data",
   "main": "dist/src/index.js",
   "types": "dist/src/index.d.ts",


### PR DESCRIPTION
In doing some testing I published the following versions that I thought npm would consider hidden prereleases:

```
0.5.1-testDirectBls.1
0.5.1-testDirectBls.2
0.5.1-testDirectBls.3
```

This is unfortunately necessary to test whether the esm.sh compatibility layer will work correctly when using the module in deno.

Anyway, I discovered that npm showed these versions by default at https://www.npmjs.com/package/bls-wallet-signer and worse *installed them by default* with `npm i bls-wallet-signer`.

Therefore, I am simply bumping the version to 0.5.1 without any changes to move these test versions into the background.