### PR TITLE
fetch default quill account via `eth_accounts` rpc call

### DIFF
--- a/extension/source/QuillPage/Onboarding/ReviewSecretPhrasePanel.tsx
+++ b/extension/source/QuillPage/Onboarding/ReviewSecretPhrasePanel.tsx
@@ -69,6 +69,10 @@ const ReviewSecretPhrasePanel: FunctionComponent<{
   const setHDWalletPhrase = async () => {
     window.KeyringController().setHDPhrase(secretPhrase.join(' '));
     window.KeyringController().createHDAccount();
+
+    const accounts = window.KeyringController().getAccounts();
+    window.QuillController().getApi().setSelectedAddress(accounts[0]);
+
     navigate('/wallet');
   };
 

--- a/extension/source/QuillPage/Wallet/Wallets/WalletWrapper.tsx
+++ b/extension/source/QuillPage/Wallet/Wallets/WalletWrapper.tsx
@@ -15,6 +15,10 @@ export const WalletsWrapper: FunctionComponent = () => {
   const [wallets, setWallets] = useState<IWallet[]>([]);
   const [loading, setLoading] = useState<boolean>(true);
 
+  const setSelectedAddress = (address: string) => {
+    window.QuillController().getApi().setSelectedAddress(address);
+  };
+
   useEffect(() => {
     setLoading(true);
 
@@ -32,6 +36,8 @@ export const WalletsWrapper: FunctionComponent = () => {
       }),
     );
     setLoading(false);
+
+    setSelectedAddress(accounts[0]);
   }, []);
 
   return (
@@ -54,7 +60,10 @@ export const WalletsWrapper: FunctionComponent = () => {
         <div className="flex flex-col gap-6 mt-8">
           {wallets.map((wallet, index) => (
             <WalletSummary
-              onClick={() => setSelected(index)}
+              onClick={() => {
+                setSelected(index);
+                setSelectedAddress(wallet.address);
+              }}
               key={wallet.name}
               wallet={wallet}
               expanded={index === selected}


### PR DESCRIPTION
## What is this PR doing?

calling `eth_accounts` returned an empty array since the account did not get added to the preferencesController's "current" account. This PR adds the account to the said controller and enables other rpc methods like `eth_getBalance` to be called via external dapp. 

**note the selected address inside quill -**

<img width="725" alt="Screenshot 2022-03-29 at 12 32 02 AM" src="https://user-images.githubusercontent.com/23727056/160468321-c91672a4-7e3e-46a1-99f5-18810b55e981.png">

**same address being used by the dapp**

https://user-images.githubusercontent.com/23727056/160467429-19222462-d993-4ffe-89ad-af415293bcc2.mov

## How can these changes be manually tested?
pull, build and import the latest version of the extension.

## Does this PR resolve or contribute to any issues?


## Checklist
- [x] I have manually tested these changes
- [x] Post a link to the PR in the group chat

## Guidelines
- If your PR is not ready, mark it as a draft
- The `resolve conversation` button is for reviewers, not authors
  - (But add a 'done' comment or similar)
