### PR TITLE
Avoid redundant calculations

### DIFF
--- a/contracts/contracts/VerificationGateway.sol
+++ b/contracts/contracts/VerificationGateway.sol
@@ -237,8 +237,7 @@ contract VerificationGateway
         successes = new bool[](opLength);
         results = new bytes[][](opLength);
         for (uint256 i = 0; i<opLength; i++) {
-            // create wallet if not found
-            wallet = createNewWallet(bundle.senderPublicKeys[i]);
+            wallet = getOrCreateWallet(bundle.senderPublicKeys[i]);
 
             // check nonce then perform action
             if (bundle.operations[i].nonce == wallet.nonce()) {
@@ -259,9 +258,10 @@ contract VerificationGateway
     }
 
     /**
-    Create a new wallet if not found for the given bls public key.
+    Gets the wallet contract associated with the public key, creating it if
+    needed.
      */
-    function createNewWallet(
+    function getOrCreateWallet(
         uint256[BLS_KEY_LEN] calldata publicKey
     ) private returns (IWallet) {
         bytes32 publicKeyHash = keccak256(abi.encodePacked(publicKey));

--- a/contracts/contracts/VerificationGateway.sol
+++ b/contracts/contracts/VerificationGateway.sol
@@ -232,12 +232,11 @@ contract VerificationGateway
         // revert if signature not verified
         verify(bundle);
 
-        IWallet wallet;
         uint256 opLength = bundle.operations.length;
         successes = new bool[](opLength);
         results = new bytes[][](opLength);
         for (uint256 i = 0; i<opLength; i++) {
-            wallet = getOrCreateWallet(bundle.senderPublicKeys[i]);
+            IWallet wallet = getOrCreateWallet(bundle.senderPublicKeys[i]);
 
             // check nonce then perform action
             if (bundle.operations[i].nonce == wallet.nonce()) {


### PR DESCRIPTION
## What is this PR doing?

Avoids some redundant calculations in `processBundle`:
- Duplicate calculation of `publicKeyHash`
- Duplicate call to `walletFromHash`

It's also a bit simpler this way, imo.

## How can these changes be manually tested?

Run the tests.

I also tried logging the gas used in `should send ETH (empty call)` and found this change reduced the gas from ~300k to ~280k.

## Does this PR resolve or contribute to any issues?

Resolves #108.

## Checklist
- [x] I have manually tested these changes
- [x] Post a link to the PR in the group chat

## Guidelines
- If your PR is not ready, mark it as a draft
- The `resolve conversation` button is for reviewers, not authors
  - (But add a 'done' comment or similar)
