### PR TITLE
Add release drafter

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,0 +1,20 @@
+categories:
+  - title: 'aggregator'
+    label: 'aggregator'
+  - title: 'aggregator-proxy'
+    label: 'aggregator-proxy'
+  - title: 'contracts'
+    label: 'contracts'
+  - title: 'clients'
+    label: 'clients'
+  - title: 'docs'
+    label: 'documentation'
+  - title: 'extension'
+    label: 'extension'
+version-resolver:
+  default: minor
+prerelease: true
+template: |
+  ## What’s Changed
+
+  $CHANGES

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -1,0 +1,24 @@
+
+name: Release Drafter
+
+on:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: read
+
+jobs:
+  update_release_draft:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+
+    steps:
+      - uses: release-drafter/release-drafter@v5
+        with:
+          config-name: release-drafter.yml
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## What is this PR doing?
Adds [release-drafter](https://github.com/release-drafter/release-drafter)

## How can these changes be manually tested?
They cannot, should trigger on next PR merge after this one.

## Does this PR resolve or contribute to any issues?
Resolves https://github.com/web3well/bls-wallet/issues/198

## Checklist
~I have manually tested these changes~ N/A
- [x] Post a link to the PR in the group chat

## Guidelines
- If your PR is not ready, mark it as a draft
- The `resolve conversation` button is for reviewers, not authors
  - (But add a 'done' comment or similar)
