### PR TITLE
Simplify success

### DIFF
--- a/contracts/contracts/BLSWallet.sol
+++ b/contracts/contracts/BLSWallet.sol
@@ -202,7 +202,7 @@ contract BLSWallet is Initializable, IBLSWallet
         try this._performOperation(op) returns (
             bytes[] memory _results
         ) {
-            success = (_results.length > 0); // false when no actions given
+            success = true;
             results = _results;
         }
         catch {


### PR DESCRIPTION
## What is this PR doing?

Simplifies the way `success` is reported by `performOperation`.

`(_results.length > 0)` appears to be derived from the call to `_performOperation`, but in fact the length of `_results` is fixed to be equal to the number of actions (even if the first action fails, `_results` is default initialized to e.g. `[0x, 0x, 0x]` for 3 actions, so `.length` will still be 3). `success` is instead best understood as whether the operations were successfully processed, which is always true in this branch by virtue of `_performOperation` not throwing an exception.

If requiring actions to be non-empty is desirable, then I suggest adding `require(op.actions.length > 0);` to `_performOperation` (I don't think it's desirable though - we actually already do this in testing).

(I burned a lot of time today trying to troubleshoot an unexpected `success === false` problem, and I thought there was something funky going on with empty byte arrays. Turned out it was unrelated, but I would have found the problem faster if it wasn't for this point of confusion.)

## How can these changes be manually tested?

Try running `processBundle` via `callStatic` with a bundle that has an operation with an empty list of actions. `success` should be `true` (was `false`).

## Does this PR resolve or contribute to any issues?


## Checklist
- [x] I have manually tested these changes
- [x] Post a link to the PR in the group chat

## Guidelines
- If your PR is not ready, mark it as a draft
- The `resolve conversation` button is for reviewers, not authors
  - (But add a 'done' comment or similar)
