### PR TITLE
Updated VerificationGateway to use EIP-712 

### DIFF
--- a/contracts/clients/src/signer/defaultDomain.ts
+++ b/contracts/clients/src/signer/defaultDomain.ts
@@ -1,3 +1,3 @@
-import { arrayify, keccak256 } from "ethers/lib/utils";
+import { arrayify } from "ethers/lib/utils";
 
-export default arrayify(keccak256("0xfeedbee5"));
+export default arrayify("0x425bd46b7016e0395c00f2e05fd74f938023d31f355d5a62fb9c63756c6a5d87");

--- a/contracts/clients/test/index.test.ts
+++ b/contracts/clients/test/index.test.ts
@@ -8,7 +8,7 @@ import { initBlsWalletSigner, Bundle, Operation } from "../src/signer";
 
 import Range from "./helpers/Range";
 
-const domain = arrayify(keccak256("0xfeedbee5"));
+const domain = arrayify("0x425bd46b7016e0395c00f2e05fd74f938023d31f355d5a62fb9c63756c6a5d87");
 const weiPerToken = BigNumber.from(10).pow(18);
 
 const samples = (() => {

--- a/contracts/scripts/deploy_all.ts
+++ b/contracts/scripts/deploy_all.ts
@@ -42,6 +42,7 @@ async function main() {
   console.log("deploying bls-wallet contracts...");
   const fx = await Fixture.create();
   const [deployedBy] = fx.addresses;
+  const domainSeparator = await fx.verificationGateway.domainSeparator();
 
   console.log("deploying test token...");
   // These can be run in parallel
@@ -61,8 +62,7 @@ async function main() {
     auxiliary: {
       chainid: fx.chainId,
       // From VerificationGateway.sol:BLS_DOMAIN
-      domain:
-        "0x0054159611832e24cdd64c6a133e71d373c5f8553dde6c762e6bffe707ad83cc",
+      domain: domainSeparator,
       genesisBlock,
       deployedBy,
       version,


### PR DESCRIPTION
## What is this PR doing?
Added EIP-712 support to verification gateway to use more secure domain and prevent signature replay on different chains.  

## How can these changes be manually tested?
- currently only some of the tests pass that too on a separate hardhat node
- TODO - fix gas limit exceeded error on hardhat test node

## Does this PR resolve or contribute to any issues?
closes #25 

## Checklist
- [ ] I have manually tested these changes
- [ ] Post a link to the PR in the group chat

## Guidelines
- If your PR is not ready, mark it as a draft
- The `resolve conversation` button is for reviewers, not authors
  - (But add a 'done' comment or similar)
