### PR TITLE
Radically simplify how window.ethereum methods are defined

### DIFF
--- a/extension/package.json
+++ b/extension/package.json
@@ -10,7 +10,7 @@
     "url": "https://blswallet.org"
   },
   "engines": {
-    "node": ">=10.0.0",
+    "node": ">=12.0.0",
     "yarn": ">= 1.0.0"
   },
   "scripts": {

--- a/extension/source/Controllers/Network/createEthMiddleware.ts
+++ b/extension/source/Controllers/Network/createEthMiddleware.ts
@@ -7,6 +7,7 @@ import {
 } from '@toruslabs/openlogin-jrpc';
 import { BigNumberish, BytesLike } from 'ethers';
 import { PROVIDER_JRPC_METHODS } from '../../common/constants';
+import web3_clientVersion from './web3_clientVersion';
 
 export type SendTransactionParams = {
   from: string;
@@ -18,7 +19,6 @@ export type SendTransactionParams = {
 };
 
 export interface IProviderHandlers {
-  version: string;
   getAccounts: (req: JRPCRequest<unknown>) => Promise<string[]>;
   requestAccounts: (req: JRPCRequest<unknown>) => Promise<string[]>;
   getProviderState: (
@@ -29,7 +29,6 @@ export interface IProviderHandlers {
 }
 
 export function createWalletMiddleware({
-  version,
   getAccounts,
   requestAccounts,
   getProviderState,
@@ -92,7 +91,7 @@ export function createWalletMiddleware({
   }
 
   return createScaffoldMiddleware({
-    web3_clientVersion: `Quill/v${version}`,
+    web3_clientVersion,
     // account lookups
     eth_accounts: createAsyncMiddleware(lookupAccounts),
     eth_coinbase: createAsyncMiddleware(lookupDefaultAccount),

--- a/extension/source/Controllers/Network/createEthMiddleware.ts
+++ b/extension/source/Controllers/Network/createEthMiddleware.ts
@@ -6,7 +6,6 @@ import {
   JRPCResponse,
 } from '@toruslabs/openlogin-jrpc';
 import { BigNumberish, BytesLike } from 'ethers';
-import { PROVIDER_JRPC_METHODS } from '../../common/constants';
 import web3_clientVersion from './web3_clientVersion';
 
 type SimpleHandler = (req: JRPCRequest<unknown>) => Promise<unknown>;
@@ -53,8 +52,7 @@ export function createWalletMiddleware({
     eth_accounts: toAsyncMiddleware(getAccounts),
     eth_coinbase: toAsyncMiddleware(eth_coinbase),
     eth_requestAccounts: toAsyncMiddleware(requestAccounts),
-    [PROVIDER_JRPC_METHODS.GET_PROVIDER_STATE]:
-      toAsyncMiddleware(getProviderState),
+    wallet_get_provider_state: toAsyncMiddleware(getProviderState),
     eth_setPreferredAggregator: toAsyncMiddleware(setPreferredAggregator),
     eth_sendTransaction: toAsyncMiddleware(eth_sendTransaction),
   });

--- a/extension/source/Controllers/Network/createEthMiddleware.ts
+++ b/extension/source/Controllers/Network/createEthMiddleware.ts
@@ -30,6 +30,7 @@ export type SendTransactionParams = {
 
 export interface IProviderHandlers {
   getAccounts: (req: JRPCRequest<unknown>) => Promise<string[]>;
+  eth_coinbase: SimpleHandler;
   requestAccounts: (req: JRPCRequest<unknown>) => Promise<string[]>;
   getProviderState: (
     req: JRPCRequest<unknown>,
@@ -40,6 +41,7 @@ export interface IProviderHandlers {
 
 export function createWalletMiddleware({
   getAccounts,
+  eth_coinbase,
   requestAccounts,
   getProviderState,
   setPreferredAggregator,
@@ -62,14 +64,6 @@ export function createWalletMiddleware({
     res: JRPCResponse<unknown>,
   ): Promise<void> {
     res.result = await getAccounts(req);
-  }
-
-  async function lookupDefaultAccount(
-    req: JRPCRequest<unknown>,
-    res: JRPCResponse<unknown>,
-  ): Promise<void> {
-    const accounts = await getAccounts(req);
-    res.result = accounts[0] || null;
   }
 
   async function requestAccountsFromProvider(
@@ -97,7 +91,7 @@ export function createWalletMiddleware({
     web3_clientVersion,
     // account lookups
     eth_accounts: createAsyncMiddleware(lookupAccounts),
-    eth_coinbase: createAsyncMiddleware(lookupDefaultAccount),
+    eth_coinbase: toAsyncMiddleware(eth_coinbase),
     eth_requestAccounts: createAsyncMiddleware(requestAccountsFromProvider),
     [PROVIDER_JRPC_METHODS.GET_PROVIDER_STATE]: createAsyncMiddleware(
       getProviderStateFromController,

--- a/extension/source/Controllers/Network/createEthMiddleware.ts
+++ b/extension/source/Controllers/Network/createEthMiddleware.ts
@@ -47,58 +47,15 @@ export function createWalletMiddleware({
   setPreferredAggregator,
   eth_sendTransaction,
 }: IProviderHandlers): JRPCMiddleware<string, unknown> {
-  if (!getAccounts) {
-    throw new Error('opts.getAccounts is required');
-  }
-
-  if (!requestAccounts) {
-    throw new Error('opts.requestAccounts is required');
-  }
-
-  if (!getProviderStateFromController) {
-    throw new Error('opts.getProviderState is required');
-  }
-
-  async function lookupAccounts(
-    req: JRPCRequest<unknown>,
-    res: JRPCResponse<unknown>,
-  ): Promise<void> {
-    res.result = await getAccounts(req);
-  }
-
-  async function requestAccountsFromProvider(
-    req: JRPCRequest<unknown>,
-    res: JRPCResponse<unknown>,
-  ): Promise<void> {
-    res.result = await requestAccounts(req);
-  }
-
-  async function getProviderStateFromController(
-    req: JRPCRequest<unknown>,
-    res: JRPCResponse<unknown>,
-  ): Promise<void> {
-    res.result = await getProviderState(req);
-  }
-
-  async function setPreferredAggregatorWrapper(
-    req: JRPCRequest<SendTransactionParams>,
-    res: JRPCResponse<unknown>,
-  ): Promise<void> {
-    res.result = await setPreferredAggregator(req);
-  }
-
   return createScaffoldMiddleware({
     web3_clientVersion,
     // account lookups
-    eth_accounts: createAsyncMiddleware(lookupAccounts),
+    eth_accounts: toAsyncMiddleware(getAccounts),
     eth_coinbase: toAsyncMiddleware(eth_coinbase),
-    eth_requestAccounts: createAsyncMiddleware(requestAccountsFromProvider),
-    [PROVIDER_JRPC_METHODS.GET_PROVIDER_STATE]: createAsyncMiddleware(
-      getProviderStateFromController,
-    ),
-    eth_setPreferredAggregator: createAsyncMiddleware<any, any>(
-      setPreferredAggregatorWrapper,
-    ),
+    eth_requestAccounts: toAsyncMiddleware(requestAccounts),
+    [PROVIDER_JRPC_METHODS.GET_PROVIDER_STATE]:
+      toAsyncMiddleware(getProviderState),
+    eth_setPreferredAggregator: toAsyncMiddleware(setPreferredAggregator),
     eth_sendTransaction: toAsyncMiddleware(eth_sendTransaction),
   });
 }

--- a/extension/source/Controllers/Network/web3_clientVersion.ts
+++ b/extension/source/Controllers/Network/web3_clientVersion.ts
@@ -1,0 +1,4 @@
+// eslint-disable-next-line @typescript-eslint/naming-convention
+const web3_clientVersion = 'Quill/v0.1.0';
+
+export default web3_clientVersion;

--- a/extension/source/Controllers/QuillController.ts
+++ b/extension/source/Controllers/QuillController.ts
@@ -499,7 +499,7 @@ export default class QuillController extends BaseController<
   private initializeProvider(): SafeEventEmitterProvider {
     const providerHandlers: IProviderHandlers = {
       // account management
-      requestAccounts: async (req) => {
+      eth_requestAccounts: async (req) => {
         const accounts = await this.requestAccounts();
         this.notifyConnections((req as any).origin, {
           method: PROVIDER_NOTIFICATIONS.UNLOCK_STATE_CHANGED,
@@ -511,7 +511,7 @@ export default class QuillController extends BaseController<
         return accounts;
       },
 
-      getAccounts: async () =>
+      eth_accounts: async () =>
         // Expose no accounts if this origin has not been approved, preventing
         // account-requiring RPC methods from completing successfully
         // only show address if account is unlocked
@@ -519,7 +519,7 @@ export default class QuillController extends BaseController<
 
       eth_coinbase: async () => this.selectedAddress || null,
 
-      getProviderState: async () => {
+      wallet_get_provider_state: async () => {
         return {
           accounts: this.selectedAddress ? [this.selectedAddress] : [],
           chainId: this.networkController.state.chainId,
@@ -527,7 +527,7 @@ export default class QuillController extends BaseController<
         };
       },
 
-      setPreferredAggregator: async (req: any) => {
+      eth_setPreferredAggregator: async (req: any) => {
         // eslint-disable-next-line prefer-destructuring
         this.tabPreferredAggregators[req.tabId] = req.params[0];
 

--- a/extension/source/Controllers/QuillController.ts
+++ b/extension/source/Controllers/QuillController.ts
@@ -498,7 +498,6 @@ export default class QuillController extends BaseController<
 
   private initializeProvider(): SafeEventEmitterProvider {
     const providerHandlers: IProviderHandlers = {
-      version: '1.0.0',
       // account management
       requestAccounts: async (req) => {
         const accounts = await this.requestAccounts();

--- a/extension/source/Controllers/QuillController.ts
+++ b/extension/source/Controllers/QuillController.ts
@@ -517,6 +517,8 @@ export default class QuillController extends BaseController<
         // only show address if account is unlocked
         this.selectedAddress ? [this.selectedAddress] : [],
 
+      eth_coinbase: async () => this.selectedAddress || null,
+
       getProviderState: async () => {
         return {
           accounts: this.selectedAddress ? [this.selectedAddress] : [],

--- a/extension/source/Controllers/QuillController.ts
+++ b/extension/source/Controllers/QuillController.ts
@@ -31,10 +31,7 @@ import {
   providerAsMiddleware,
   SafeEventEmitterProvider,
 } from './Network/INetworkController';
-import {
-  IProviderHandlers,
-  SendTransactionParams,
-} from './Network/createEthMiddleware';
+import { SendTransactionParams } from './Network/createEthMiddleware';
 import {
   AddressPreferences,
   PreferencesConfig,

--- a/extension/source/Controllers/QuillController.ts
+++ b/extension/source/Controllers/QuillController.ts
@@ -532,7 +532,7 @@ export default class QuillController extends BaseController<
         return 'ok';
       },
 
-      submitBatch: async (req: any) => {
+      eth_sendTransaction: async (req: any) => {
         const txParams = getAllReqParam<SendTransactionParams[]>(req);
         const { from } = txParams[0];
 

--- a/extension/source/Controllers/QuillController.ts
+++ b/extension/source/Controllers/QuillController.ts
@@ -496,8 +496,8 @@ export default class QuillController extends BaseController<
     // });
   }
 
-  private initializeProvider(): SafeEventEmitterProvider {
-    const providerHandlers: IProviderHandlers = {
+  private initializeProvider() {
+    this.networkController.initializeProvider({
       // account management
       eth_requestAccounts: async (req) => {
         const accounts = await this.requestAccounts();
@@ -571,10 +571,7 @@ export default class QuillController extends BaseController<
 
         return result.hash;
       },
-    };
-    const providerProxy =
-      this.networkController.initializeProvider(providerHandlers);
-    return providerProxy;
+    });
   }
 
   private async requestAccounts(): Promise<string[]> {

--- a/extension/source/PageContentScript/InPageProvider.ts
+++ b/extension/source/PageContentScript/InPageProvider.ts
@@ -2,11 +2,7 @@ import type { JRPCRequest, JRPCSuccess } from '@toruslabs/openlogin-jrpc';
 import { EthereumRpcError } from 'eth-rpc-errors';
 import dequal from 'fast-deep-equal';
 import type { Duplex } from 'readable-stream';
-import {
-  PROVIDER,
-  PROVIDER_JRPC_METHODS,
-  PROVIDER_NOTIFICATIONS,
-} from '../common/constants';
+import { PROVIDER, PROVIDER_NOTIFICATIONS } from '../common/constants';
 
 import BaseProvider from './BaseProvider';
 import {
@@ -99,7 +95,7 @@ class QuillInPageProvider extends BaseProvider<InPageProviderState> {
   async _initializeState(): Promise<void> {
     try {
       const { accounts, chainId, isUnlocked } = (await this.request({
-        method: PROVIDER_JRPC_METHODS.GET_PROVIDER_STATE,
+        method: 'wallet_get_provider_state',
         params: [],
       })) as InPageWalletProviderState;
 

--- a/extension/source/common/constants.ts
+++ b/extension/source/common/constants.ts
@@ -2,10 +2,6 @@ export const CONTENT_SCRIPT = 'quill-contentscript';
 export const INPAGE = 'quill-inpage';
 export const PROVIDER = 'quill-provider';
 
-export const PROVIDER_JRPC_METHODS = {
-  GET_PROVIDER_STATE: 'wallet_get_provider_state',
-};
-
 export const PROVIDER_NOTIFICATIONS = {
   ACCOUNTS_CHANGED: 'wallet_accounts_changed',
   CHAIN_CHANGED: 'wallet_chain_changed',


### PR DESCRIPTION
## What is this PR doing?

`createEthMiddleware` was unnecessarily prescriptive about how we define our `window.ethereum` methods. Two bad things were happening:
1. `createEthMiddleware` restricted exactly which methods could be provided without helping to define how those methods work in any way
2. `createEthMiddleware` did multiple unnecessary name transforms on each method, for example `submitBatch` is the basis for `submitTransaction` and is then used to define `eth_sendTransaction` rather than simply using the name `eth_sendTransaction` from the start

This PR fixes both of these problems. Now the method names in `QuillController` map exactly to the `window.ethereum` method names (so it's easy to search the codebase and find what you're looking for instead of finding where to start tracing the plumbing back to what you actually want).

If we define any more rpc methods, it's also much simpler. As an example, you can simply add this to the method list in `QuillController`:

```diff
 eth_accounts: async () =>
   // Expose no accounts if this origin has not been approved, preventing
   // account-requiring RPC methods from completing successfully
   // only show address if account is unlocked
   this.selectedAddress ? [this.selectedAddress] : [],
+
+foo: async () => 'bar',
 
 eth_coinbase: async () => this.selectedAddress || null,
```

Yep just one line. Then in the console:
![Screen Shot 2022-05-19 at 5 28 52 pm](https://user-images.githubusercontent.com/9291586/169236900-709ecf64-c402-4f83-96c7-d6b4571d451a.png)

## How can these changes be manually tested?

Replicate adding a new `window.ethereum` method as described above. Check existing methods still work as expected.

Also try searching for `eth_sendTransaction` and note that you'll immediately land on the code that's relevant. Compare this to the same thing on the `main` branch and observe the significant work involved to then figure out where the relevant code is.

## Does this PR resolve or contribute to any issues?

Nope.

## Checklist
- [x] I have manually tested these changes
- [x] Post a link to the PR in the group chat

## Guidelines
- If your PR is not ready, mark it as a draft
- The `resolve conversation` button is for reviewers, not authors
  - (But add a 'done' comment or similar)
