### PR TITLE
Use BigNumber for nonces

### DIFF
--- a/aggregator/src/app/EthereumService.ts
+++ b/aggregator/src/app/EthereumService.ts
@@ -74,7 +74,7 @@ export default class EthereumService {
     public blsWalletSigner: BlsWalletSigner,
     verificationGatewayAddress: string,
     utilitiesAddress: string,
-    public nextNonce: number,
+    public nextNonce: BigNumber,
   ) {
     this.verificationGateway = VerificationGateway__factory.connect(
       verificationGatewayAddress,
@@ -88,7 +88,8 @@ export default class EthereumService {
   }
 
   NextNonce() {
-    const result = this.nextNonce++;
+    const result = this.nextNonce;
+    this.nextNonce = this.nextNonce.add(1);
     return result;
   }
 
@@ -99,7 +100,7 @@ export default class EthereumService {
     aggPrivateKey: string,
   ): Promise<EthereumService> {
     const wallet = EthereumService.Wallet(aggPrivateKey);
-    const nextNonce = (await wallet.getTransactionCount());
+    const nextNonce = BigNumber.from(await wallet.getTransactionCount());
     const chainId = await wallet.getChainId();
     const blsWalletSigner = await initBlsWalletSigner({ chainId });
 


### PR DESCRIPTION
## What is this PR doing?

Switches to storing nonces as `BigNumber` in EthereumService, since that's the only place we were still using `number`. I think I mostly already fixed this when doing the bundle conversion.

Turns out we're already relying on `wallet.getTransactionCount()` from ethers which uses `number`, so... that's a bit awkward. I did some quick math though and if tx fees are as low as 1 cent then you still have to go through $trillions in fees before exhausting the safe integer range of `number`. Let's just assume that in such a scenario the organization running the affected aggregator would have the resources to deal with the problem before it happens :).

## How can these changes be manually tested?

Run the premerge script.

## Does this PR resolve or contribute to any issues?

Resolves #10.

## Checklist
- [x] I have manually tested these changes
- [x] Post a link to the PR in the group chat

## Guidelines
- If your PR is not ready, mark it as a draft
- The `resolve conversation` button is for reviewers, not authors
  - (But add a 'done' comment or similar)
