### PR TITLE
Add /estimateFee

### DIFF
--- a/aggregator/deps.ts
+++ b/aggregator/deps.ts
@@ -48,7 +48,7 @@ export type {
   PublicKey,
   Signature,
   VerificationGateway,
-} from "https://esm.sh/bls-wallet-clients@0.5.4-3dc82be";
+} from "https://esm.sh/bls-wallet-clients@0.5.4-50dbd9f";
 
 export {
   Aggregator as AggregatorClient,
@@ -58,10 +58,10 @@ export {
   getConfig,
   MockERC20__factory,
   VerificationGateway__factory,
-} from "https://esm.sh/bls-wallet-clients@0.5.4-3dc82be";
+} from "https://esm.sh/bls-wallet-clients@0.5.4-50dbd9f";
 
 // Workaround for esbuild's export-star bug
-import blsWalletClients from "https://esm.sh/bls-wallet-clients@0.5.4-3dc82be";
+import blsWalletClients from "https://esm.sh/bls-wallet-clients@0.5.4-50dbd9f";
 const {
   bundleFromDto,
   bundleToDto,

--- a/aggregator/deps.ts
+++ b/aggregator/deps.ts
@@ -48,7 +48,7 @@ export type {
   PublicKey,
   Signature,
   VerificationGateway,
-} from "https://esm.sh/bls-wallet-clients@0.5.4-8c9c0ef";
+} from "https://esm.sh/bls-wallet-clients@0.5.4-3dc82be";
 
 export {
   Aggregator as AggregatorClient,
@@ -58,10 +58,10 @@ export {
   getConfig,
   MockERC20__factory,
   VerificationGateway__factory,
-} from "https://esm.sh/bls-wallet-clients@0.5.4-8c9c0ef";
+} from "https://esm.sh/bls-wallet-clients@0.5.4-3dc82be";
 
 // Workaround for esbuild's export-star bug
-import blsWalletClients from "https://esm.sh/bls-wallet-clients@0.5.4-8c9c0ef";
+import blsWalletClients from "https://esm.sh/bls-wallet-clients@0.5.4-3dc82be";
 const {
   bundleFromDto,
   bundleToDto,

--- a/aggregator/manualTests/mint1ViaAggregator.ts
+++ b/aggregator/manualTests/mint1ViaAggregator.ts
@@ -33,6 +33,11 @@ const bundle = wallet.sign({
   }],
 });
 
+console.log("Calling estimateFee");
+
+const feeEstimation = await client.estimateFee(bundle);
+console.log({ feeEstimation });
+
 console.log("Sending mint bundle to aggregator");
 
 const failures = await client.add(bundle);

--- a/aggregator/src/app/AggregationStrategy.ts
+++ b/aggregator/src/app/AggregationStrategy.ts
@@ -15,6 +15,7 @@ import * as env from "../env.ts";
 import EthereumService from "./EthereumService.ts";
 import { BundleRow } from "./BundleTable.ts";
 import countActions from "./helpers/countActions.ts";
