### PR TITLE
Avoid problematic toString no-ops

### DIFF
--- a/contracts/clients/src/signer/getPublicKeyStr.ts
+++ b/contracts/clients/src/signer/getPublicKeyStr.ts
@@ -1,16 +1,11 @@
 import * as hubbleBls from "../../deps/hubble-bls";
-import getPublicKey from "./getPublicKey";
 
 export default (
     signerFactory: hubbleBls.signer.BlsSignerFactory,
     domain: Uint8Array,
   ) =>
   (privateKey: string): string => {
-    const [x0, x1, y0, y1] = getPublicKey(signerFactory, domain)(privateKey);
-    return hubbleBls.mcl.dumpG2([
-      x0.toString(),
-      x1.toString(),
-      y0.toString(),
-      y1.toString(),
-    ]);
+    const signer = signerFactory.getSigner(domain, privateKey);
+
+    return hubbleBls.mcl.dumpG2(signer.pubkey);
   };

--- a/contracts/clients/test/index.test.ts
+++ b/contracts/clients/test/index.test.ts
@@ -161,4 +161,21 @@ describe("index", () => {
 
     expect(verify(aggAggBundle)).to.equal(true);
   });
+
+  it("generates expected publicKeyStr", async () => {
+    const { getPublicKeyStr } = await initBlsWalletSigner({
+      chainId: 123,
+      domain,
+    });
+
+    expect(getPublicKeyStr(samples.privateKey)).to.equal(
+      [
+        "0x",
+        "0127eaaf599e0e5997ebff004ae96b61afef4c35d9d67277ebd32a08bc42e2eb",
+        "01dc98a8d2e5ac73933935dbb2888c6719914e86f14de30bf441b951867e27cd",
+        "2f29d73e617ee30597f79b3fe567a11eb3bea1a2625ccb3fcb9635edf1d2f429",
+        "27fac8b975dd299618e7f48753fdfa492f11f701445cdd7c3ca98bf5c386ec65",
+      ].join(""),
+    );
+  });
 });

--- a/contracts/clients/test/index.test.ts
+++ b/contracts/clients/test/index.test.ts
@@ -1,13 +1,15 @@
 import "source-map-support/register";
 
-import { BigNumber } from "@ethersproject/bignumber";
-import { arrayify } from "@ethersproject/bytes";
-import { keccak256 } from "@ethersproject/keccak256";
+import * as ethers from "ethers";
+import { BigNumber } from "ethers";
 import { expect } from "chai";
 
 import { initBlsWalletSigner, Bundle, Operation } from "../src/signer";
 
 import Range from "./helpers/Range";
+
+const keccak256 = ethers.utils.keccak256;
+const arrayify = ethers.utils.arrayify;
 
 const domain = arrayify(keccak256("0xfeedbee5"));
 const weiPerToken = BigNumber.from(10).pow(18);


### PR DESCRIPTION
## What is this PR doing?

Fixes the `toString` issue [described previously](https://github.com/jzaki/bls-wallet/pull/75/files#r776924162).

Bonus:
- Replaces @ethersproject imports that were missed earlier with the appropriate ethers direct imports

## How can these changes be manually tested?

Run the new test that has been added.

## Does this PR resolve or contribute to any issues?

Resolves #83.

## Checklist
- [x] I have manually tested these changes
- [x] Post a link to the PR in the group chat

## Guidelines
- If your PR is not ready, mark it as a draft
- The `resolve conversation` button is for reviewers, not authors
  - (But add a 'done' comment or similar)
