### PR TITLE
Use hash to identify the approved proxy admin function rather than storing the whole bytecode

### DIFF
--- a/contracts/contracts/BLSWallet.sol
+++ b/contracts/contracts/BLSWallet.sol
@@ -17,8 +17,8 @@ contract BLSWallet is Initializable, IBLSWallet
     bytes32 public recoveryHash;
     bytes32 pendingRecoveryHash;
     uint256 pendingRecoveryHashTime;
-    bytes public approvedProxyAdminFunction;
-    bytes pendingPAFunction;
+    bytes32 public approvedProxyAdminFunctionHash;
+    bytes32 pendingPAFunctionHash;
     uint256 pendingPAFunctionTime;
 
     // BLS variables
@@ -38,8 +38,8 @@ contract BLSWallet is Initializable, IBLSWallet
     event PendingGatewaySet(
         address pendingGateway
     );
-    event PendingProxyAdminFunctionSet(
-        bytes pendingProxyAdminFunction
+    event PendingProxyAdminFunctionHashSet(
+        bytes32 pendingProxyAdminFunctionHash
     );
 
     event RecoveryHashUpdated(
@@ -54,8 +54,8 @@ contract BLSWallet is Initializable, IBLSWallet
         address oldGateway,
         address newGateway
     );
-    event ProxyAdminFunctionApproved(
-        bytes approvedProxyAdmin
+    event ProxyAdminFunctionHashApproved(
+        bytes32 approvedProxyAdminHash
     );
 
     function initialize(
@@ -131,10 +131,10 @@ contract BLSWallet is Initializable, IBLSWallet
     /**
     Prepare wallet with desired implementation contract to upgrade to.
     */
-    function setProxyAdminFunction(bytes calldata encodedFunction) public onlyTrustedGateway {
-        pendingPAFunction = encodedFunction;
+    function setProxyAdminFunctionHash(bytes32 encodedFunctionHash) public onlyTrustedGateway {
+        pendingPAFunctionHash = encodedFunctionHash;
         pendingPAFunctionTime = block.timestamp + 604800; // 1 week from now
-        emit PendingProxyAdminFunctionSet(pendingPAFunction);
+        emit PendingProxyAdminFunctionHashSet(encodedFunctionHash);
     }
 
     /**
@@ -162,10 +162,10 @@ contract BLSWallet is Initializable, IBLSWallet
             emit GatewayUpdated(previousGateway, trustedBLSGateway);
         }
         if (block.timestamp > pendingPAFunctionTime) {
-            approvedProxyAdminFunction = pendingPAFunction;
+            approvedProxyAdminFunctionHash = pendingPAFunctionHash;
             pendingPAFunctionTime = type(uint256).max;
-            pendingPAFunction = new bytes(0);
-            emit ProxyAdminFunctionApproved(approvedProxyAdminFunction);
+            pendingPAFunctionHash = 0;
+            emit ProxyAdminFunctionHashApproved(approvedProxyAdminFunctionHash);
         }
     }
 
@@ -186,7 +186,7 @@ contract BLSWallet is Initializable, IBLSWallet
         pendingGatewayTime = type(uint256).max;
         pendingBLSGateway = address(0);
         pendingPAFunctionTime = type(uint256).max;
-        pendingPAFunction = new bytes(0);
+        pendingPAFunctionHash = 0;
     }
 
     /**
@@ -239,8 +239,8 @@ contract BLSWallet is Initializable, IBLSWallet
         }
     }
 
-    function clearApprovedProxyAdminFunction() public onlyTrustedGateway {
-        approvedProxyAdminFunction = new bytes(0);
+    function clearApprovedProxyAdminFunctionHash() public onlyTrustedGateway {
+        approvedProxyAdminFunctionHash = 0;
     }
 
     /**

--- a/contracts/contracts/VerificationGateway.sol
+++ b/contracts/contracts/VerificationGateway.sol
@@ -165,21 +165,18 @@ contract VerificationGateway
         wallet.setAnyPending();
 
         // ensure wallet has pre-approved encodedFunction
-        bytes memory approvedFunction = wallet.approvedProxyAdminFunction();
-        bool matchesApproved = (encodedFunction.length == approvedFunction.length);
-        for (uint i=0; matchesApproved && i<approvedFunction.length; i++) {
-            matchesApproved = (encodedFunction[i] == approvedFunction[i]);
-        }
+        bytes32 approvedFunction = wallet.approvedProxyAdminFunctionHash();
+        bool matchesApproved = keccak256(encodedFunction) == approvedFunction;
 
         if (matchesApproved == false) {
             // prepare for a future call
-            wallet.setProxyAdminFunction(encodedFunction);
+            wallet.setProxyAdminFunctionHash(keccak256(encodedFunction));
         }
         else {
             // call approved function
             (bool success, ) = address(walletProxyAdmin).call(encodedFunction);
             require(success, "VG: call to proxy admin failed");
-            wallet.clearApprovedProxyAdminFunction();
+            wallet.clearApprovedProxyAdminFunctionHash();
         }
     }
 

--- a/contracts/contracts/VerificationGateway.sol
+++ b/contracts/contracts/VerificationGateway.sol
@@ -165,12 +165,13 @@ contract VerificationGateway
         wallet.setAnyPending();
 
         // ensure wallet has pre-approved encodedFunction
-        bytes32 approvedFunction = wallet.approvedProxyAdminFunctionHash();
-        bool matchesApproved = keccak256(encodedFunction) == approvedFunction;
+        bytes32 approvedFunctionHash = wallet.approvedProxyAdminFunctionHash();
+        bytes32 encodedFunctionHash = keccak256(encodedFunction);
+        bool matchesApproved = encodedFunctionHash == approvedFunctionHash;
 
         if (matchesApproved == false) {
             // prepare for a future call
-            wallet.setProxyAdminFunctionHash(keccak256(encodedFunction));
+            wallet.setProxyAdminFunctionHash(encodedFunctionHash);
         }
         else {
             // call approved function

--- a/contracts/contracts/interfaces/IWallet.sol
+++ b/contracts/contracts/interfaces/IWallet.sol
@@ -35,9 +35,9 @@ interface IWallet {
     // checks any pending variables and sets them if past their timestamp
     function setAnyPending() external;
 
-    function setProxyAdminFunction(bytes memory) external;
-    function approvedProxyAdminFunction() external view returns (bytes memory);
-    function clearApprovedProxyAdminFunction() external;
+    function setProxyAdminFunctionHash(bytes32) external;
+    function approvedProxyAdminFunctionHash() external view returns (bytes32);
+    function clearApprovedProxyAdminFunctionHash() external;
 }
 
 /** Interface for bls-specific functions


### PR DESCRIPTION
## What is this PR doing?

Uses hashes for these fields:

```diff
-    bytes public approvedProxyAdminFunction;
-    bytes pendingPAFunction;
+    bytes32 public approvedProxyAdminFunctionHash;
+    bytes32 pendingPAFunctionHash;
```

This saves gas. Then when setting the proxy admin function we can simply check the hash:

```diff
-        bool matchesApproved = (encodedFunction.length == approvedFunction.length);
-        for (uint i=0; matchesApproved && i<approvedFunction.length; i++) {
-            matchesApproved = (encodedFunction[i] == approvedFunction[i]);
-        }
+        bool matchesApproved = keccak256(encodedFunction) == approvedFunction;
```

## How can these changes be manually tested?

Run the tests, in particular:
`should register with new verification gateway`

## Does this PR resolve or contribute to any issues?

Resolves #118.

## Checklist
- [x] I have manually tested these changes
- [x] Post a link to the PR in the group chat

## Guidelines
- If your PR is not ready, mark it as a draft
- The `resolve conversation` button is for reviewers, not authors
  - (But add a 'done' comment or similar)
