### PR TITLE
Make password creation form functional

### DIFF
--- a/extension/source/QuillPage/components/PasswordCreationForm.tsx
+++ b/extension/source/QuillPage/components/PasswordCreationForm.tsx
@@ -33,12 +33,12 @@ const PasswordCreationForm: React.FunctionComponent<{
       setConfirmPasswordFieldValue(newConfirmPassword);
     }
 
-    const newResultPasswd =
+    const newResultPassword =
       newPassword === newConfirmPassword ? newPassword : undefined;
 
-    if (newResultPasswd !== password) {
-      setPassword(newResultPasswd);
-      onPasswordUpdate(newResultPasswd);
+    if (newResultPassword !== password) {
+      setPassword(newResultPassword);
+      onPasswordUpdate(newResultPassword);
     }
   }
 

--- a/extension/source/QuillPage/components/PasswordCreationForm.tsx
+++ b/extension/source/QuillPage/components/PasswordCreationForm.tsx
@@ -18,9 +18,6 @@ const passwordCommentaryMap: Record<PasswordStrength['descriptor'], string> = {
 const PasswordCreationForm: React.FunctionComponent<{
   onPasswordUpdate: (password: string | undefined) => void;
 }> = ({ onPasswordUpdate }) => {
-  // eslint-disable-next-line @typescript-eslint/no-unused-expressions
-  onPasswordUpdate;
-
   const [password, setPassword] = React.useState<string>();
 
   const [passwordFieldValue, setPasswordFieldValue] = React.useState('');

--- a/extension/source/QuillPage/components/PasswordCreationForm.tsx
+++ b/extension/source/QuillPage/components/PasswordCreationForm.tsx
@@ -1,27 +1,116 @@
 import * as React from 'react';
+
+import measurePasswordStrength, {
+  PasswordStrength,
+} from '../../helpers/measurePasswordStrength';
 import QuickColumn from './QuickColumn';
 import QuickRow from './QuickRow';
 
-const PasswordCreationForm: React.FunctionComponent = () => (
-  <div className="password-creation-form quick-column">
-    <QuickColumn>
-      <input
-        type="password"
-        placeholder="Password"
-        style={{ width: '100%', flexGrow: 0 }}
-      />
-      <input
-        type="password"
-        placeholder="Confirm password"
-        style={{ width: '100%', flexGrow: 0 }}
-      />
-      <QuickRow>
-        <div>Password strength</div>
-        <div>Average</div>
-      </QuickRow>
-      <div>This password is ok, but could be more secure.</div>
-    </QuickColumn>
-  </div>
-);
+const passwordCommentaryMap: Record<PasswordStrength['descriptor'], string> = {
+  'Very weak': 'Please consider using a stronger password.',
+  Weak: 'Please consider using a stronger password.',
+  Average:
+    "This password is about average, which isn't great for protecting assets.",
+  Good: 'This is a relatively good password, but could be more secure.',
+  Strong: '',
+};
+
+const PasswordCreationForm: React.FunctionComponent<{
+  onPasswordUpdate: (password: string | undefined) => void;
+}> = ({ onPasswordUpdate }) => {
+  // eslint-disable-next-line @typescript-eslint/no-unused-expressions
+  onPasswordUpdate;
+
+  const [password, setPassword] = React.useState<string>();
+
+  const [passwordFieldValue, setPasswordFieldValue] = React.useState('');
+  const [confirmPasswordFieldValue, setConfirmPasswordFieldValue] =
+    React.useState('');
+
+  function handleFieldsChange(newPassword: string, newConfirmPassword: string) {
+    if (newPassword !== passwordFieldValue) {
+      setPasswordFieldValue(newPassword);
+    }
+
+    if (newConfirmPassword !== confirmPasswordFieldValue) {
+      setConfirmPasswordFieldValue(newConfirmPassword);
+    }
+
+    const newResultPasswd =
+      newPassword === newConfirmPassword ? newPassword : undefined;
+
+    if (newResultPasswd !== password) {
+      setPassword(newResultPasswd);
+      onPasswordUpdate(newResultPasswd);
+    }
+  }
+
+  const passwordStrength = measurePasswordStrength(passwordFieldValue);
+
+  const confirmFieldClasses = ['password-confirm-field'];
+
+  if (confirmPasswordFieldValue === '') {
+    confirmFieldClasses.push('empty');
+  } else if (confirmPasswordFieldValue === passwordFieldValue) {
+    confirmFieldClasses.push('correct');
+  } else if (passwordFieldValue.startsWith(confirmPasswordFieldValue)) {
+    confirmFieldClasses.push('incomplete');
+  } else {
+    confirmFieldClasses.push('incorrect');
+  }
+
+  return (
+    <div
+      className={[
+        'password-creation-form',
+        'quick-column',
+        passwordStrength.descriptor.toLowerCase().replace(' ', '-'),
+      ].join(' ')}
+    >
+      <QuickColumn>
+        <input
+          type="password"
+          placeholder="Password"
+          style={{ width: '100%', flexGrow: 0 }}
+          onInput={(e) => {
+            const newPassword = (e.target as HTMLInputElement).value;
+            handleFieldsChange(newPassword, confirmPasswordFieldValue);
+          }}
+        />
+        <input
+          type="password"
+          placeholder="Confirm password"
+          className={confirmFieldClasses.join(' ')}
+          style={{ width: '100%', flexGrow: 0 }}
+          onInput={(e) => {
+            const newConfirmPassword = (e.target as HTMLInputElement).value;
+            handleFieldsChange(passwordFieldValue, newConfirmPassword);
+          }}
+        />
+        <QuickRow>
+          <div>Password strength</div>
+          <div>{passwordStrength.descriptor}</div>
+        </QuickRow>
+        <div>
+          <div
+            className="password-meter"
+            style={{
+              width: `${passwordStrength.fillRatio * 100}%`,
+            }}
+          >
+            &nbsp;
+          </div>
+          <div>
+            Fill width: {(passwordStrength.fillRatio * 100).toFixed(1)}%
+          </div>
+        </div>
+        <div>
+          {passwordFieldValue &&
+            passwordCommentaryMap[passwordStrength.descriptor]}
+        </div>
+      </QuickColumn>
+    </div>
+  );
+};
 
 export default PasswordCreationForm;

--- a/extension/source/QuillPage/components/PasswordCreationPanel.tsx
+++ b/extension/source/QuillPage/components/PasswordCreationPanel.tsx
@@ -14,7 +14,7 @@ const PasswordCreationPanel: React.FunctionComponent<{
         wallets.
       </p>
     </div>
-    <PasswordCreationForm />
+    <PasswordCreationForm onPasswordUpdate={() => {}} />
     <div>
       <div style={{ display: 'inline-block' }}>
         <Button

--- a/extension/source/QuillPage/components/PasswordCreationPanel.tsx
+++ b/extension/source/QuillPage/components/PasswordCreationPanel.tsx
@@ -5,31 +5,36 @@ import PasswordCreationForm from './PasswordCreationForm';
 
 const PasswordCreationPanel: React.FunctionComponent<{
   onComplete: () => void;
-}> = ({ onComplete }) => (
-  <>
-    <div className="instructions-text">
-      <h3>Let&apos;s start by setting a password.</h3>
-      <p>
-        Occasionally we will ask you for this to prevent unwanted access of your
-        wallets.
-      </p>
-    </div>
-    <PasswordCreationForm onPasswordUpdate={() => {}} />
-    <div>
-      <div style={{ display: 'inline-block' }}>
-        <Button
-          onPress={onComplete}
-          highlight={true}
-          icon={{
-            src: browser.runtime.getURL('assets/arrow-small.svg'),
-            px: 19,
-          }}
-        >
-          Continue
-        </Button>
+}> = ({ onComplete }) => {
+  const [password, setPassword] = React.useState<string>();
+
+  return (
+    <>
+      <div className="instructions-text">
+        <h3>Let&apos;s start by setting a password.</h3>
+        <p>
+          Occasionally we will ask you for this to prevent unwanted access of
+          your wallets.
+        </p>
       </div>
-    </div>
-  </>
-);
+      <PasswordCreationForm onPasswordUpdate={setPassword} />
+      <div>
+        <div style={{ display: 'inline-block' }}>
+          <Button
+            onPress={() => password && onComplete()}
+            highlight={true}
+            icon={{
+              src: browser.runtime.getURL('assets/arrow-small.svg'),
+              px: 19,
+            }}
+            disabled={password === undefined}
+          >
+            Continue
+          </Button>
+        </div>
+      </div>
+    </>
+  );
+};
 
 export default PasswordCreationPanel;

--- a/extension/source/QuillPage/styles.scss
+++ b/extension/source/QuillPage/styles.scss
@@ -60,4 +60,27 @@
       }
     }
   }
