### PR TITLE
Override initial keyringController state to include chainId

### DIFF
--- a/extension/source/Controllers/background.ts
+++ b/extension/source/Controllers/background.ts
@@ -77,6 +77,10 @@ async function loadStateFromPersistence(): Promise<QuillControllerState> {
         chainId: providerConfig.chainId,
         providerConfig,
       },
+      KeyringControllerState: {
+        ...DEFAULT_STATE.KeyringControllerState,
+        chainId: providerConfig.chainId,
+      },
     });
   }
 


### PR DESCRIPTION
## What is this PR doing?
The keyring controller was missing the chainId in the default state configuration which needed to be set when its initialized. Added an override to pull chainId from env and add to the state of KeyringController.

## How can these changes be manually tested?
1. run `chrome.storage.local.clear()` to remove existing stored config
2. refresh (twice) the app and create new HD wallet

## Does this PR resolve or contribute to any issues?
closes #174 

## Checklist
- [x] I have manually tested these changes
- [x] Post a link to the PR in the group chat

## Guidelines
- If your PR is not ready, mark it as a draft
- The `resolve conversation` button is for reviewers, not authors
  - (But add a 'done' comment or similar)
