### PR TITLE
Switch VG export to type only, add Troubleshooting section

### DIFF
--- a/aggregator/README.md
+++ b/aggregator/README.md
@@ -143,6 +143,29 @@ are actually imported whenever you run something). There's also a bunch of other
 checking going on. As the name suggests, it's a good idea to make sure this
 script completes successfully before merging into main.
 
+### Troubleshooting
+
+#### TS "Duplicate identifier" error
+
+If you see TypeScript errors like below when attempting to run a script/command
+from Deno such as `./programs/aggregator.ts`:
+
+```sh
+TS2300 [ERROR]: Duplicate identifier 'TypedArray'.
+    type TypedArray =
+         ~~~~~~~~~~
+    at https://cdn.esm.sh/v59/node.ns.d.ts:508:10
+
+    'TypedArray' was also declared here.
+        type TypedArray =
+             ~~~~~~~~~~
+        at https://cdn.esm.sh/v62/node.ns.d.ts:508:10
+```
+
+You need to reload modules (`-r`):
+
+`deno run -r --allow-net --allow-env --allow-read --unstable ./programs/aggregator.ts`
+
 ### Notable Components
 
 - **src/chain**: Should contain all of the contract interactions, exposing more

--- a/aggregator/deps.ts
+++ b/aggregator/deps.ts
@@ -39,13 +39,13 @@ export type {
   Operation,
   PublicKey,
   Signature,
+  VerificationGateway,
 } from "https://esm.sh/bls-wallet-clients@0.5.3";
 
 export {
   Aggregator as AggregatorClient,
   BlsWalletWrapper,
   getConfig,
-  VerificationGateway,
   VerificationGateway__factory,
 } from "https://esm.sh/bls-wallet-clients@0.5.3";
 


### PR DESCRIPTION
## What is this PR doing?

- Fix export of `VerificationGateway` to be type only.
- Add Troubleshooting section with TS Duplicate Identifier entry for aggregator.

## How can these changes be manually tested?

Run `./programs/aggregator.ts`, or for reload test `deno run -r --allow-net --allow-env --allow-read --unstable ./programs/aggregator.ts` (Note the `-r` flag).

## Does this PR resolve or contribute to any issues?

n/a

## Checklist
- [x] I have manually tested these changes
- [x] Post a link to the PR in the group chat

## Guidelines
- If your PR is not ready, mark it as a draft
- The `resolve conversation` button is for reviewers, not authors
  - (But add a 'done' comment or similar)
