### PR TITLE
Routing changes

### DIFF
--- a/extension/source/QuillPage/Onboarding/OnboardingActionPanel.tsx
+++ b/extension/source/QuillPage/Onboarding/OnboardingActionPanel.tsx
@@ -1,40 +1,49 @@
-import { FunctionComponent } from 'react';
+import { FunctionComponent, useEffect, useState } from 'react';
+import { useSearchParams } from 'react-router-dom';
 
 import PasswordCreationPanel from './PasswordCreationPanel';
 import SecretPhrasePanel from './SecretPhrasePanel';
 import SetNicknamePanel from './SetNicknamePanel';
 import WorkflowNumbers from './WorkflowNumbers';
 
-const OnboardingActionPanel: FunctionComponent<{ pageIndex: number }> = ({
-  pageIndex,
-}) => (
-  <div className="h-screen p-32 flex flex-col flex-grow space-y-16 items-center">
-    <WorkflowNumbers current={pageIndex + 1} max={3} />
-    <div className="w-96">
-      {
-        [
-          <PasswordCreationPanel
-            key={1}
-            onComplete={() => {
-              window.location.href = `?p=2`;
-            }}
-          />,
-          <SetNicknamePanel
-            key={2}
-            onComplete={() => {
-              window.location.href = `?p=3`;
-            }}
-          />,
-          <SecretPhrasePanel
-            key={3}
-            onComplete={() => {
-              window.location.href = `?p=1`;
-            }}
-          />,
-        ][pageIndex]
-      }
+const OnboardingActionPanel: FunctionComponent = () => {
+  const [params, setParams] = useSearchParams();
+  const [pageIndex, setPageIndex] = useState(1);
+
+  useEffect(() => {
+    const currentPage = Number(params.get('p'));
+    setPageIndex(currentPage - 1);
+  }, [params]);
+
+  return (
+    <div className="h-screen p-32 flex flex-col flex-grow space-y-16 items-center">
+      <WorkflowNumbers max={3} />
+      <div className="w-96">
+        {
+          [
+            <PasswordCreationPanel
+              key={1}
+              onComplete={() => {
+                setParams({ p: '2' });
+              }}
+            />,
+            <SetNicknamePanel
+              key={2}
+              onComplete={() => {
+                setParams({ p: '3' });
+              }}
+            />,
+            <SecretPhrasePanel
+              key={3}
+              onComplete={() => {
+                setParams({ p: '1' });
+              }}
+            />,
+          ][pageIndex]
+        }
+      </div>
     </div>
-  </div>
-);
+  );
+};
 
 export default OnboardingActionPanel;

--- a/extension/source/QuillPage/Onboarding/OnboardingInfoPanel.tsx
+++ b/extension/source/QuillPage/Onboarding/OnboardingInfoPanel.tsx
@@ -1,4 +1,5 @@
-import { FunctionComponent } from 'react';
+import { FunctionComponent, useEffect, useState } from 'react';
+import { useSearchParams } from 'react-router-dom';
 import { runtime } from 'webextension-polyfill';
 import LogoFooter from './LogoFooter';
 
@@ -38,33 +39,41 @@ const info = [
   },
 ];
 