+
+  .password-creation-form {
+    .password-meter {
+      display: inline-block;
+      background-color: grey;
+      color: white;
+      transition: width 200ms ease;
+    }
+
+    .password-confirm-field {
+      &.correct {
+        background-color: green;
+      }
+
+      &.incorrect {
+        background-color: red;
+      }
+
+      &.incomplete {
+        background-color: yellow;
+      }
+    }
+  }
 }

--- a/extension/source/helpers/measurePasswordStrength.ts
+++ b/extension/source/helpers/measurePasswordStrength.ts
@@ -1,6 +1,6 @@
 import zxcvbn from 'zxcvbn';
 
-type PasswordStrength = {
+export type PasswordStrength = {
   guessesLog10: number;
   descriptor: 'Very weak' | 'Weak' | 'Average' | 'Good' | 'Strong';
   fillRatio: number;


### PR DESCRIPTION
# _Dependent PR_

This PR builds on top of https://github.com/jzaki/bls-wallet/pull/95. Please review and merge that one first.

## What is this PR doing?

Adds functionality to the password creation form:
- Displays password strength using method from previous work
  - Shows weak/strong/etc
  - Description elaborating on weak/strong/etc
  - Horizontal bar with a width corresponding to granular strength measurement
- Confirm password box shows whether it is correct/incorrect/incomplete
- Continue button is disabled if a password hasn't been entered or the confirm field doesn't match

I included some naive css this time because I couldn't help it. Just things like `background-color: green` though. Intended to be thrown away.

![Screen Shot 2022-01-14 at 3 59 08 pm](https://user-images.githubusercontent.com/9291586/149454208-71f7044c-c187-416b-bfc8-f9a5102484c0.png)

## How can these changes be manually tested?

Visit the password creation form and verify the above.

## Does this PR resolve or contribute to any issues?

Resolves #97, resolves #98.

## Checklist
- [x] I have manually tested these changes
- [x] Post a link to the PR in the group chat

## Guidelines
- If your PR is not ready, mark it as a draft
- The `resolve conversation` button is for reviewers, not authors
  - (But add a 'done' comment or similar)
