### PR TITLE
Fix open on install

### DIFF
--- a/extension/source/Controllers/background.ts
+++ b/extension/source/Controllers/background.ts
@@ -411,7 +411,7 @@ runtime.onInstalled.addListener(({ reason }) => {
 });
 
 function openExtensionInBrowser(route = null, queryString = null) {
-  let extensionURL = runtime.getURL('home.html');
+  let extensionURL = runtime.getURL('quillPage.html#/wallet');
 
   if (route) {
     extensionURL += `#${route}`;


### PR DESCRIPTION
## What is this PR doing?

Fixes the page that gets opened automatically when installing the extension.

(Was home.html which was just a broken link.)

## How can these changes be manually tested?

Install the extension and see the quill page gets opened correctly (shows onboarding).

## Does this PR resolve or contribute to any issues?

Nope.

## Checklist
- [x] I have manually tested these changes
- [x] Post a link to the PR in the group chat

## Guidelines
- If your PR is not ready, mark it as a draft
- The `resolve conversation` button is for reviewers, not authors
  - (But add a 'done' comment or similar)