-const OnboardingInfoPanel: FunctionComponent<{ pageIndex: number }> = ({
-  pageIndex,
-}) => (
-  <div className="bg-blue-500 flex flex-col w-2/5">
-    <div
-      className="h-screen p-32 flex flex-col justify-between"
-      style={{
-        background: `center no-repeat url(${runtime.getURL(
-          'assets/info-panel-pretty-curve.svg',
-        )})`,
-      }}
-    >
+const OnboardingInfoPanel: FunctionComponent = () => {
+  const [params, _] = useSearchParams();
+  const [pageIndex, setPageIndex] = useState(0);
+
+  useEffect(() => {
+    const currentPage = Number(params.get('p'));
+    setPageIndex(currentPage - 1);
+  }, [params]);
+
+  return (
+    <div className="bg-blue-500 flex flex-col w-2/5">
       <div
-        className="h-64 w-full rounded-md"
+        className="h-screen p-32 flex flex-col justify-between"
         style={{
-          background: `url(${runtime.getURL(
-            `assets/onboarding-art-${pageIndex + 1}.svg`,
-          )}) no-repeat center`,
+          background: `center no-repeat url(${runtime.getURL(
+            'assets/info-panel-pretty-curve.svg',
+          )})`,
         }}
-      />
-      <div className="flex-grow text-white py-8">
-        <div className="font-medium mb-2">{info[pageIndex].heading}</div>
-        <div className="font-light">{info[pageIndex].description}</div>
+      >
+        <div
+          className="h-64 w-full rounded-md"
+          style={{
+            background: `url(${runtime.getURL(
+              `assets/onboarding-art-${pageIndex + 1}.svg`,
+            )}) no-repeat center`,
+          }}
+        />
+        <div className="flex-grow text-white py-8">
+          <div className="font-medium mb-2">{info[pageIndex].heading}</div>
+          <div className="font-light">{info[pageIndex].description}</div>
+        </div>
+        <LogoFooter />
       </div>
-      <LogoFooter />
     </div>
-  </div>
-);
+  );
+};
 
 export default OnboardingInfoPanel;

--- a/extension/source/QuillPage/Onboarding/OnboardingPage.tsx
+++ b/extension/source/QuillPage/Onboarding/OnboardingPage.tsx
@@ -1,15 +1,28 @@
-import { FunctionComponent } from 'react';
+import { FunctionComponent, useEffect } from 'react';
+import { useNavigate } from 'react-router-dom';
 
 import OnboardingActionPanel from './OnboardingActionPanel';
 import OnboardingInfoPanel from './OnboardingInfoPanel';
 
-const OnboardingPage: FunctionComponent<{ pageIndex: number }> = ({
-  pageIndex,
-}) => (
-  <div className="flex h-screen">
-    <OnboardingInfoPanel pageIndex={pageIndex} />
-    <OnboardingActionPanel pageIndex={pageIndex} />
-  </div>
-);
+const onboardingComplete = false;
+
+const OnboardingPage: FunctionComponent = () => {
+  let navigate = useNavigate();
+
+  useEffect(() => {
+    // TODO - add loading state to prevent
+    // DOM loading if onboarding complete
+    if (onboardingComplete) {
+      navigate('/wallet/');
+    }
+  }, [onboardingComplete]);
+
+  return (
+    <div className="flex h-screen">
+      <OnboardingInfoPanel />
+      <OnboardingActionPanel />
+    </div>
+  );
+};
 
 export default OnboardingPage;

--- a/extension/source/QuillPage/Onboarding/SecretPhrasePanel.tsx
+++ b/extension/source/QuillPage/Onboarding/SecretPhrasePanel.tsx
@@ -1,33 +1,26 @@
-import { FunctionComponent, useState } from 'react';
+import { ethers } from 'ethers';
+import { FunctionComponent, useEffect, useState } from 'react';
 
 import ReviewSecretPhrasePanel from './ReviewSecretPhrasePanel';
 import ViewSecretPhrasePanel from './ViewSecretPhrasePanel';
 
