### PR TITLE
Enable eth_setPreferredAggregator

### DIFF
--- a/extension/source/Controllers/Network/createEthMiddleware.ts
+++ b/extension/source/Controllers/Network/createEthMiddleware.ts
@@ -24,6 +24,7 @@ export interface IProviderHandlers {
   getProviderState: (
     req: JRPCRequest<unknown>,
   ) => Promise<{ accounts: string[]; chainId: string; isUnlocked: boolean }>;
+  setPreferredAggregator: (req: JRPCRequest<unknown>) => Promise<string>;
   submitBatch: (req: JRPCRequest<SendTransactionParams>) => Promise<string>;
 }
 
@@ -32,6 +33,7 @@ export function createWalletMiddleware({
   getAccounts,
   requestAccounts,
   getProviderState,
+  setPreferredAggregator,
   submitBatch,
 }: IProviderHandlers): JRPCMiddleware<string, unknown> {
   if (!getAccounts) {
@@ -75,6 +77,13 @@ export function createWalletMiddleware({
     res.result = await getProviderState(req);
   }
 
+  async function setPreferredAggregatorWrapper(
+    req: JRPCRequest<SendTransactionParams>,
+    res: JRPCResponse<unknown>,
+  ): Promise<void> {
+    res.result = await setPreferredAggregator(req);
+  }
+
   async function submitTransaction(
     req: JRPCRequest<SendTransactionParams>,
     res: JRPCResponse<unknown>,
@@ -90,6 +99,9 @@ export function createWalletMiddleware({
     eth_requestAccounts: createAsyncMiddleware(requestAccountsFromProvider),
     [PROVIDER_JRPC_METHODS.GET_PROVIDER_STATE]: createAsyncMiddleware(
       getProviderStateFromController,
+    ),
+    eth_setPreferredAggregator: createAsyncMiddleware<any, any>(
+      setPreferredAggregatorWrapper,
     ),
     eth_sendTransaction: createAsyncMiddleware<any, any>(submitTransaction),
   });

--- a/extension/source/Controllers/Network/createJsonRpcClient.ts
+++ b/extension/source/Controllers/Network/createJsonRpcClient.ts
@@ -7,7 +7,6 @@ import {
   mergeMiddleware,
 } from '@toruslabs/openlogin-jrpc';
 import { Aggregator } from 'bls-wallet-clients';
-import { AGGREGATOR_URL } from '../../env';
 
 import PollingBlockTracker from '../Block/PollingBlockTracker';
 import { ProviderConfig } from '../constants';
@@ -98,7 +97,7 @@ function createAggregatorMiddleware(): JRPCMiddleware<unknown, unknown> {
       if (hash in knownTransactions) {
         const knownTx = knownTransactions[hash];
 
-        const aggregator = new Aggregator(AGGREGATOR_URL);
+        const aggregator = new Aggregator(knownTx.aggregatorUrl);
         const bundleReceipt = await aggregator.lookupReceipt(hash);
 
         if (bundleReceipt === undefined) {

--- a/extension/source/Controllers/knownTransactions.ts
+++ b/extension/source/Controllers/knownTransactions.ts
@@ -6,6 +6,7 @@ const knownTransactions: Record<
   SendTransactionParams & {
     nonce: string;
     value: BigNumberish;
+    aggregatorUrl: string;
   }
 > = {};
 


### PR DESCRIPTION
## What is this PR doing?

Adds new jrpc method `eth_setPreferredAggregator` which works like so:

```js
await ethereum.request({
  method: 'eth_setPreferredAggregator',
  params: ['https://arbitrum-testnet.blswallet.org'],
});
```

This is part of the puzzle to allow dapps to pay for user transactions. In the manual test below we simply use the free aggregator, but this technique will allow a dapp to point to an aggregator which will aggregate only transactions for that dapp for free (in particular, by proxying a paid aggregator and including payment to tx.origin).

## How can these changes be manually tested?

Configure your extension to use our new paid aggregator for arbitrum testnet:
```
AGGREGATOR_URL=https://arbitrum-testnet-paid.blswallet.org
```

Now at https://arbitrum-testnet.blswallet.org/billboard if you try to rent the billboard it'll get stuck forever in 'waiting for confirmation' because this aggregator expects to be paid.

Next, reload and set your preferred aggregator to the free aggregator in the console:

```js
await ethereum.request({
  method: 'eth_setPreferredAggregator',
  params: ['https://arbitrum-testnet.blswallet.org'],
});
```

The result of this request should be the string `'ok'`, like this:

![Screen Shot 2022-05-17 at 11 54 39 am](https://user-images.githubusercontent.com/9291586/168712396-8a95b54c-a4e0-4638-aa8e-35db256af99c.png)

Then, try to rent the billboard again and this time it should be successful.

## Does this PR resolve or contribute to any issues?

Resolves https://github.com/web3well/bls-wallet/issues/170

## Checklist
- [x] I have manually tested these changes
- [x] Post a link to the PR in the group chat

## Guidelines
- If your PR is not ready, mark it as a draft
- The `resolve conversation` button is for reviewers, not authors
  - (But add a 'done' comment or similar)
