### PR TITLE
Support for general transactions in extension

### DIFF
--- a/extension/source/Background/RequestHandler.ts
+++ b/extension/source/Background/RequestHandler.ts
@@ -51,15 +51,27 @@ export default function RequestHandler(
           throw new Error('Not implemented: "value" field missing');
         }
 
+        if (tx.data === undefined) {
+          throw new Error('Not implemented: "function data" field missing');
+        }
+
         if (app.wallet === undefined) {
           throw new Error('No wallet available');
         }
 
+        let promptText: string;
+        if (tx.data === '0x') {
+          promptText = `ETH Transfer 
+          ${formatBalance(tx.value, 'ETH')} 
+          to ${formatCompactAddress(tx.to)}`;
+        } else {
+          promptText = `Contract Interaction ${formatCompactAddress(tx.to)} 
+          value ${formatBalance(tx.value, 'ETH')} 
+          data  ${tx.data}`;
+        }
+
         const promptResult = await promptUser({
-          promptText: `Send ${formatBalance(
-            tx.value,
-            'ETH',
-          )} to ${formatCompactAddress(tx.to)}?`,
+          promptText,
         });
 
         if (promptResult !== 'Yes') {
@@ -71,7 +83,7 @@ export default function RequestHandler(
             nonce: await app.wallet.Nonce(),
             ethValue: BigNumber.from(tx.value),
             contractAddress: tx.to,
-            encodedFunction: '0x',
+            encodedFunction: tx.data,
           },
           app.wallet.privateKey,
         );

--- a/extension/source/CreateTransaction/CreateTransaction.tsx
+++ b/extension/source/CreateTransaction/CreateTransaction.tsx
@@ -10,6 +10,7 @@ type Props = { events: PageEvents };
 export default class CreateTransaction extends React.Component<Props> {
   amountRef?: HTMLInputElement;
   recipientRef?: HTMLInputElement;
+  dataRef?: HTMLInputElement;
 
   render(): React.ReactElement {
     return (
@@ -29,10 +30,18 @@ export default class CreateTransaction extends React.Component<Props> {
               ETH
             </div>
             <div>
-              Recipient:{' '}
+              Contract/Recipient:{' '}
               <input
                 ref={(r) => (this.recipientRef = r ?? undefined)}
                 type="text"
+              />
+            </div>
+            <div>
+              Encoded Function Data:{' '}
+              <input
+                ref={(r) => (this.dataRef = r ?? undefined)}
+                type="text"
+                defaultValue="0x"
               />
             </div>
             <div>
@@ -57,6 +66,7 @@ export default class CreateTransaction extends React.Component<Props> {
                     try {
                       const amount = this.amountRef?.value || undefined;
                       const to = this.recipientRef?.value || undefined;
+                      const data = this.dataRef?.value || undefined;
 
                       if (amount === undefined || to === undefined) {
                         this.props.events.emit(
@@ -76,6 +86,7 @@ export default class CreateTransaction extends React.Component<Props> {
                               .parseEther(amount)
                               .toHexString(),
                             to,
+                            data,
                           },
                         ],
                       });


### PR DESCRIPTION
closes #30

- added a new field in the create transaction window to accept encoded function data
- passing the function data to confirmation dialog
- showing different prompt message based on the function data

I had to include #6 as it contains base for #30 