### PR TITLE
Add checks to gateway upgrade

### DIFF
--- a/contracts/contracts/VerificationGateway.sol
+++ b/contracts/contracts/VerificationGateway.sol
@@ -219,7 +219,7 @@ contract VerificationGateway
 
         require(
             VerificationGateway(blsGateway).walletFromHash(hash) == wallet,
-            "Not recognized by new gateway"
+            "Not recognized"
         );
 
         ProxyAdmin currentProxyAdmin = ProxyAdmin(

--- a/contracts/contracts/VerificationGateway.sol
+++ b/contracts/contracts/VerificationGateway.sol
@@ -222,16 +222,11 @@ contract VerificationGateway
             "Not recognized"
         );
 
-        ProxyAdmin currentProxyAdmin = ProxyAdmin(
-            TransparentUpgradeableProxy(payable(address(wallet))).admin()
-        );
-
-        ProxyAdmin newGatewayProxyAdmin = VerificationGateway(blsGateway)
-            .walletProxyAdmin();
-
-        require(
-            currentProxyAdmin == newGatewayProxyAdmin,
-            "Proxy admin mismatch"
+        // getProxyAdmin fails if not called by the current proxy admin, so this
+        // enforces that the wallet's proxy admin matches the one in the new
+        // gateway.
+        VerificationGateway(blsGateway).walletProxyAdmin().getProxyAdmin(
+            TransparentUpgradeableProxy(payable(address(wallet)))
         );
 
         wallet.setTrustedGateway(blsGateway);

--- a/contracts/contracts/VerificationGateway.sol
+++ b/contracts/contracts/VerificationGateway.sol
@@ -222,12 +222,22 @@ contract VerificationGateway
             "Not recognized by new gateway"
         );
 
-        // TODO: Require proxy admin matches new gateway
+        ProxyAdmin currentProxyAdmin = ProxyAdmin(
+            TransparentUpgradeableProxy(payable(address(wallet))).admin()
+        );
+
+        ProxyAdmin newGatewayProxyAdmin = VerificationGateway(blsGateway)
+            .walletProxyAdmin();
+
+        require(
+            currentProxyAdmin == newGatewayProxyAdmin,
+            "Proxy admin mismatch"
+        );
 
         wallet.setTrustedGateway(blsGateway);
     }
 
