### PR TITLE
Separate out AggregationStrategy

### DIFF
--- a/aggregator/src/app/AggregationStrategy.ts
+++ b/aggregator/src/app/AggregationStrategy.ts
@@ -1,0 +1,396 @@
+import {
+  BigNumber,
+  BlsWalletSigner,
+  Bundle,
+  ERC20,
+  ERC20__factory,
+  ethers,
+} from "../../deps.ts";
+
+import nil from "../helpers/nil.ts";
+import Range from "../helpers/Range.ts";
+import assert from "../helpers/assert.ts";
+import bigSum from "./helpers/bigSum.ts";
+import * as env from "../env.ts";
+import EthereumService from "./EthereumService.ts";
+import { BundleRow } from "./BundleTable.ts";
+import countActions from "./helpers/countActions.ts";
+
+export default class AggregationStrategy {
+  static defaultConfig = {
+    maxAggregationSize: env.MAX_AGGREGATION_SIZE,
+    fees: {
+      type: env.FEE_TYPE,
+      perGas: env.FEE_PER_GAS,
+      perByte: env.FEE_PER_BYTE,
+    },
+  };
+
+  constructor(
+    public blsWalletSigner: BlsWalletSigner,
+    public ethereumService: EthereumService,
+    public config = AggregationStrategy.defaultConfig,
+  ) {}
+
+  async run(eligibleRows: BundleRow[]): (
+    Promise<{
+      aggregateBundle: Bundle | nil;
+      includedRows: BundleRow[];
+      failedRows: BundleRow[];
+    }>
+  ) {
+    let aggregateBundle = this.blsWalletSigner.aggregate([]);
+    const includedRows: BundleRow[] = [];
+    const failedRows: BundleRow[] = [];
+
+    while (eligibleRows.length > 0) {
+      const {
+        aggregateBundle: newAggregateBundle,
+        includedRows: newIncludedRows,
+        failedRows: newFailedRows,
+        remainingEligibleRows,
+      } = await this.#augmentAggregateBundle(
+        aggregateBundle,
+        eligibleRows,
+      );
+
+      aggregateBundle = newAggregateBundle;
+      includedRows.push(...newIncludedRows);
+      failedRows.push(...newFailedRows);
+      eligibleRows = remainingEligibleRows;
+    }
+
+    return {
+      aggregateBundle: aggregateBundle.operations.length > 0
+        ? aggregateBundle
+        : nil,
+      includedRows,
+      failedRows,
+    };
+  }
+
+  async #augmentAggregateBundle(
+    previousAggregateBundle: Bundle,
+    eligibleRows: BundleRow[],
+  ): (
+    Promise<{
+      aggregateBundle: Bundle;
+      includedRows: BundleRow[];
+      failedRows: BundleRow[];
+      remainingEligibleRows: BundleRow[];
+    }>
+  ) {
+    let aggregateBundle: Bundle | nil = nil;
+    let includedRows: BundleRow[] = [];
+    const failedRows: BundleRow[] = [];
+    // TODO (merge-ok): Count gas instead, have idea
+    // or way to query max gas per txn (submission).
+    let actionCount = countActions(previousAggregateBundle);
+
+    for (const row of eligibleRows) {
+      const rowActionCount = countActions(row.bundle);
+
+      if (actionCount + rowActionCount > this.config.maxAggregationSize) {
+        break;
+      }
+
+      includedRows.push(row);
+      actionCount += rowActionCount;
+    }
+
+    if (includedRows.length === 0) {
+      return {
+        aggregateBundle: previousAggregateBundle,
+        includedRows,
+        failedRows,
+
+        // If we're not able to include anything more, don't consider any rows
+        // eligible anymore.
+        remainingEligibleRows: [],
+      };
+    }
+
+    const [previousFee, ...fees] = (await this.#measureFees([
+      previousAggregateBundle,
+      ...includedRows.map((r) => r.bundle),
+    ]));
+
+    const firstFailureIndex = await this.#findFirstFailureIndex(
+      previousAggregateBundle,
+      previousFee,
+      includedRows.map((r) => r.bundle),
+      fees,
+    );
+
+    let remainingEligibleRows: BundleRow[];
+
+    if (firstFailureIndex !== nil) {
+      const failedRow = includedRows[firstFailureIndex];
+      failedRows.push(failedRow);
+
+      includedRows = includedRows.slice(
+        0,
+        firstFailureIndex,
+      );
+
+      const eligibleRowIndex = eligibleRows.indexOf(failedRow);
+      assert(eligibleRowIndex !== -1);
+
+      remainingEligibleRows = eligibleRows.slice(includedRows.length + 1);
+    } else {
+      remainingEligibleRows = eligibleRows.slice(includedRows.length);
+    }
+
+    aggregateBundle = this.blsWalletSigner.aggregate([
+      previousAggregateBundle,
+      ...includedRows.map((r) => r.bundle),
+    ]);
+
+    return {
+      aggregateBundle,
+      includedRows,
+      failedRows,
+      remainingEligibleRows,
+    };
+  }
+
+  async #measureFees(bundles: Bundle[]): Promise<{
+    success: boolean;
+    fee: BigNumber;
+  }[]> {
+    const es = this.ethereumService;
+    const feeToken = this.#FeeToken();
+
+    const { measureResults, callResults: processBundleResults } = await es
+      .callStaticSequenceWithMeasure(
+        feeToken
+          ? es.Call(feeToken, "balanceOf", [es.wallet.address])
+          : es.Call(es.utilities, "ethBalanceOf", [es.wallet.address]),
+        bundles.map((bundle) =>
+          es.Call(
+            es.verificationGateway,
+            "processBundle",
+            [bundle],
+          )
+        ),
+      );
+
+    return Range(bundles.length).map((i) => {
+      const [before, after] = [measureResults[i], measureResults[i + 1]];
+      assert(before.success);
+      assert(after.success);
+
+      const bundleResult = processBundleResults[i];
+
+      let success: boolean;
+
+      if (bundleResult.success) {
+        const [operationResults] = bundleResult.returnValue;
+
+        // We require that at least one operation succeeds, even though
+        // processBundle doesn't revert in this case.
+        success = operationResults.some((opSuccess) => opSuccess === true);
+      } else {
+        success = false;
+      }
+
+      const fee = after.returnValue[0].sub(before.returnValue[0]);
+
+      return { success, fee };
+    });
+  }
+
+  #FeeToken(): ERC20 | nil {
+    const feeType = this.config.fees.type;
+
+    if (feeType === "ether") {
+      return nil;
+    }
+
+    return ERC20__factory.connect(
+      feeType.slice("token:".length),
+      this.ethereumService.wallet.provider,
+    );
+  }
+
+  async #measureRequiredFee(bundle: Bundle) {
+    const gasEstimate = await this.ethereumService.verificationGateway
+      .estimateGas
+      .processBundle(bundle);
+
+    const callDataSize = ethers.utils.hexDataLength(
+      this.ethereumService.verificationGateway.interface
+        .encodeFunctionData("processBundle", [bundle]),
+    );
+
+    return (
+      gasEstimate.mul(this.config.fees.perGas).add(
+        this.config.fees.perByte.mul(callDataSize),
+      )
+    );
+  }
+
+  /**
+   * Get a lower bound for the fee that is required for processing the
+   * bundle.
+   *
+   * This exists because it's a very good lower bound and it's very fast.
+   * Therefore, when there's an insufficient fee bundle:
+   * - This lower bound is usually enough to find it
+   * - Finding it this way is much more efficient
+   */
+  #measureRequiredFeeLowerBound(bundle: Bundle) {
+    const callDataEmptyBundleSize = ethers.utils.hexDataLength(
+      this.ethereumService.verificationGateway.interface
+        .encodeFunctionData("processBundle", [
+          this.blsWalletSigner.aggregate([]),
+        ]),
+    );
+
+    const callDataSize = ethers.utils.hexDataLength(
+      this.ethereumService.verificationGateway.interface
+        .encodeFunctionData("processBundle", [bundle]),
+    );
+
+    // We subtract the size of an empty bundle because it represents the number
+    // of *additional* bytes added when aggregating. The bundle doesn't
+    // necessarily have to pay the initial overhead to be viable.
+    const callDataMarginalSize = callDataSize - callDataEmptyBundleSize;
+
+    return this.config.fees.perByte.mul(callDataMarginalSize);
+  }
+
+  async #findFirstFailureIndex(
+    previousAggregateBundle: Bundle,
+    previousFee: { success: boolean; fee: BigNumber },
+    bundles: Bundle[],
+    fees: { success: boolean; fee: BigNumber }[],
+  ): Promise<number | nil> {
+    if (bundles.length === 0) {
+      return nil;
+    }
+
+    const len = bundles.length;
+    assert(fees.length === len);
+
+    const checkFirstN = async (n: number): Promise<{
+      success: boolean;
+      fee: BigNumber;
+      requiredFee: BigNumber;
+    }> => {
+      if (n === 0) {
+        return {
+          success: true,
+          fee: BigNumber.from(0),
+          requiredFee: BigNumber.from(0),
+        };
+      }
+
+      const fee = bigSum([
+        previousFee.fee,
+        ...fees.slice(0, n).map((r) => r.fee),
+      ]);
+
+      const requiredFee = await this.#measureRequiredFee(
+        this.blsWalletSigner.aggregate([
+          previousAggregateBundle,
+          ...bundles.slice(0, n),
+        ]),
+      );
+
+      const success = fee.gte(requiredFee);
+
+      return { success, fee, requiredFee };
+    };
+
+    // This calculation is entirely local and cheap. It can find a failing
+    // bundle, but it might not be the *first* failing bundle.
+    const fastFailureIndex = (() => {
+      for (let i = 0; i < len; i++) {
+        // If the actual call failed then we consider it a failure, even if the
+        // fee is somehow met (e.g. if zero fee is required).
+        if (fees[i].success === false) {
+          return i;
+        }
+
+        // Because the required fee mostly comes from the calldata size, this
+        // should find the first insufficient fee most of the time.
+        const lowerBound = this.#measureRequiredFeeLowerBound(bundles[i]);
+
+        if (fees[i].fee.lt(lowerBound)) {
+          return i;
+        }
+      }
+    })();
+
+    let left = 0;
+    let leftRequiredFee = BigNumber.from(0);
+    let right: number;
+    let rightRequiredFee: BigNumber;
+
+    if (fastFailureIndex !== nil) {
+      // Having a fast failure index is not enough because it might not be the
+      // first. To establish that it really is the first, we need to ensure that
+      // all bundles up to that index are ok (indeed, this is the assumption
+      // that is relied upon outside - that the subset before the first failing
+      // index can proceed without further checking).
+
+      const { success, requiredFee } = await checkFirstN(fastFailureIndex);
+
+      if (success) {
+        return fastFailureIndex;
+      }
+
+      // In case of failure, we now know there as a failing index in a more
+      // narrow range, so we can at least restrict the bisect to this smaller
+      // range.
+      right = fastFailureIndex;
+      rightRequiredFee = requiredFee;
+    } else {
+      // If we don't have a failing index, we still need to establish that there
+      // is a failing index to be found. This is because it's a requirement of
+      // the upcoming bisect logic that there is a failing bundle in
+      // `bundles.slice(left, right)`.
+
+      const { success, requiredFee } = await checkFirstN(bundles.length);
+
+      if (success) {
+        return nil;
+      }
+
+      right = bundles.length;
+      rightRequiredFee = requiredFee;
+    }
+
+    // Do a bisect to narrow in on the (first) culprit.
+    while (right - left > 1) {
+      const mid = Math.floor((left + right) / 2);
+
+      const { success, requiredFee } = await checkFirstN(mid);
+
+      if (success) {
+        left = mid;
+        leftRequiredFee = requiredFee;
+      } else {
+        right = mid;
+        rightRequiredFee = requiredFee;
+      }
+    }
+
+    assert(right - left === 1, "bisect should identify a single result");
+
+    // The bisect procedure maintains that the culprit is a member of
+    // `bundles.slice(left, right)`. That's now equivalent to `[bundles[left]]`,
+    // so `left` is our culprit index.
+
+    const bundleFee = fees[left].fee;
+    const bundleRequiredFee = rightRequiredFee.sub(leftRequiredFee);
+
+    // Tracking the fees so that we can include this assertion isn't strictly
+    // necessary. But the cost is negligible and should help troubleshooting a
+    // lot if something goes wrong.
+    assert(bundleFee.lt(bundleRequiredFee));
+
+    return left;
+  }
+}

