### PR TITLE
Fix docker build

### DIFF
--- a/aggregator/Dockerfile
+++ b/aggregator/Dockerfile
@@ -1,4 +1,4 @@
-FROM denoland/deno:1.14.1
+FROM denoland/deno:1.16.3
 
 ADD build /app
 WORKDIR /app

--- a/aggregator/programs/build.ts
+++ b/aggregator/programs/build.ts
@@ -38,8 +38,6 @@ async function shortContentHash(filePath: string) {
 }
 
 async function BuildName() {
-  // TODO: Make build name change when networkConfig changes
-
   const commitShort = (await shell.Line("git", "rev-parse", "HEAD")).slice(
     0,
     7,

--- a/aggregator/programs/build.ts
+++ b/aggregator/programs/build.ts
@@ -10,111 +10,12 @@ import nil from "../src/helpers/nil.ts";
 const args = parseArgs(Deno.args);
 
 Deno.chdir(repoDir);
-
 const buildDir = `${repoDir}/build`;
 
-const commitShort = (await shell.Line("git", "rev-parse", "HEAD")).slice(0, 7);
-
-const isDirty = (await shell.Lines("git", "status", "--porcelain")).length > 0;
-
-const envHashShort = (await shell.Line("shasum", "-a", "256", dotEnvPath))
-  .slice(0, 7);
-
-const buildName = [
-  "git",
-  commitShort,
-  ...(isDirty ? ["dirty"] : []),
-  "env",
-  envName,
-  envHashShort,
-].join("-");
-
-try {
-  await Deno.remove(buildDir, { recursive: true });
-} catch (error) {
-  if (error.name === "NotFound") {
-    // We don't care that remove failed due to NotFound (why do we need to catch
-    // an exception to handle this normal use case? 🤔)
-  } else {
-    throw error;
-  }
-}
-
-await Deno.mkdir(buildDir);
-
-const originalDotEnv = await Deno.readTextFile(dotEnvPath);
-
-let networkConfigPath: string | nil = nil;
-
-const dotEnv = originalDotEnv
-  .split("\n")
-  .map((line) => {
-    if (line.startsWith("NETWORK_CONFIG_PATH=")) {
-      networkConfigPath = line.slice("NETWORK_CONFIG_PATH=".length);
-
-      // Need to replace this value with a fixed location because otherwise this
-      // file won't be included in the docker image
-      return "NETWORK_CONFIG_PATH=networkConfig.json";
-    }
-
-    return line;
-  })
-  .join("\n");
-
-if (networkConfigPath !== nil) {
-  await Deno.copyFile(networkConfigPath, `${buildDir}/networkConfig.json`);
-}
-
-await Deno.writeTextFile(`${buildDir}/.env`, dotEnv);
-
-for (const f of await allFiles()) {
-  if (!f.endsWith(".ts")) {
-    continue;
-  }
-
-  console.log("Processing", f);
-  await Deno.mkdir(dirname(`${buildDir}/ts/${f}`), { recursive: true });
-  await Deno.copyFile(f, `${buildDir}/ts/${f}`);
-}
-
-const sudoDockerArg = args["sudo-docker"] === true ? ["sudo"] : [];
-
-await shell.run(
-  ...sudoDockerArg,
-  "docker",
-  "build",
-  repoDir,
-  "-t",
-  `aggregator:${buildName}`,
-);
-
-const dockerImageName = `aggregator-${buildName}-docker-image`;
-
-await shell.run(
-  ...sudoDockerArg,
-  "docker",
-  "save",
-  "--output",
-  `${repoDir}/build/${dockerImageName}.tar`,
-  `aggregator:${buildName}`,
-);
-
-if (sudoDockerArg.length > 0) {
-  // chown to the current user
-  const username = await shell.Line("whoami");
-
-  await shell.run(
-    "sudo",
-    "chown",
-    username,
-    `${repoDir}/build/${dockerImageName}.tar`,
-  );
-}
-
-await shell.run(
-  "gzip",
-  `${repoDir}/build/${dockerImageName}.tar`,
-);
+await ensureFreshBuildDir();
+await buildEnvironment();
+await copyTypescriptFiles();
+await buildDockerImage();
 
 console.log("Aggregator build complete");
 
@@ -128,4 +29,125 @@ async function allFiles() {
       "--exclude-standard",
     ),
   ];
+}
+
+async function BuildName() {
+  // TODO: Make build name change when networkConfig changes
+
+  const commitShort = (await shell.Line("git", "rev-parse", "HEAD")).slice(
+    0,
+    7,
+  );
+
+  const isDirty =
+    (await shell.Lines("git", "status", "--porcelain")).length > 0;
+
+  const envHashShort = (await shell.Line("shasum", "-a", "256", dotEnvPath))
+    .slice(0, 7);
+
+  return [
+    "git",
+    commitShort,
+    ...(isDirty ? ["dirty"] : []),
+    "env",
+    envName,
+    envHashShort,
+  ].join("-");
+}
+
+async function ensureFreshBuildDir() {
+  try {
+    await Deno.remove(buildDir, { recursive: true });
+  } catch (error) {
+    if (error.name === "NotFound") {
+      // We don't care that remove failed due to NotFound (why do we need to catch
+      // an exception to handle this normal use case? 🤔)
+    } else {
+      throw error;
+    }
+  }
+
+  await Deno.mkdir(buildDir);
+}
+
+async function buildEnvironment() {
+  const originalDotEnv = await Deno.readTextFile(dotEnvPath);
+
+  let networkConfigPath: string | nil = nil;
+
+  const dotEnv = originalDotEnv
+    .split("\n")
+    .map((line) => {
+      if (line.startsWith("NETWORK_CONFIG_PATH=")) {
+        networkConfigPath = line.slice("NETWORK_CONFIG_PATH=".length);
+
+        // Need to replace this value with a fixed location because otherwise this
+        // file won't be included in the docker image
+        return "NETWORK_CONFIG_PATH=networkConfig.json";
+      }
+
+      return line;
+    })
+    .join("\n");
+
+  if (networkConfigPath !== nil) {
+    await Deno.copyFile(networkConfigPath, `${buildDir}/networkConfig.json`);
+  }
+
+  await Deno.writeTextFile(`${buildDir}/.env`, dotEnv);
+}
+
+async function copyTypescriptFiles() {
+  for (const f of await allFiles()) {
+    if (!f.endsWith(".ts")) {
+      continue;
+    }
+
+    console.log("Processing", f);
+    await Deno.mkdir(dirname(`${buildDir}/ts/${f}`), { recursive: true });
+    await Deno.copyFile(f, `${buildDir}/ts/${f}`);
+  }
+}
+
+async function buildDockerImage() {
+  const buildName = await BuildName();
+
+  const sudoDockerArg = args["sudo-docker"] === true ? ["sudo"] : [];
+
+  await shell.run(
+    ...sudoDockerArg,
+    "docker",
+    "build",
+    repoDir,
+    "-t",
+    `aggregator:${buildName}`,
+  );
+
+  const dockerImageName = `aggregator-${buildName}-docker-image`;
+
+  await shell.run(
+    ...sudoDockerArg,
+    "docker",
+    "save",
+    "--output",
+    `${repoDir}/build/${dockerImageName}.tar`,
+    `aggregator:${buildName}`,
+  );
+
+  if (sudoDockerArg.length > 0) {
+    // chown to the current user
+    const username = await shell.Line("whoami");
+
+    await shell.run(
+      "sudo",
+      "chown",
+      username,
+      `${repoDir}/build/${dockerImageName}.tar`,
+    );
+  }
+
+  await shell.run(
+    "gzip",
+    `${repoDir}/build/${dockerImageName}.tar`,
+  );
 }


### PR DESCRIPTION
## What is this PR doing?

The docker build was broken because our .env now generally points to a networkConfig outside the aggregator subproject, and therefore isn't available inside the docker image.

This fixes that by copying the networkConfig to the top-level and updating this value in the built .env file.

Also refactors `build.ts` into separate functions. You might prefer to go commit-by-commit to inspect the changes.

## How can these changes be manually tested?

1. Run the build `./programs/build.ts --sudo-docker`
2. Run the image and check that it starts up normally `sudo docker run --rm -it --net=host <insert image name from build log>`

## Does this PR resolve or contribute to any issues?

Resolves #80

## Checklist
- [x] I have manually tested these changes
- [x] Post a link to the PR in the group chat

## Guidelines
- If your PR is not ready, mark it as a draft
- The `resolve conversation` button is for reviewers, not authors
  - (But add a 'done' comment or similar)