-    /** 
+    /**
     Base function for verifying and processing BLS-signed transactions.
     Creates a new contract wallet per bls key if existing wallet not found.
     Can be called with a single operation with no actions.

--- a/contracts/contracts/VerificationGateway.sol
+++ b/contracts/contracts/VerificationGateway.sol
@@ -215,10 +215,16 @@ contract VerificationGateway
             "BLSWallet: gateway address param not valid"
         );
 
-        // TODO: Require registration in new gateway
+        IWallet wallet = walletFromHash(hash);
+
+        require(
+            VerificationGateway(blsGateway).walletFromHash(hash) == wallet,
+            "Not recognized by new gateway"
+        );
+
         // TODO: Require proxy admin matches new gateway
 
-        walletFromHash(hash).setTrustedGateway(blsGateway);
+        wallet.setTrustedGateway(blsGateway);
     }
 
     /** 

--- a/contracts/contracts/VerificationGateway.sol
+++ b/contracts/contracts/VerificationGateway.sol
@@ -214,6 +214,10 @@ contract VerificationGateway
             (blsGateway != address(0)) && (size > 0),
             "BLSWallet: gateway address param not valid"
         );
+
+        // TODO: Require registration in new gateway
+        // TODO: Require proxy admin matches new gateway
+
         walletFromHash(hash).setTrustedGateway(blsGateway);
     }
 

--- a/contracts/shared/helpers/Fixture.ts
+++ b/contracts/shared/helpers/Fixture.ts
@@ -87,7 +87,9 @@ export default class Fixture {
     );
 
     // deploy utilities
-    const utilities = await create2Fixture.create2Contract("AggregatorUtilities");
+    const utilities = await create2Fixture.create2Contract(
+      "AggregatorUtilities",
+    );
 
     const BLSWallet = await ethers.getContractFactory("BLSWallet");
 
@@ -201,8 +203,20 @@ export default class Fixture {
     // Advance time one week
     const latestTimestamp = (await ethers.provider.getBlock("latest"))
       .timestamp;
+
     await network.provider.send("evm_setNextBlockTimestamp", [
       BigNumber.from(latestTimestamp).add(seconds).toHexString(),
     ]);
+
+    const wallet = await this.lazyBlsWallets[1]();
+
+    // Process an empty operation so that the next timestamp above actually gets
+    // into a block. This enables static calls to see the updated time.
+    await this.verificationGateway.processBundle(
+      wallet.sign({
+        nonce: await wallet.Nonce(),
+        actions: [],
+      }),
+    );
   }
 }

--- a/contracts/shared/helpers/Fixture.ts
+++ b/contracts/shared/helpers/Fixture.ts
@@ -212,11 +212,13 @@ export default class Fixture {
 
     // Process an empty operation so that the next timestamp above actually gets
     // into a block. This enables static calls to see the updated time.
-    await this.verificationGateway.processBundle(
-      wallet.sign({
-        nonce: await wallet.Nonce(),
-        actions: [],
-      }),
-    );
+    await (
+      await this.verificationGateway.processBundle(
+        wallet.sign({
+          nonce: await wallet.Nonce(),
+          actions: [],
+        }),
+      )
+    ).wait();
   }
 }

--- a/contracts/test/deploy-test.ts
+++ b/contracts/test/deploy-test.ts
@@ -33,7 +33,7 @@ describe("Deployer", async function () {
 
   beforeEach(async function () {});
 
-  it("should deploy to caculated (create2) address", async function () {
+  it("should deploy to calculated (create2) address", async function () {
     const testSalt = BigNumber.from(0);
     const initCodeHash = ethers.utils.solidityKeccak256(
       ["bytes"],

--- a/contracts/test/upgrade-test.ts
+++ b/contracts/test/upgrade-test.ts
@@ -16,6 +16,7 @@ import { BigNumber } from "ethers";
 import defaultDomain from "../clients/src/signer/defaultDomain";
 import { BlsSignerFactory } from "../clients/deps/hubble-bls/signer";
 import { solidityPack } from "ethers/lib/utils";
+import { ActionData } from "../clients/src";
 
 describe("Upgrade", async function () {
   this.beforeAll(async function () {
@@ -121,34 +122,99 @@ describe("Upgrade", async function () {
       walletOldVg.privateKey,
     );
 
-    // Atomically perform actions:
+    const setExternalWalletAction: ActionData = {
+      ethValue: BigNumber.from(0),
+      contractAddress: vg2.address,
+      encodedFunction: vg2.interface.encodeFunctionData("setExternalWallet", [
+        signedAddress,
+        walletOldVg.PublicKey(),
+      ]),
+    };
+
+    const setTrustedBLSGatewayAction: ActionData = {
+      ethValue: BigNumber.from(0),
+      contractAddress: fx.verificationGateway.address,
+      encodedFunction: fx.verificationGateway.interface.encodeFunctionData(
+        "setTrustedBLSGateway",
+        [hash, vg2.address],
+      ),
+    };
+
+    // Upgrading the gateway requires these three steps:
     //  1. register external wallet in vg2
     //  2. change proxy admin to that in vg2
-    //  3. lastly, set wallet's new trusted gateway address
+    //  3. lastly, set wallet's new trusted gateway
+    //
+    // If (1) or (2) are skipped, then (3) should fail, and therefore the whole
+    // operation should fail.
+
+    {
+      // Fail if setExternalWalletAction is skipped
+
+      const { successes } =
+        await fx.verificationGateway.callStatic.processBundle(
+          walletOldVg.sign({
+            nonce: BigNumber.from(2),
+            actions: [
+              // skip: setExternalWalletAction,
+              changeProxyAction,
+              setTrustedBLSGatewayAction,
+            ],
+          }),
+        );
+
+      expect(successes).to.deep.equal([false]);
+    }
+
+    {
+      // Fail if changeProxyAction is skipped
+
+      const { successes } =
+        await fx.verificationGateway.callStatic.processBundle(
+          walletOldVg.sign({
+            nonce: BigNumber.from(2),
+            actions: [
+              setExternalWalletAction,
+              // skip: changeProxyAction,
+              setTrustedBLSGatewayAction,
+            ],
+          }),
+        );
+
+      expect(successes).to.deep.equal([false]);
+    }
+
+    {
+      // Succeed if nothing is skipped
+
+      const { successes } =
+        await fx.verificationGateway.callStatic.processBundle(
+          walletOldVg.sign({
+            nonce: BigNumber.from(2),
+            actions: [
+              setExternalWalletAction,
+              changeProxyAction,
+              setTrustedBLSGatewayAction,
+            ],
+          }),
+        );
+
+      expect(successes).to.deep.equal([true]);
+    }
+
+    expect(await vg2.walletFromHash(hash)).not.to.equal(walletAddress);
+
+    // Now actually perform the upgrade so we can perform some more detailed
+    // checks.
     await (
       await fx.verificationGateway.processBundle(
         fx.blsWalletSigner.aggregate([
           walletOldVg.sign({
             nonce: BigNumber.from(2),
             actions: [
-              {
-                ethValue: 0,
-                contractAddress: vg2.address,
-                encodedFunction: vg2.interface.encodeFunctionData(
-                  "setExternalWallet",
-                  [signedAddress, blsSigner.pubkey],
-                ),
-              },
+              setExternalWalletAction,
               changeProxyAction,
-              {
-                ethValue: 0,
-                contractAddress: fx.verificationGateway.address,
-                encodedFunction:
-                  fx.verificationGateway.interface.encodeFunctionData(
-                    "setTrustedBLSGateway",
-                    [hash, vg2.address],
-                  ),
-              },
+              setTrustedBLSGatewayAction,
             ],
           }),
         ]),


### PR DESCRIPTION
## What is this PR doing?

Adds the following checks to `setTrustedBLSGateway`:
- The new gateway has the mapping from the public key to the wallet
- The proxy admin of the wallet matches the proxy admin of the new gateway

## How can these changes be manually tested?

`yarn hardhat test`

## Does this PR resolve or contribute to any issues?

Resolves #105.

Also resolves #107 (and obsoletes PR #114) because these checks indirectly require the new gateway to be a gateway.

## Checklist
- [x] I have manually tested these changes
- [x] Post a link to the PR in the group chat

## Guidelines
- If your PR is not ready, mark it as a draft
- The `resolve conversation` button is for reviewers, not authors
  - (But add a 'done' comment or similar)
