### PR TITLE
Fix public key override to zero after creation

### DIFF
--- a/contracts/contracts/BLSWallet.sol
+++ b/contracts/contracts/BLSWallet.sol
@@ -65,6 +65,8 @@ contract BLSWallet is Initializable, IBLSWallet
         trustedBLSGateway = blsGateway;
         pendingGatewayTime = type(uint256).max;
         pendingPAFunctionTime = type(uint256).max;
+        pendingRecoveryHashTime = type(uint256).max;
+        pendingBLSPublicKeyTime = type(uint256).max;
     }
 
     /** */
@@ -73,7 +75,6 @@ contract BLSWallet is Initializable, IBLSWallet
     ) public onlyTrustedGateway {
         require(isZeroBLSKey(blsPublicKey), "BLSWallet: public key already set");
         blsPublicKey = blsKey;
-        pendingBLSPublicKeyTime = type(uint256).max;
     }
 
     function isZeroBLSKey(uint256[4] memory blsKey) public pure returns (bool) {

--- a/contracts/contracts/BLSWallet.sol
+++ b/contracts/contracts/BLSWallet.sol
@@ -73,6 +73,7 @@ contract BLSWallet is Initializable, IBLSWallet
     ) public onlyTrustedGateway {
         require(isZeroBLSKey(blsPublicKey), "BLSWallet: public key already set");
         blsPublicKey = blsKey;
+        pendingBLSPublicKeyTime = type(uint256).max;
     }
 
     function isZeroBLSKey(uint256[4] memory blsKey) public pure returns (bool) {

--- a/contracts/test/recovery-test.ts
+++ b/contracts/test/recovery-test.ts
@@ -86,7 +86,7 @@ describe("Recovery", async function () {
     expect(await blsWallet.getBLSPublicKey()).to.eql(newKey);
   });
 
-  it("should override public key after creation", async function () {
+  it("should NOT override public key after creation", async function () {
     const initialKey = await blsWallet.getBLSPublicKey();
 
     const ZERO = ethers.BigNumber.from(0);
@@ -95,7 +95,7 @@ describe("Recovery", async function () {
     await blsWallet.setAnyPending();
 
     const finalKey = await blsWallet.getBLSPublicKey();
-    expect(finalKey).to.eql([ZERO, ZERO, ZERO, ZERO]);
+    expect(finalKey).to.eql(initialKey);
   });
 
   it("should set recovery hash", async function () {

--- a/contracts/test/recovery-test.ts
+++ b/contracts/test/recovery-test.ts
@@ -7,6 +7,7 @@ import { PublicKey, BlsWalletWrapper, Signature } from "../clients/src";
 import Fixture from "../shared/helpers/Fixture";
 import deployAndRunPrecompileCostEstimator from "../shared/helpers/deployAndRunPrecompileCostEstimator";
 import { defaultDeployerAddress } from "../shared/helpers/deployDeployer";
+import { BLSWallet } from "../typechain";
 
 const signWalletAddress = async (
   fx: Fixture,
@@ -43,7 +44,7 @@ describe("Recovery", async function () {
   const safetyDelaySeconds = 7 * 24 * 60 * 60;
   let fx: Fixture;
   let wallet1, wallet2, walletAttacker;
-  let blsWallet;
+  let blsWallet: BLSWallet;
   let recoverySigner;
   let hash1, hash2;
   let salt;
@@ -83,6 +84,18 @@ describe("Recovery", async function () {
     await (await blsWallet.setAnyPending()).wait();
 
     expect(await blsWallet.getBLSPublicKey()).to.eql(newKey);
+  });
+
+  it("should override public key after creation", async function () {
+    const initialKey = await blsWallet.getBLSPublicKey();
+
+    const ZERO = ethers.BigNumber.from(0);
+    expect(initialKey).to.not.eql([ZERO, ZERO, ZERO, ZERO]);
+
+    await blsWallet.setAnyPending();
+
+    const finalKey = await blsWallet.getBLSPublicKey();
+    expect(finalKey).to.eql([ZERO, ZERO, ZERO, ZERO]);
   });
 
   it("should set recovery hash", async function () {


### PR DESCRIPTION
## What is this PR doing?
- update `pendingBLSPublicKeyTime` after latchBLSPublicKey is called 
- 6510604 adds a test to check the presence of the bug
- 45d1a50 updates the contract and adds a test case

## How can these changes be manually tested?
run npx hardhat test

## Does this PR resolve or contribute to any issues?
closes #134 

## Checklist
- [x] I have manually tested these changes
- [x] Post a link to the PR in the group chat

## Guidelines
- If your PR is not ready, mark it as a draft
- The `resolve conversation` button is for reviewers, not authors
  - (But add a 'done' comment or similar)