+import ClientReportableError from "./helpers/ClientReportableError.ts";
 
 export default class AggregationStrategy {
   static defaultConfig = {
@@ -95,7 +96,7 @@ export default class AggregationStrategy {
       balanceResultBefore.returnValue === undefined ||
       balanceResultAfter.returnValue === undefined
     ) {
-      throw new Error("Failed to get balance");
+      throw new ClientReportableError("Failed to get balance");
     }
 
     const balanceBefore = balanceResultBefore.returnValue[0];
@@ -104,7 +105,7 @@ export default class AggregationStrategy {
     const feeDetected = balanceAfter.sub(balanceBefore);
 
     if (bundleResult.returnValue === undefined) {
-      throw new Error("Failed to statically process bundle");
+      throw new ClientReportableError("Failed to statically process bundle");
     }
 
     const feeRequired = await this.#measureRequiredFee(bundle);

--- a/aggregator/src/app/AggregationStrategyRouter.ts
+++ b/aggregator/src/app/AggregationStrategyRouter.ts
@@ -1,0 +1,35 @@
+import { Router } from "../../deps.ts";
+import BundleHandler from "./helpers/BundleHandler.ts";
+
+import AggregationStrategy from "./AggregationStrategy.ts";
+import AsyncReturnType from "../helpers/AsyncReturnType.ts";
+import ClientReportableError from "./helpers/ClientReportableError.ts";
+
+export default function AggregationStrategyRouter(
+  aggregationStrategy: AggregationStrategy,
+) {
+  const router = new Router({ prefix: "/" });
+
+  router.post(
+    "estimateFee",
+    BundleHandler(async (ctx, bundle) => {
+      let result: AsyncReturnType<AggregationStrategy["estimateFee"]>;
+
+      try {
+        result = await aggregationStrategy.estimateFee(bundle);
+      } catch (error) {
+        if (error instanceof ClientReportableError) {
+          ctx.response.status = 500;
+          ctx.response.body = error.message;
+          return;
+        }
+
+        throw error;
+      }
+
+      ctx.response.body = result;
+    }),
+  );
+
+  return router;
+}

--- a/aggregator/src/app/AggregationStrategyRouter.ts
+++ b/aggregator/src/app/AggregationStrategyRouter.ts
@@ -27,7 +27,12 @@ export default function AggregationStrategyRouter(
         throw error;
       }
 
-      ctx.response.body = result;
+      ctx.response.body = {
+        feeType: aggregationStrategy.config.fees.type,
+        feeDetected: result.feeDetected.toString(),
+        feeRequired: result.feeRequired.toString(),
+        successes: result.successes,
+      };
     }),
   );
 

--- a/aggregator/src/app/app.ts
+++ b/aggregator/src/app/app.ts
@@ -15,6 +15,7 @@ import getNetworkConfig from "../helpers/getNetworkConfig.ts";
 import AppEvent from "./AppEvent.ts";
 import BundleTable from "./BundleTable.ts";
 import AggregationStrategy from "./AggregationStrategy.ts";
