### PR TITLE
Add PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -11,4 +11,7 @@
 - [ ] I have manually tested these changes
 - [ ] Post a link to the PR in the group chat
 
-*If your PR is not ready, please mark it as a draft*
+## Guidelines
+- If your PR is not ready, mark it as a draft
+- The `resolve conversation` button is for reviewers, not authors
+  - (But add a 'done' comment or similar)

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,15 @@
+## What is this PR doing?
+
+
+## How can these changes be manually tested?
+
+
+## Does this PR resolve or contribute to any issues?
+
+
+## Checklist
+- [ ] I have manually tested these changes
+- [ ] This PR is ready for review
+- [ ] Post a link to the PR in the group chat
+
+*If your PR is not ready, please mark it as a draft*

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -9,7 +9,6 @@
 
 ## Checklist
 - [ ] I have manually tested these changes
-- [ ] This PR is ready for review
 - [ ] Post a link to the PR in the group chat
 
 *If your PR is not ready, please mark it as a draft*


### PR DESCRIPTION
## What is this PR doing?

Adds a template that prefills these headings and the checklist when opening a PR.

## How can these changes be manually tested?

I don't think github gives you a way to do this heh.

## Does this PR resolve or contribute to any issues?

Nope.

## Checklist
- [ ] I have manually tested these changes
- [x] Post a link to the PR in the group chat

## Guidelines
- If your PR is not ready, mark it as a draft
- The `resolve conversation` button is for reviewers, not authors
  - (But add a 'done' comment or similar)