--- a/aggregator/src/app/BundleService.ts
+++ b/aggregator/src/app/BundleService.ts
@@ -23,6 +23,9 @@ import runQueryGroup from "./runQueryGroup.ts";
 import EthereumService from "./EthereumService.ts";
 import AppEvent from "./AppEvent.ts";
 import BundleTable, { BundleRow } from "./BundleTable.ts";
+import countActions from "./helpers/countActions.ts";
+import plus from "./helpers/plus.ts";
+import bigSum from "./helpers/bigSum.ts";
 
 export default class BundleService {
   static defaultConfig = {
@@ -666,16 +669,4 @@ export default class BundleService {
       await delay(100);
     }
   }
-}
-
-function countActions(bundle: Bundle) {
-  return bundle.operations.map((op) => op.actions.length).reduce(plus, 0);
-}
-
-function plus(a: number, b: number) {
-  return a + b;
-}
-
-function bigSum(values: BigNumber[]) {
-  return values.reduce((a, b) => a.add(b), BigNumber.from(0));
 }

--- a/aggregator/src/app/BundleService.ts
+++ b/aggregator/src/app/BundleService.ts
@@ -3,18 +3,12 @@ import {
   BlsWalletSigner,
   Bundle,
   delay,
-  ERC20,
-  ERC20__factory,
-  ethers,
   QueryClient,
 } from "../../deps.ts";
 
 import { IClock } from "../helpers/Clock.ts";
 import Mutex from "../helpers/Mutex.ts";
 import toShortPublicKey from "./helpers/toPublicKeyShort.ts";
