### PR TITLE
added reverse mapping for external wallets from hash

### DIFF
--- a/contracts/contracts/VerificationGateway.sol
+++ b/contracts/contracts/VerificationGateway.sol
@@ -26,6 +26,7 @@ contract VerificationGateway
     ProxyAdmin public immutable walletProxyAdmin;
     address public blsWalletLogic;
     mapping(bytes32 => IWallet) externalWalletsFromHash;
+    mapping(address => bool) registeredWalletAddresses;
 
 
     /** Aggregated signature with corresponding senders + operations */
@@ -127,6 +128,7 @@ contract VerificationGateway
         uint256[2] calldata messageSenderSignature,
         uint256[BLS_KEY_LEN] calldata publicKey
     ) public {
+        require(!registeredWalletAddresses[msg.sender], "mapping to this wallet already exists");
         safeSetWallet(messageSenderSignature, publicKey, msg.sender);
     }
 
@@ -313,6 +315,7 @@ contract VerificationGateway
         bytes32 publicKeyHash = keccak256(abi.encodePacked(
             publicKey
         ));
+        registeredWalletAddresses[wallet] = true;
         externalWalletsFromHash[publicKeyHash] = IWallet(wallet);
     }
 


### PR DESCRIPTION
## What is this PR doing?
added reverse mapping for external wallets so that the address can be looked up when `setExternalWallet` is called and the wallets which are already registered can be denied re-registration to maintain 1:1 mapping with BLS Key and Wallet.

## How can these changes be manually tested?


## Does this PR resolve or contribute to any issues?
#104 

## Checklist
- [ ] I have manually tested these changes
- [x] Post a link to the PR in the group chat

## Guidelines
- If your PR is not ready, mark it as a draft
- The `resolve conversation` button is for reviewers, not authors
  - (But add a 'done' comment or similar)