+import AggregationStrategyRouter from "./AggregationStrategyRouter.ts";
 
 export default async function app(emit: (evt: AppEvent) => void) {
   const { addresses } = await getNetworkConfig();
@@ -59,6 +60,7 @@ export default async function app(emit: (evt: AppEvent) => void) {
   const routers = [
     BundleRouter(bundleService),
     AdminRouter(adminService),
+    AggregationStrategyRouter(aggregationStrategy),
   ];
 
   const app = new Application();

--- a/aggregator/src/app/helpers/ClientReportableError.ts
+++ b/aggregator/src/app/helpers/ClientReportableError.ts
@@ -1,0 +1,10 @@
+/**
+ * For errors that are ok to send down to the client.
+ * (Since blindly sending error information down to the client would be a
+ * security issue.)
+ */
+export default class ClientReportableError extends Error {
+  constructor(message: string) {
+    super(message);
+  }
+}

--- a/aggregator/test/AggregationStrategy.test.ts
+++ b/aggregator/test/AggregationStrategy.test.ts
@@ -1,0 +1,29 @@
+import { assertEquals, BigNumber } from "./deps.ts";
+
+import Fixture from "./helpers/Fixture.ts";
+
+Fixture.test("zero fee estimate from default test config", async (fx) => {
+  const [wallet] = await fx.setupWallets(1);
+
+  const bundle = wallet.sign({
+    nonce: await wallet.Nonce(),
+    actions: [
+      {
+        ethValue: 0,
+        contractAddress: fx.testErc20.address,
+        encodedFunction: fx.testErc20.interface.encodeFunctionData(
+          "mint",
+          [wallet.address, 3],
+        ),
+      },
+    ],
+  });
+
+  const feeEstimation = await fx.aggregationStrategy.estimateFee(bundle);
+
+  assertEquals(feeEstimation, {
+    feeDetected: BigNumber.from(0),
+    feeRequired: BigNumber.from(0),
+    successes: [true],
+  });
+});

--- a/aggregator/test/helpers/Fixture.ts
+++ b/aggregator/test/helpers/Fixture.ts
@@ -92,6 +92,11 @@ export default class Fixture {
       chainId,
       ethereumService,
       ethereumService.blsWalletSigner,
+      new AggregationStrategy(
+        ethereumService.blsWalletSigner,
+        ethereumService,
+        aggregationStrategyDefaultTestConfig,
+      ),
       netCfg,
     );
 
@@ -124,6 +129,7 @@ export default class Fixture {
     public chainId: number,
     public ethereumService: EthereumService,
     public blsWalletSigner: BlsWalletSigner,
+    public aggregationStrategy: AggregationStrategy,
     public networkConfig: NetworkConfig,
   ) {
     this.testErc20 = MockERC20__factory.connect(
@@ -154,10 +160,14 @@ export default class Fixture {
     const tableName = `bundles_test_${suffix}`;
     const table = await BundleTable.createFresh(queryClient, tableName);
 
-    const aggregationStrategy = new AggregationStrategy(
-      this.blsWalletSigner,
-      this.ethereumService,
-      aggregationStrategyConfig,
+    const aggregationStrategy = (
+      aggregationStrategyConfig === aggregationStrategyDefaultTestConfig
+        ? this.aggregationStrategy
+        : new AggregationStrategy(
+          this.blsWalletSigner,
+          this.ethereumService,
+          aggregationStrategyConfig,
+        )
     );
 
     const bundleService = new BundleService(

--- a/contracts/clients/src/Aggregator.ts
+++ b/contracts/clients/src/Aggregator.ts
@@ -47,9 +47,13 @@ export default class Aggregator {
   }
 
   async add(bundle: Bundle): Promise<TransactionFailure[]> {
-    const result = await this.jsonPost("/bundle", bundleToDto(bundle));
+    const json: any = await this.jsonPost("/bundle", bundleToDto(bundle));
 
-    return (result as any).failures as TransactionFailure[];
+    if (json === null || typeof json !== "object" || !("failures" in json)) {
+      throw new Error(`Unexpected response: ${JSON.stringify(json)}`);
+    }
+
+    return json.failures as TransactionFailure[];
   }
 
   async estimateFee(bundle: Bundle): Promise<EstimateFeeResponse> {
@@ -75,10 +79,6 @@ export default class Aggregator {
       json = JSON.parse(text);
     } catch {
       throw new Error(`Unexpected invalid JSON response: ${text}`);
-    }
-
-    if (json === null || typeof json !== "object" || !("failures" in json)) {
-      throw new Error(`Unexpected response: ${text}`);
     }
 
     return json;

--- a/contracts/clients/src/Aggregator.ts
+++ b/contracts/clients/src/Aggregator.ts
@@ -26,6 +26,13 @@ export type BundleDto = {
   signature: [string, string];
 };
 
+export type EstimateFeeResponse = {
+  feeType: string;
+  feeDetected: string;
+  feeRequired: string;
+  successes: boolean[];
+};
+
 export default class Aggregator {
   origin: string;
 
@@ -40,9 +47,21 @@ export default class Aggregator {
   }
 
   async add(bundle: Bundle): Promise<TransactionFailure[]> {
-    const resp = await fetch(`${this.origin}/bundle`, {
+    const result = await this.jsonPost("/bundle", bundleToDto(bundle));
+
+    return (result as any).failures as TransactionFailure[];
+  }
+
+  async estimateFee(bundle: Bundle): Promise<EstimateFeeResponse> {
+    const result = await this.jsonPost("/estimateFee", bundleToDto(bundle));
+
+    return result as EstimateFeeResponse;
+  }
+
+  async jsonPost(path: string, body: unknown): Promise<unknown> {
+    const resp = await fetch(`${this.origin}${path}`, {
       method: "POST",
-      body: JSON.stringify(bundleToDto(bundle)),
+      body: JSON.stringify(body),
       headers: {
         "content-type": "application/json",
       },
@@ -62,6 +81,6 @@ export default class Aggregator {
       throw new Error(`Unexpected response: ${text}`);
     }
 
-    return json.failures;
+    return json;
   }
 }


### PR DESCRIPTION
## What is this PR doing?

Adds endpoint `/estimateFee` which takes a bundle and returns a response like this:

```json
{
  "feeType": "ether",
  "feeDetected": "1",
  "feeRequired": "7700230000000000",
  "successes": [true]
}
```

## How can these changes be manually tested?

Run the premerge script.

## Does this PR resolve or contribute to any issues?

Resolves #154.

## Checklist
- [x] I have manually tested these changes
- [x] Post a link to the PR in the group chat

## Guidelines
- If your PR is not ready, mark it as a draft
- The `resolve conversation` button is for reviewers, not authors
  - (But add a 'done' comment or similar)