-const exampleSecretPhrase = [
-  'Potato',
-  'Velvet',
-  'Keen',
-  'Water',
-  'Travel',
-  'Pill',
-  'Book',
-  'Photo',
-  'Image',
-  'Space',
-  'Pause',
-  'Power',
-];
-
 const SecretPhrasePanel: FunctionComponent<{
   secretPhrase?: string[];
   onComplete?: () => void;
-}> = ({ secretPhrase = exampleSecretPhrase, onComplete = () => {} }) => {
+}> = ({ onComplete = () => {} }) => {
+  const [mnemonic, setMnemonic] = useState<string[]>([]);
+
+  useEffect(() => {
+    const mnemonic = ethers.Wallet.createRandom().mnemonic.phrase;
+    setMnemonic(mnemonic.split(' '));
+  }, []);
+
   const [inReview, setInReview] = useState(false);
 
   if (!inReview) {
     return (
       <ViewSecretPhrasePanel
-        secretPhrase={secretPhrase}
+        secretPhrase={mnemonic}
         onComplete={() => setInReview(true)}
       />
     );
@@ -35,7 +28,7 @@ const SecretPhrasePanel: FunctionComponent<{
 
   return (
     <ReviewSecretPhrasePanel
-      secretPhrase={secretPhrase}
+      secretPhrase={mnemonic}
       onBack={() => setInReview(false)}
       onComplete={onComplete}
     />

--- a/extension/source/QuillPage/Onboarding/WorkflowNumbers.tsx
+++ b/extension/source/QuillPage/Onboarding/WorkflowNumbers.tsx
@@ -1,35 +1,45 @@
-import { FunctionComponent } from 'react';
+import { FunctionComponent, useEffect, useState } from 'react';
+import { useSearchParams } from 'react-router-dom';
 
 import Range from '../../helpers/Range';
 
 const WorkflowNumbers: FunctionComponent<{
-  current: number;
   max: number;
-}> = ({ current, max }) => (
-  <div className="flex justify-center space-x-10">
-    {Range(max).map((i) => (
-      <div
-        key={i}
-        className={`icon-lg rounded-full text-center leading-8 cursor-pointer ${
-          i + 1 <= current ? 'bg-blue-500 text-white' : 'text-black'
-        }`}
-        onClick={() => onSelect(i)}
-        onKeyDown={(e) => {
-          if (['Space', 'Enter'].includes(e.code)) {
-            onSelect(i + 1);
-          }
-        }}
-      >
-        {i + 1}
-      </div>
-    ))}
-  </div>
-);
+}> = ({ max }) => {
+  const [params, setParams] = useSearchParams();
+  const [currentPage, setCurrentPage] = useState(1);
 
-function onSelect(pageIndex: number) {
-  // Note: This is for demo purposes only. We're not going to be using
-  // search parameters like this.
-  window.location.href = `?p=${pageIndex + 1}`;
-}
+  useEffect(() => {
+    const currentPage = Number(params.get('p'));
+    setCurrentPage(currentPage);
+  }, [params]);
+
+  function onSelect(index: number) {
+    // Note: This is for demo purposes only. We're not going to be using
+    // search parameters like this.
+    setParams({ p: (index + 1).toString() });
+  }
+
+  return (
+    <div className="flex justify-center space-x-10">
+      {Range(max).map((i) => (
+        <div
+          key={i}
+          className={`icon-lg rounded-full text-center leading-8 cursor-pointer ${
+            i + 1 <= currentPage ? 'bg-blue-500 text-white' : 'text-black'
+          }`}
+          onClick={() => onSelect(i)}
+          onKeyDown={(e) => {
+            if (['Space', 'Enter'].includes(e.code)) {
+              onSelect(i + 1);
+            }
+          }}
+        >
+          {i + 1}
+        </div>
+      ))}
+    </div>
+  );
+};
 
 export default WorkflowNumbers;

--- a/extension/source/QuillPage/QuillPage.tsx
+++ b/extension/source/QuillPage/QuillPage.tsx
@@ -1,22 +1,18 @@
 import { FunctionComponent } from 'react';
+import { HashRouter, Route, Routes } from 'react-router-dom';
 
 import OnboardingPage from './Onboarding/OnboardingPage';
 import { WalletPage } from './Wallet/WalletPage';
 
-// Note: This is for demo purposes only while building the ui. This is not how
-// navigation will work.
-const pageNumber = Number(
-  new URL(window.location.href).searchParams.get('p') ?? '1',
-);
-
-const onboardingComplete = true;
-
 const QuillPage: FunctionComponent = () => {
-  if (!onboardingComplete) {
-    return <OnboardingPage pageIndex={pageNumber - 1} />;
-  }
-
-  return <WalletPage />;
+  return (
+    <HashRouter>
+      <Routes>
+        <Route path="/onboarding" element={<OnboardingPage />} />
+        <Route path="/wallet/*" element={<WalletPage />} />
+      </Routes>
+    </HashRouter>
+  );
 };
 
 export default QuillPage;

--- a/extension/source/QuillPage/Wallet/Navigation.tsx
+++ b/extension/source/QuillPage/Wallet/Navigation.tsx
@@ -13,22 +13,22 @@ const navigationTargets = [
   {
     name: 'Wallets',
     icon: <Wallet className="icon-md" />,
-    target: '/',
+    target: '/wallet',
   },
   {
     name: 'Connections',
     icon: <LinkIcon className="icon-md" />,
-    target: '/connections',
+    target: '/wallet/connections',
   },
   {
     name: 'Contacts',
     icon: <AddressBook className="icon-md" />,
-    target: '/contacts',
+    target: '/wallet/contacts',
   },
   {
     name: 'Settings',
     icon: <GearSix className="icon-md" />,
-    target: '/settings',
+    target: '/wallet/settings',
   },
 ];
 

--- a/extension/source/QuillPage/Wallet/WalletPage.tsx
+++ b/extension/source/QuillPage/Wallet/WalletPage.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { HashRouter, Routes, Route } from 'react-router-dom';
+import { Route, Routes } from 'react-router-dom';
 import { ConnectionsWrapper } from './Connections/ConnectionWrapper';
 import { ContactsWrapper } from './Contacts/ContactsWrapper';
 import { Navigation } from './Navigation';
@@ -44,38 +44,37 @@ const routes: IRoutes[] = [
 export const WalletPage: React.FunctionComponent = () => {
   return (
     <div className="flex h-screen">
-      <HashRouter>
-        {/* Navigation */}
-        <Navigation />
+      {/* Navigation */}
+      <Navigation />
 
-        <div className="flex-grow flex">
-          {/* summary pane */}
-          <div className="w-1/3 bg-grey-100 border-x border-grey-300 p-8 overflow-y-scroll">
-            <Routes>
-              {routes.map((item) => (
-                <Route
-                  key={item.name}
-                  path={item.path}
-                  element={item.summaryComponent}
-                />
-              ))}
-            </Routes>
-          </div>
-
-          {/* details pane */}
-          <div className="w-2/3 p-8 overflow-y-scroll">
-            <Routes>
-              {routes.map((item) => (
-                <Route
-                  key={item.name}
-                  path={item.path}
-                  element={item.detailComponent}
-                />
-              ))}
-            </Routes>
-          </div>
+      <div className="flex-grow flex">
+        {/* summary pane */}
+        <div className="w-1/3 bg-grey-100 border-x border-grey-300 p-8 overflow-y-scroll">
+          <Routes>
+            {routes.map((item) => (
+              <Route
+                index={item.path === '/'}
+                key={item.name}
+                path={item.path}
+                element={item.summaryComponent}
+              />
+            ))}
+          </Routes>
         </div>
-      </HashRouter>
+
+        {/* details pane */}
+        <div className="w-2/3 p-8 overflow-y-scroll">
+          <Routes>
+            {routes.map((item) => (
+              <Route
+                key={item.name}
+                path={item.path}
+                element={item.detailComponent}
+              />
+            ))}
+          </Routes>
+        </div>
+      </div>
     </div>
   );
 };


### PR DESCRIPTION
## What is this PR doing?
- onboarding and wallet page can be accessed together on separate routes
- added flag to redirect to wallets page if onboarding is complete (disabled for development)
- onboarding page routing used window.location which reloaded the app on navigation. replaced that with react-router
- using router hooks to avoid prop drilling
- added hd wallet mnemonic generation

## How can these changes be manually tested?


## Does this PR resolve or contribute to any issues?


## Checklist
- [ ] I have manually tested these changes
- [ ] Post a link to the PR in the group chat

## Guidelines
- If your PR is not ready, mark it as a draft
- The `resolve conversation` button is for reviewers, not authors
  - (But add a 'done' comment or similar)
