### PR TITLE
Prevent setting non-gateway in setTrustedGateway

### DIFF
--- a/contracts/contracts/VerificationGateway.sol
+++ b/contracts/contracts/VerificationGateway.sol
@@ -267,6 +267,13 @@ contract VerificationGateway
     }
 
     /**
+    Declare that this is a verification gateway. See BLSWallet#setTrustedGateway.
+     */
+    function isVerificationGateway() public pure returns (bool) {
+        return true;
+    }
+
+    /**
     Create a new wallet if not found for the given bls public key.
      */
     function createNewWallet(

--- a/contracts/contracts/VerificationGateway.sol
+++ b/contracts/contracts/VerificationGateway.sol
@@ -8,6 +8,7 @@ import "@openzeppelin/contracts/proxy/transparent/ProxyAdmin.sol";
 import "@openzeppelin/contracts/proxy/transparent/TransparentUpgradeableProxy.sol";
 
 import "./interfaces/IWallet.sol";
+import "./interfaces/IVerificationGateway.sol";
 
 /**
 A non-upgradable gateway used to create BLSWallets and call them with
@@ -16,7 +17,7 @@ The gateway holds a single ProxyAdmin contract for all wallets, and can
 only called by a wallet that the VG created, and only if the first param
 is the calling wallet's address.
  */
-contract VerificationGateway
+contract VerificationGateway is IVerificationGateway
 {
     /** Domain chosen arbitrarily */
     bytes32 BLS_DOMAIN = keccak256(abi.encodePacked(uint32(0xfeedbee5)));
@@ -207,13 +208,13 @@ contract VerificationGateway
      */
     function setTrustedBLSGateway(
         bytes32 hash,
-        address blsGateway
+        IVerificationGateway blsGateway
     ) public onlyWallet(hash) {
         uint256 size;
         // solhint-disable-next-line no-inline-assembly
         assembly { size := extcodesize(blsGateway) }
         require(
-            (blsGateway != address(0)) && (size > 0),
+            (address(blsGateway) != address(0)) && (size > 0),
             "BLSWallet: gateway address param not valid"
         );
         walletFromHash(hash).setTrustedGateway(blsGateway);
@@ -269,7 +270,7 @@ contract VerificationGateway
     /**
     Declare that this is a verification gateway. See BLSWallet#setTrustedGateway.
      */
-    function isVerificationGateway() public pure returns (bool) {
+    function isVerificationGateway() external pure returns (bool) {
         return true;
     }
 

--- a/contracts/contracts/interfaces/IVerificationGateway.sol
+++ b/contracts/contracts/interfaces/IVerificationGateway.sol
@@ -1,0 +1,7 @@
+//SPDX-License-Identifier: Unlicense
+pragma solidity >=0.8.0 <0.9.0;
+pragma abicoder v2;
+
+interface IVerificationGateway {
+  function isVerificationGateway() external pure returns (bool);
+}

--- a/contracts/contracts/interfaces/IWallet.sol
+++ b/contracts/contracts/interfaces/IWallet.sol
@@ -2,6 +2,8 @@
 pragma solidity >=0.8.4 <0.9.0;
 pragma abicoder v2;
 
+import "./IVerificationGateway.sol";
+
 /** Interface for a contract wallet that can perform Operations
  */
 interface IWallet {
@@ -17,7 +19,7 @@ interface IWallet {
         bytes encodedFunction;
     }
 
-    function initialize(address gateway) external;
+    function initialize(IVerificationGateway gateway) external;
     function nonce() external returns (uint256);
 
     function performOperation(
@@ -31,7 +33,7 @@ interface IWallet {
     function recover(uint256[4] calldata newBLSKey) external;
 
     // prepares gateway to be set (after pending timestamp)
-    function setTrustedGateway(address gateway) external;
+    function setTrustedGateway(IVerificationGateway gateway) external;
     // checks any pending variables and sets them if past their timestamp
     function setAnyPending() external;
 

--- a/contracts/test/upgrade-test.ts
+++ b/contracts/test/upgrade-test.ts
@@ -205,18 +205,13 @@ describe("Upgrade", async function () {
   });
 
   it("should reject attempt to set non-gateway in setTrustedBLSGateway", async () => {
-    // Recreate hubble bls signer
-    const walletOldVg = await fx.lazyBlsWallets[0]();
-
-    const hash = walletOldVg.blsWalletSigner.getPublicKeyHash(
-      walletOldVg.privateKey,
-    );
-
-    const oldNonce = await walletOldVg.Nonce();
+    const wallet = await fx.lazyBlsWallets[0]();
+    const hash = wallet.blsWalletSigner.getPublicKeyHash(wallet.privateKey);
+    const oldNonce = await wallet.Nonce();
 
     await (
       await fx.verificationGateway.processBundle(
-        walletOldVg.sign({
+        wallet.sign({
           nonce: BigNumber.from(2),
           actions: [
             {
@@ -229,7 +224,7 @@ describe("Upgrade", async function () {
                     hash,
 
                     // A wallet is not a gateway
-                    walletOldVg.address,
+                    wallet.address,
                   ],
                 ),
             },
@@ -238,7 +233,7 @@ describe("Upgrade", async function () {
       )
     ).wait();
 
-    const newNonce = await walletOldVg.Nonce();
+    const newNonce = await wallet.Nonce();
 
     // Nonce has not incremented because the action failed
     expect(newNonce.eq(oldNonce));


### PR DESCRIPTION
## What is this PR doing?

Adds `isVerificationGateway() -> true` and uses it to prevent accidentally upgrading the gateway to something that isn't a gateway.

## How can these changes be manually tested?

`yarn hardhat test` (See test that has been added)

## Does this PR resolve or contribute to any issues?

Resolves #107.

## Checklist
- [x] I have manually tested these changes
- [x] Post a link to the PR in the group chat

## Guidelines
- If your PR is not ready, mark it as a draft
- The `resolve conversation` button is for reviewers, not authors
  - (But add a 'done' comment or similar)