-import nil from "../helpers/nil.ts";
-import Range from "../helpers/Range.ts";
-import assert from "../helpers/assert.ts";
 
 import TransactionFailure from "./TransactionFailure.ts";
 import SubmissionTimer from "./SubmissionTimer.ts";
@@ -25,7 +19,7 @@ import AppEvent from "./AppEvent.ts";
 import BundleTable, { BundleRow } from "./BundleTable.ts";
 import countActions from "./helpers/countActions.ts";
 import plus from "./helpers/plus.ts";
-import bigSum from "./helpers/bigSum.ts";
+import AggregationStrategy from "./AggregationStrategy.ts";
 
 export default class BundleService {
   static defaultConfig = {
@@ -34,11 +28,6 @@ export default class BundleService {
     maxAggregationDelayMillis: env.MAX_AGGREGATION_DELAY_MILLIS,
     maxUnconfirmedAggregations: env.MAX_UNCONFIRMED_AGGREGATIONS,
     maxEligibilityDelay: env.MAX_ELIGIBILITY_DELAY,
-    fees: {
-      type: env.FEE_TYPE,
-      perGas: env.FEE_PER_GAS,
-      perByte: env.FEE_PER_BYTE,
-    },
   };
 
   unconfirmedBundles = new Set<Bundle>();
@@ -60,6 +49,7 @@ export default class BundleService {
     public bundleTable: BundleTable,
     public blsWalletSigner: BlsWalletSigner,
     public ethereumService: EthereumService,
+    public aggregationStrategy: AggregationStrategy,
     public config = BundleService.defaultConfig,
   ) {
     this.submissionTimer = new SubmissionTimer(
@@ -201,7 +191,7 @@ export default class BundleService {
       );
 
       const { aggregateBundle, includedRows, failedRows } = await this
-        .createAggregateBundle(eligibleRows);
+        .aggregationStrategy.run(eligibleRows);
 
       for (const failedRow of failedRows) {
         await this.handleFailedRow(failedRow, currentBlockNumber);
@@ -221,368 +211,6 @@ export default class BundleService {
     this.addTask(() => this.tryAggregating());
 
     return submissionResult;
-  }
-
-  async createAggregateBundle(eligibleRows: BundleRow[]): (
-    Promise<{
-      aggregateBundle: Bundle | nil;
-      includedRows: BundleRow[];
-      failedRows: BundleRow[];
-    }>
-  ) {
-    let aggregateBundle = this.blsWalletSigner.aggregate([]);
-    const includedRows: BundleRow[] = [];
-    const failedRows: BundleRow[] = [];
-
-    while (eligibleRows.length > 0) {
-      const {
-        aggregateBundle: newAggregateBundle,
-        includedRows: newIncludedRows,
-        failedRows: newFailedRows,
-        remainingEligibleRows,
-      } = await this.augmentAggregateBundle(
-        aggregateBundle,
-        eligibleRows,
-      );
-
-      aggregateBundle = newAggregateBundle;
-      includedRows.push(...newIncludedRows);
-      failedRows.push(...newFailedRows);
-      eligibleRows = remainingEligibleRows;
-    }
-
-    return {
-      aggregateBundle: aggregateBundle.operations.length > 0
-        ? aggregateBundle
-        : nil,
-      includedRows,
-      failedRows,
-    };
-  }
-
-  async augmentAggregateBundle(
-    previousAggregateBundle: Bundle,
-    eligibleRows: BundleRow[],
-  ): (
-    Promise<{
-      aggregateBundle: Bundle;
-      includedRows: BundleRow[];
-      failedRows: BundleRow[];
-      remainingEligibleRows: BundleRow[];
-    }>
-  ) {
-    let aggregateBundle: Bundle | nil = nil;
-    let includedRows: BundleRow[] = [];
-    const failedRows: BundleRow[] = [];
-    // TODO (merge-ok): Count gas instead, have idea
-    // or way to query max gas per txn (submission).
-    let actionCount = countActions(previousAggregateBundle);
-
-    for (const row of eligibleRows) {
-      const rowActionCount = countActions(row.bundle);
-
-      if (actionCount + rowActionCount > this.config.maxAggregationSize) {
-        break;
-      }
-
-      includedRows.push(row);
-      actionCount += rowActionCount;
-    }
-
-    if (includedRows.length === 0) {
-      return {
-        aggregateBundle: previousAggregateBundle,
-        includedRows,
-        failedRows,
-
-        // If we're not able to include anything more, don't consider any rows
-        // eligible anymore.
-        remainingEligibleRows: [],
-      };
-    }
-
-    const [previousFee, ...fees] = (await this.measureFees([
-      previousAggregateBundle,
-      ...includedRows.map((r) => r.bundle),
-    ]));
-
-    const firstFailureIndex = await this.findFirstFailureIndex(
-      previousAggregateBundle,
-      previousFee,
-      includedRows.map((r) => r.bundle),
-      fees,
-    );
-
-    let remainingEligibleRows: BundleRow[];
-
-    if (firstFailureIndex !== nil) {
-      const failedRow = includedRows[firstFailureIndex];
-      failedRows.push(failedRow);
-
-      includedRows = includedRows.slice(
-        0,
-        firstFailureIndex,
-      );
-
-      const eligibleRowIndex = eligibleRows.indexOf(failedRow);
-      assert(eligibleRowIndex !== -1);
-
-      remainingEligibleRows = eligibleRows.slice(includedRows.length + 1);
-    } else {
-      remainingEligibleRows = eligibleRows.slice(includedRows.length);
-    }
-
-    aggregateBundle = this.blsWalletSigner.aggregate([
-      previousAggregateBundle,
-      ...includedRows.map((r) => r.bundle),
-    ]);
-
-    return {
-      aggregateBundle,
-      includedRows,
-      failedRows,
-      remainingEligibleRows,
-    };
-  }
-
-  async measureFees(bundles: Bundle[]): Promise<{
-    success: boolean;
-    fee: BigNumber;
-  }[]> {
-    const es = this.ethereumService;
-    const feeToken = this.FeeToken();
-
-    const { measureResults, callResults: processBundleResults } = await es
-      .callStaticSequenceWithMeasure(
-        feeToken
-          ? es.Call(feeToken, "balanceOf", [es.wallet.address])
-          : es.Call(es.utilities, "ethBalanceOf", [es.wallet.address]),
-        bundles.map((bundle) =>
-          es.Call(
-            es.verificationGateway,
-            "processBundle",
-            [bundle],
-          )
-        ),
-      );
-
-    return Range(bundles.length).map((i) => {
-      const [before, after] = [measureResults[i], measureResults[i + 1]];
-      assert(before.success);
-      assert(after.success);
-
-      const bundleResult = processBundleResults[i];
-
-      let success: boolean;
-
-      if (bundleResult.success) {
-        const [operationResults] = bundleResult.returnValue;
-
-        // We require that at least one operation succeeds, even though
-        // processBundle doesn't revert in this case.
-        success = operationResults.some((opSuccess) => opSuccess === true);
-      } else {
-        success = false;
-      }
-
-      const fee = after.returnValue[0].sub(before.returnValue[0]);
-
-      return { success, fee };
-    });
-  }
-
-  FeeToken(): ERC20 | nil {
-    const feeType = this.config.fees.type;
-
-    if (feeType === "ether") {
-      return nil;
-    }
-
-    return ERC20__factory.connect(
-      feeType.slice("token:".length),
-      this.ethereumService.wallet.provider,
-    );
-  }
-
-  async measureRequiredFee(bundle: Bundle) {
-    const gasEstimate = await this.ethereumService.verificationGateway
-      .estimateGas
-      .processBundle(bundle);
-
-    const callDataSize = ethers.utils.hexDataLength(
-      this.ethereumService.verificationGateway.interface
-        .encodeFunctionData("processBundle", [bundle]),
-    );
-
-    return (
-      gasEstimate.mul(this.config.fees.perGas).add(
-        this.config.fees.perByte.mul(callDataSize),
-      )
-    );
-  }
-
-  /**
-   * Get a lower bound for the fee that is required for processing the
-   * bundle.
-   *
-   * This exists because it's a very good lower bound and it's very fast.
-   * Therefore, when there's an insufficient fee bundle:
-   * - This lower bound is usually enough to find it
-   * - Finding it this way is much more efficient
-   */
-  measureRequiredFeeLowerBound(bundle: Bundle) {
-    const callDataEmptyBundleSize = ethers.utils.hexDataLength(
-      this.ethereumService.verificationGateway.interface
-        .encodeFunctionData("processBundle", [
-          this.blsWalletSigner.aggregate([]),
-        ]),
-    );
-
-    const callDataSize = ethers.utils.hexDataLength(
-      this.ethereumService.verificationGateway.interface
-        .encodeFunctionData("processBundle", [bundle]),
-    );
-
-    // We subtract the size of an empty bundle because it represents the number
-    // of *additional* bytes added when aggregating. The bundle doesn't
-    // necessarily have to pay the initial overhead to be viable.
-    const callDataMarginalSize = callDataSize - callDataEmptyBundleSize;
-
-    return this.config.fees.perByte.mul(callDataMarginalSize);
-  }
-
-  async findFirstFailureIndex(
-    previousAggregateBundle: Bundle,
-    previousFee: { success: boolean; fee: BigNumber },
-    bundles: Bundle[],
-    fees: { success: boolean; fee: BigNumber }[],
-  ): Promise<number | nil> {
-    if (bundles.length === 0) {
-      return nil;
-    }
-
-    const len = bundles.length;
-    assert(fees.length === len);
-
-    const checkFirstN = async (n: number): Promise<{
-      success: boolean;
-      fee: BigNumber;
-      requiredFee: BigNumber;
-    }> => {
-      if (n === 0) {
-        return {
-          success: true,
-          fee: BigNumber.from(0),
-          requiredFee: BigNumber.from(0),
-        };
-      }
-
-      const fee = bigSum([
-        previousFee.fee,
-        ...fees.slice(0, n).map((r) => r.fee),
-      ]);
-
-      const requiredFee = await this.measureRequiredFee(
-        this.blsWalletSigner.aggregate([
-          previousAggregateBundle,
-          ...bundles.slice(0, n),
-        ]),
-      );
-
-      const success = fee.gte(requiredFee);
-
-      return { success, fee, requiredFee };
-    };
-
-    // This calculation is entirely local and cheap. It can find a failing
-    // bundle, but it might not be the *first* failing bundle.
-    const fastFailureIndex = (() => {
-      for (let i = 0; i < len; i++) {
-        // If the actual call failed then we consider it a failure, even if the
-        // fee is somehow met (e.g. if zero fee is required).
-        if (fees[i].success === false) {
-          return i;
-        }
-
-        // Because the required fee mostly comes from the calldata size, this
-        // should find the first insufficient fee most of the time.
-        const lowerBound = this.measureRequiredFeeLowerBound(bundles[i]);
-
-        if (fees[i].fee.lt(lowerBound)) {
-          return i;
-        }
-      }
-    })();
-
-    let left = 0;
-    let leftRequiredFee = BigNumber.from(0);
-    let right: number;
-    let rightRequiredFee: BigNumber;
-
-    if (fastFailureIndex !== nil) {
-      // Having a fast failure index is not enough because it might not be the
-      // first. To establish that it really is the first, we need to ensure that
-      // all bundles up to that index are ok (indeed, this is the assumption
-      // that is relied upon outside - that the subset before the first failing
-      // index can proceed without further checking).
-
-      const { success, requiredFee } = await checkFirstN(fastFailureIndex);
-
-      if (success) {
-        return fastFailureIndex;
-      }
-
-      // In case of failure, we now know there as a failing index in a more
-      // narrow range, so we can at least restrict the bisect to this smaller
-      // range.
-      right = fastFailureIndex;
-      rightRequiredFee = requiredFee;
-    } else {
-      // If we don't have a failing index, we still need to establish that there
-      // is a failing index to be found. This is because it's a requirement of
-      // the upcoming bisect logic that there is a failing bundle in
-      // `bundles.slice(left, right)`.
-
-      const { success, requiredFee } = await checkFirstN(bundles.length);
-
-      if (success) {
-        return nil;
-      }
-
-      right = bundles.length;
-      rightRequiredFee = requiredFee;
-    }
-
-    // Do a bisect to narrow in on the (first) culprit.
-    while (right - left > 1) {
-      const mid = Math.floor((left + right) / 2);
-
-      const { success, requiredFee } = await checkFirstN(mid);
-
-      if (success) {
-        left = mid;
-        leftRequiredFee = requiredFee;
-      } else {
-        right = mid;
-        rightRequiredFee = requiredFee;
-      }
-    }
-
-    assert(right - left === 1, "bisect should identify a single result");
-
-    // The bisect procedure maintains that the culprit is a member of
-    // `bundles.slice(left, right)`. That's now equivalent to `[bundles[left]]`,
-    // so `left` is our culprit index.
-
-    const bundleFee = fees[left].fee;
-    const bundleRequiredFee = rightRequiredFee.sub(leftRequiredFee);
-
-    // Tracking the fees so that we can include this assertion isn't strictly
-    // necessary. But the cost is negligible and should help troubleshooting a
-    // lot if something goes wrong.
-    assert(bundleFee.lt(bundleRequiredFee));
-
-    return left;
   }
 
   async handleFailedRow(row: BundleRow, currentBlockNumber: BigNumber) {

--- a/aggregator/src/app/app.ts
+++ b/aggregator/src/app/app.ts
@@ -14,6 +14,7 @@ import Clock from "../helpers/Clock.ts";
 import getNetworkConfig from "../helpers/getNetworkConfig.ts";
 import AppEvent from "./AppEvent.ts";
 import BundleTable from "./BundleTable.ts";
+import AggregationStrategy from "./AggregationStrategy.ts";
 
 export default async function app(emit: (evt: AppEvent) => void) {
   const { addresses } = await getNetworkConfig();
@@ -34,6 +35,11 @@ export default async function app(emit: (evt: AppEvent) => void) {
     env.PRIVATE_KEY_AGG,
   );
 
+  const aggregationStrategy = new AggregationStrategy(
+    ethereumService.blsWalletSigner,
+    ethereumService,
+  );
+
   const bundleService = new BundleService(
     emit,
     clock,
@@ -42,6 +48,7 @@ export default async function app(emit: (evt: AppEvent) => void) {
     bundleTable,
     ethereumService.blsWalletSigner,
     ethereumService,
+    aggregationStrategy,
   );
 
   const adminService = new AdminService(

--- a/aggregator/src/app/helpers/bigSum.ts
+++ b/aggregator/src/app/helpers/bigSum.ts
@@ -1,0 +1,5 @@
+import { BigNumber } from "../../../deps.ts";
+
+export default function bigSum(values: BigNumber[]) {
+  return values.reduce((a, b) => a.add(b), BigNumber.from(0));
+}

--- a/aggregator/src/app/helpers/countActions.ts
+++ b/aggregator/src/app/helpers/countActions.ts
@@ -1,0 +1,6 @@
+import { Bundle } from "../../../deps.ts";
+import plus from "./plus.ts";
+
+export default function countActions(bundle: Bundle) {
+  return bundle.operations.map((op) => op.actions.length).reduce(plus, 0);
+}

--- a/aggregator/src/app/helpers/plus.ts
+++ b/aggregator/src/app/helpers/plus.ts
@@ -1,0 +1,3 @@
+export default function plus(a: number, b: number) {
+  return a + b;
+}

--- a/aggregator/test/BundleServiceFees.test.ts
+++ b/aggregator/test/BundleServiceFees.test.ts
@@ -6,24 +6,33 @@ import {
   ethers,
   Operation,
 } from "./deps.ts";
-import Fixture, { bundleServiceDefaultTestConfig } from "./helpers/Fixture.ts";
+import Fixture, {
+  aggregationStrategyDefaultTestConfig,
+  bundleServiceDefaultTestConfig,
+} from "./helpers/Fixture.ts";
 
 const oneToken = ethers.utils.parseUnits("1.0", 18);
 
 async function createBundleService(
   fx: Fixture,
-  feesOverride?: Partial<typeof bundleServiceDefaultTestConfig["fees"]>,
+  feesOverride?: Partial<typeof aggregationStrategyDefaultTestConfig["fees"]>,
 ) {
-  return await fx.createBundleService({
-    ...bundleServiceDefaultTestConfig,
-    maxAggregationSize: 24,
-    fees: {
-      type: `token:${fx.testErc20.address}`,
-      perGas: BigNumber.from(10_000_000_000),
-      perByte: BigNumber.from(100_000_000_000_000),
-      ...feesOverride,
+  return await fx.createBundleService(
+    {
+      ...bundleServiceDefaultTestConfig,
+      maxAggregationSize: 24,
     },
-  });
+    {
+      ...aggregationStrategyDefaultTestConfig,
+      maxAggregationSize: 24,
+      fees: {
+        type: `token:${fx.testErc20.address}`,
+        perGas: BigNumber.from(10_000_000_000),
+        perByte: BigNumber.from(100_000_000_000_000),
+        ...feesOverride,
+      },
+    },
+  );
 }
 
 function approveAndSendTokensToOrigin(

--- a/aggregator/test/BundleServiceSubmitting.test.ts
+++ b/aggregator/test/BundleServiceSubmitting.test.ts
@@ -1,5 +1,8 @@
 import { assertEquals, BigNumber } from "./deps.ts";
-import Fixture, { bundleServiceDefaultTestConfig } from "./helpers/Fixture.ts";
+import Fixture, {
+  aggregationStrategyDefaultTestConfig,
+  bundleServiceDefaultTestConfig,
+} from "./helpers/Fixture.ts";
 import Range from "../src/helpers/Range.ts";
 
 const bundleServiceConfig = {
@@ -8,8 +11,17 @@ const bundleServiceConfig = {
   maxAggregationDelayMillis: 5000,
 };
 
+const aggregationStrategyConfig = {
+  ...aggregationStrategyDefaultTestConfig,
+  maxAggregationSize: 5,
+};
+
 Fixture.test("submits a single action in a timed submission", async (fx) => {
-  const bundleService = await fx.createBundleService(bundleServiceConfig);
+  const bundleService = await fx.createBundleService(
+    bundleServiceConfig,
+    aggregationStrategyConfig,
+  );
+
   const [wallet] = await fx.setupWallets(1);
 
   const bundle = wallet.sign({
@@ -47,7 +59,11 @@ Fixture.test("submits a single action in a timed submission", async (fx) => {
 });
 
 Fixture.test("submits a full submission without delay", async (fx) => {
-  const bundleService = await fx.createBundleService(bundleServiceConfig);
+  const bundleService = await fx.createBundleService(
+    bundleServiceConfig,
+    aggregationStrategyConfig,
+  );
+
   const [wallet] = await fx.setupWallets(1);
   const walletNonce = await wallet.Nonce();
 
@@ -90,7 +106,11 @@ Fixture.test(
     "leftover bundles after delay",
   ].join(" "),
   async (fx) => {
-    const bundleService = await fx.createBundleService(bundleServiceConfig);
+    const bundleService = await fx.createBundleService(
+      bundleServiceConfig,
+      aggregationStrategyConfig,
+    );
+
     const [wallet] = await fx.setupWallets(1);
     const walletNonce = await wallet.Nonce();
 
@@ -151,7 +171,11 @@ Fixture.test(
 Fixture.test(
   "submits 3 bundles in reverse (incorrect) nonce order",
   async (fx) => {
-    const bundleService = await fx.createBundleService(bundleServiceConfig);
+    const bundleService = await fx.createBundleService(
+      bundleServiceConfig,
+      aggregationStrategyConfig,
+    );
+
     const [wallet] = await fx.setupWallets(1);
     const walletNonce = await wallet.Nonce();
 
@@ -226,10 +250,13 @@ Fixture.test(
 );
 
 Fixture.test("retains failing bundle when its eligibility delay is smaller than MAX_ELIGIBILITY_DELAY", async (fx) => {
-  const bundleService = await fx.createBundleService({
-    ...bundleServiceConfig,
-    maxEligibilityDelay: 300,
-  });
+  const bundleService = await fx.createBundleService(
+    {
+      ...bundleServiceConfig,
+      maxEligibilityDelay: 300,
+    },
+    aggregationStrategyConfig,
+  );
 
   const [wallet] = await fx.setupWallets(1);
 
@@ -263,10 +290,13 @@ Fixture.test("retains failing bundle when its eligibility delay is smaller than 
 });
 
 Fixture.test("removes failing bundle when its eligibility delay is larger than MAX_ELIGIBILITY_DELAY", async (fx) => {
-  const bundleService = await fx.createBundleService({
-    ...bundleServiceConfig,
-    maxEligibilityDelay: 300,
-  });
+  const bundleService = await fx.createBundleService(
+    {
+      ...bundleServiceConfig,
+      maxEligibilityDelay: 300,
+    },
+    aggregationStrategyConfig,
+  );
 
   const [wallet] = await fx.setupWallets(1);
 


### PR DESCRIPTION
## What is this PR doing?

Separates `AggregationStrategy` from `BundleService` so that all the logic for converting a known set of eligible bundles into a concrete aggregate bundle for submitting is in one place. (Basically just cut and paste half of `BundleService` and then fix some imports.)

This will make it easier eg to implement mev and other more complex strategies.

It also makes `BundleService` more focused on the admin side of receiving bundles and deciding when to try to submit things on chain.

## How can these changes be manually tested?

Run the premerge script.

## Does this PR resolve or contribute to any issues?

Resolves #152.

## Checklist
- [x] I have manually tested these changes
- [x] Post a link to the PR in the group chat

## Guidelines
- If your PR is not ready, mark it as a draft
- The `resolve conversation` button is for reviewers, not authors
  - (But add a 'done' comment or similar)
