### PR TITLE
Dapp interaction with `eth_sendTransaction` rpc call

### DIFF
--- a/extension/source/Controllers/Keyring/KeyringController.ts
+++ b/extension/source/Controllers/Keyring/KeyringController.ts
@@ -91,6 +91,12 @@ export default class KeyringController
     return wallet.sign(tx);
   }
 
+  async getNonce(address: string) {
+    const privKey = this._getPrivateKeyFor(address);
+    const wallet = await this._getBLSWallet(privKey);
+    return wallet.Nonce();
+  }
+
   async _createAccountAndUpdate(privateKey: string): Promise<string> {
     const address = await this._getContractWalletAddress(privateKey);
 
@@ -110,7 +116,10 @@ export default class KeyringController
   }
 
   private _getPrivateKeyFor(address: string): string {
-    const keyPair = this.state.wallets.find((x) => x.address === address);
+    const checksummedAddress = ethers.utils.getAddress(address);
+    const keyPair = this.state.wallets.find(
+      (x) => x.address === checksummedAddress,
+    );
     if (!keyPair) throw new Error('key does not exist');
     return keyPair.privateKey;
   }

--- a/extension/source/Controllers/Network/createEthMiddleware.ts
+++ b/extension/source/Controllers/Network/createEthMiddleware.ts
@@ -16,7 +16,7 @@ type TransactionFailure =
   | { type: 'unpredictable-gas-limit'; description: string }
   | { type: 'invalid-creation'; description: string };
 
-type SendTransactionParams = {
+export type SendTransactionParams = {
   from: string;
   to: string;
   gas?: BigNumberish;

--- a/extension/source/Controllers/QuillController.ts
+++ b/extension/source/Controllers/QuillController.ts
@@ -30,7 +30,10 @@ import {
   providerAsMiddleware,
   SafeEventEmitterProvider,
 } from './Network/INetworkController';
-import { IProviderHandlers } from './Network/createEthMiddleware';
+import {
+  IProviderHandlers,
+  SendTransactionParams,
+} from './Network/createEthMiddleware';
 import {
   AddressPreferences,
   PreferencesConfig,
@@ -518,23 +521,23 @@ export default class QuillController extends BaseController<
       },
 
       submitBatch: async (req: any) => {
-        const params = req.params[0];
+        const params: SendTransactionParams = req.params[0];
 
         const nonce = await this.keyringController.getNonce(params.from);
         const tx = {
           nonce: nonce.toString(),
           actions: [
             {
-              ethValue: params?.value.toString(),
-              contractAddress: params?.to.toString(),
-              encodedFunction: params?.data.toString(),
+              ethValue: params.value.toString(),
+              contractAddress: params.to,
+              encodedFunction: params.data,
             },
           ],
         };
 
         const bundle = await this.keyringController.signTransactions(
           params.from,
-          tx as any,
+          tx,
         );
         const agg = new Aggregator(AGGREGATOR_URL);
         return agg.add(bundle);

--- a/extension/source/Controllers/QuillController.ts
+++ b/extension/source/Controllers/QuillController.ts
@@ -11,6 +11,7 @@ import type { Duplex } from 'readable-stream';
 
 import { Runtime } from 'webextension-polyfill';
 import { BigNumber } from 'ethers';
+import { Aggregator } from 'bls-wallet-clients';
 import {
   createRandomId,
   getDefaultProviderConfig,
@@ -53,6 +54,7 @@ import { createOriginMiddleware } from './Network/createOriginMiddleware';
 import createTabIdMiddleware from './rpcHelpers/TabIdMiddleware';
 import createMetaRPCHandler from './streamHelpers/MetaRPCHandler';
 import { PROVIDER_NOTIFICATIONS } from '../common/constants';
+import { AGGREGATOR_URL } from '../env';
 
 export const DEFAULT_CONFIG = {
   CurrencyControllerConfig: {
@@ -513,6 +515,29 @@ export default class QuillController extends BaseController<
           chainId: this.networkController.state.chainId,
           isUnlocked: !!this.selectedAddress,
         };
+      },
+
+      submitBatch: async (req: any) => {
+        const params = req.params[0];
+
+        const nonce = await this.keyringController.getNonce(params.from);
+        const tx = {
+          nonce: nonce.toString(),
+          actions: [
+            {
+              ethValue: params?.value.toString(),
+              contractAddress: params?.to.toString(),
+              encodedFunction: params?.data.toString(),
+            },
+          ],
+        };
+
+        const bundle = await this.keyringController.signTransactions(
+          params.from,
+          tx as any,
+        );
+        const agg = new Aggregator(AGGREGATOR_URL);
+        return agg.add(bundle);
       },
     };
     const providerProxy =


### PR DESCRIPTION
## What is this PR doing?
Adds `eth_sendTransaction` rpc endpoint to the QuillController which enables connections with any generic dapp without modification. 

### What should work -
- Connection with injected provider
- sending transactions / sending ETH (externally via a dapp)

**[DEMO] Sending eth**
https://user-images.githubusercontent.com/23727056/161533589-70f330b8-0493-4d44-b9e0-0401737a3d30.mov

**[DEMO] Contract Interaction**
https://user-images.githubusercontent.com/23727056/161534683-fbc2ffb0-7fde-4a45-977b-7eb65a2cbd48.mov

### What won't work -
- Transaction confirmations - Since Aggregator does not return transaction receipt #178 , eth_getTransactionReceipt cannot query for the same #179
- Popup for confirmation - need to add UI for popup confirmation #180
- Can only connect and interact with dapp using the default account #181
- Contract creation #182
- Can only send 1 action for the moment #184 

## How can these changes be manually tested?
Pull changes, import extension and test with a dapp

## Does this PR resolve or contribute to any issues?
closes #67 

## Checklist
- [x] I have manually tested these changes
- [x] Post a link to the PR in the group chat

## Guidelines
- If your PR is not ready, mark it as a draft
- The `resolve conversation` button is for reviewers, not authors
  - (But add a 'done' comment or similar)
