### PR TITLE
Measure password strength

### DIFF
--- a/extension/package.json
+++ b/extension/package.json
@@ -26,6 +26,7 @@
   },
   "dependencies": {
     "@babel/runtime": "^7.14.0",
+    "@types/zxcvbn": "^4.4.1",
     "advanced-css-reset": "^1.2.2",
     "async-mutex": "^0.3.2",
     "bls-wallet-clients": "0.5.3",
@@ -38,7 +39,8 @@
     "typed-emitter": "^1.3.1",
     "typescript": "^4.4.2",
     "webext-base-css": "^1.3.1",
-    "webextension-polyfill-ts": "^0.25.0"
+    "webextension-polyfill-ts": "^0.25.0",
+    "zxcvbn": "^4.4.2"
   },
   "devDependencies": {
     "@abhijithvijayan/eslint-config": "2.6.3",

--- a/extension/source/helpers/measurePasswordStrength.ts
+++ b/extension/source/helpers/measurePasswordStrength.ts
@@ -1,5 +1,57 @@
 import zxcvbn from 'zxcvbn';
 
-export default function measurePasswordStrength(password: string): number {
-  return zxcvbn(password).guesses_log10;
+type PasswordStrength = {
+  guessesLog10: number;
+  descriptor: 'Very weak' | 'Weak' | 'Average' | 'Good' | 'Strong';
+  fillRatio: number;
+};
+
+export default function measurePasswordStrength(
+  password: string,
+): PasswordStrength {
+  const guessesLog10 = zxcvbn(password).guesses_log10;
+
+  let descriptor: PasswordStrength['descriptor'];
+
+  if (guessesLog10 < 3) {
+    descriptor = 'Very weak';
+  } else if (guessesLog10 < 6) {
+    descriptor = 'Weak';
+  } else if (guessesLog10 < 9) {
+    descriptor = 'Average';
+  } else if (guessesLog10 < 12) {
+    descriptor = 'Good';
+  } else {
+    descriptor = 'Strong';
+  }
+
+  let fillRatio: number;
+
+  if (guessesLog10 < 12) {
+    fillRatio = guessesLog10 / 15;
+  } else {
+    fillRatio = 12 / 15 + 3 * approach(3, 1 / 15, guessesLog10 - 12);
+  }
+
+  return {
+    guessesLog10,
+    descriptor,
+    fillRatio,
+  };
+}
+
+/**
+ * Very simple function that approaches 1 as x grows to infinity. Looks like
+ * y = x close to the origin (slope = 1).
+ */
+function approach1(x: number) {
+  return x / (x + 1);
+}
+
+/**
+ * Builds upon approach1, specifying the target to approach and the initial
+ * slope.
+ */
+function approach(target: number, initialSlope: number, x: number) {
+  return target * approach1((x * initialSlope) / target);
 }

--- a/extension/source/helpers/measurePasswordStrength.ts
+++ b/extension/source/helpers/measurePasswordStrength.ts
@@ -1,0 +1,5 @@
+import zxcvbn from 'zxcvbn';
+
+export default function measurePasswordStrength(password: string): number {
+  return zxcvbn(password).guesses_log10;
+}

--- a/extension/source/helpers/measurePasswordStrength.ts
+++ b/extension/source/helpers/measurePasswordStrength.ts
@@ -30,7 +30,7 @@ export default function measurePasswordStrength(
   if (guessesLog10 < 12) {
     fillRatio = guessesLog10 / 15;
   } else {
-    fillRatio = 12 / 15 + 3 * approach(3, 1 / 15, guessesLog10 - 12);
+    fillRatio = 12 / 15 + approach(3 / 15, 1 / 15, guessesLog10 - 12);
   }
 
   return {

--- a/extension/yarn.lock
+++ b/extension/yarn.lock
@@ -1715,6 +1715,11 @@
     "@types/webpack-sources" "*"
     source-map "^0.6.0"
 
+"@types/zxcvbn@^4.4.1":
+  version "4.4.1"
+  resolved "https://registry.yarnpkg.com/@types/zxcvbn/-/zxcvbn-4.4.1.tgz#46e42cbdcee681b22181478feaf4af2bc4c1abd2"
+  integrity sha512-3NoqvZC2W5gAC5DZbTpCeJ251vGQmgcWIHQJGq2J240HY6ErQ9aWKkwfoKJlHLx+A83WPNTZ9+3cd2ILxbvr1w==
+
 "@typescript-eslint/eslint-plugin@^4.4.1":
   version "4.7.0"
   resolved "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-4.7.0.tgz"
@@ -8631,3 +8636,8 @@ zip-stream@^4.1.0:
     archiver-utils "^2.1.0"
     compress-commons "^4.1.0"
     readable-stream "^3.6.0"
+
+zxcvbn@^4.4.2:
+  version "4.4.2"
+  resolved "https://registry.yarnpkg.com/zxcvbn/-/zxcvbn-4.4.2.tgz#28ec17cf09743edcab056ddd8b1b06262cc73c30"
+  integrity sha1-KOwXzwl0PtyrBW3dixsGJizHPDA=


### PR DESCRIPTION
## What is this PR doing?

Adds `measurePasswordStrength` to define how we measure passwords, based on [zxcvbn](https://www.npmjs.com/package/zxcvbn).

This includes:
- Numerical score, which is proportional to the estimated entropy contained in the password
- A descriptor from the list `Very weak`, `Weak`, `Average`, `Good`, `Strong`
- `fillRatio` to be used with the displayed strength meter
  - normalizes the score into the range 0-1 which is linear before strong, and then smoothly approaches 1 in the strong range

I did some research for this to achieve the following:
- The `Average` category lines up with the average measured strength of 50 random samples from the [2009 rockyou password leak](https://www.kaggle.com/wjburns/common-password-list-rockyoutxt/version/1)
- The outputs from those 50 random samples and a few manual entries are subjectively reasonable
- The categories are roughly consistent with LastPass

See comments on the [ticket](https://github.com/jzaki/bls-wallet/issues/96) for more details.

## How can these changes be manually tested?

Run something like this:

```ts
const samples = [
  '',
  'password',
  'passw0rd',
  'pa0sword',
  'passwxrd',
  'password!',
  'thlsdjtu',
  'ritmatrk',
  'chbswdur',
  'jxfxnrkd',
  'basic',
  'thlsd',
  'ritma',
  'chbsw',
  'jxfxn',
  'Tr0ub4dor&3',
  'correct horse battery staple',
];

for (const sample of samples) {
  console.log(`${sample} ${JSON.stringify(measurePasswordStrength(sample))}`);
}
```

And inspect the results. This is what I got:

```
pa0sword {"guessesLog10":6.662757831681573,"descriptor":"Average","fillRatio":0.4441838554454382}
passwxrd {"guessesLog10":6.089905111439397,"descriptor":"Average","fillRatio":0.4059936740959598}
password! {"guessesLog10":4.045322978786657,"descriptor":"Weak","fillRatio":0.26968819858577714}
thlsdjtu {"guessesLog10":8.000000004342944,"descriptor":"Average","fillRatio":0.533333333622863}
ritmatrk {"guessesLog10":8.000000004342944,"descriptor":"Average","fillRatio":0.533333333622863}
chbswdur {"guessesLog10":8.000000004342944,"descriptor":"Average","fillRatio":0.533333333622863}
jxfxnrkd {"guessesLog10":8.000000004342944,"descriptor":"Average","fillRatio":0.533333333622863}
basic {"guessesLog10":3.04099769242349,"descriptor":"Weak","fillRatio":0.20273317949489933}
thlsd {"guessesLog10":5.000004342923104,"descriptor":"Weak","fillRatio":0.3333336228615403}
ritma {"guessesLog10":5.000004342923104,"descriptor":"Weak","fillRatio":0.3333336228615403}
chbsw {"guessesLog10":5.000004342923104,"descriptor":"Weak","fillRatio":0.3333336228615403}
jxfxn {"guessesLog10":5.000004342923104,"descriptor":"Weak","fillRatio":0.3333336228615403}
Tr0ub4dor&3 {"guessesLog10":11.000000000004341,"descriptor":"Good","fillRatio":0.7333333333336227}
correct horse battery staple {"guessesLog10":20.330032012866745,"descriptor":"Strong","fillRatio":0.9470433976427762}
```

## Does this PR resolve or contribute to any issues?

Resolves #96.

## Checklist
- [x] I have manually tested these changes
- [x] Post a link to the PR in the group chat

## Guidelines
- If your PR is not ready, mark it as a draft
- The `resolve conversation` button is for reviewers, not authors
  - (But add a 'done' comment or similar)
