### PR TITLE
Confirmation dialog followup

### DIFF
--- a/extension/package.json
+++ b/extension/package.json
@@ -56,7 +56,6 @@
     "stream-browserify": "^3.0.0",
     "typed-emitter": "^1.4.0",
     "typescript": "^4.5.3",
-    "uuid": "^8.3.2",
     "webext-base-css": "^1.3.2",
     "webextension-polyfill": "^0.8.0",
     "zxcvbn": "^4.4.2"
@@ -78,7 +77,6 @@
     "@types/react-dom": "^17.0.11",
     "@types/react-router-dom": "^5.3.3",
     "@types/react-table": "^7.7.9",
-    "@types/uuid": "^8.3.4",
     "@types/webextension-polyfill": "^0.8.2",
     "@types/webpack": "^5.28.0",
     "@types/zxcvbn": "^4.4.1",

--- a/extension/source/Confirm/Confirm.tsx
+++ b/extension/source/Confirm/Confirm.tsx
@@ -5,10 +5,9 @@ import { runtime, storage } from 'webextension-polyfill';
 import { Check, X, CaretLeft, CaretRight } from 'phosphor-react';
 import { ethers } from 'ethers';
 import Button from '../components/Button';
-import { SendTransactionParams } from '../types/Rpc';
+import { PromptMessage, SendTransactionParams } from '../types/Rpc';
 import TransactionCard from './TransactionCard';
 import onAction from '../helpers/onAction';
-import type { PromptMessage } from '../background/TransactionsController';
 
 const Confirm: FunctionComponent = () => {
   const [id, setId] = useState<string | null>();

--- a/extension/source/Confirm/Confirm.tsx
+++ b/extension/source/Confirm/Confirm.tsx
@@ -5,7 +5,11 @@ import { runtime, storage } from 'webextension-polyfill';
 import { Check, X, CaretLeft, CaretRight } from 'phosphor-react';
 import { ethers } from 'ethers';
 import Button from '../components/Button';
-import { PromptMessage, SendTransactionParams } from '../types/Rpc';
+import {
+  PromptMessage,
+  SendTransactionParams,
+  TransactionStatus,
+} from '../types/Rpc';
 import TransactionCard from './TransactionCard';
 import onAction from '../helpers/onAction';
 
@@ -101,13 +105,19 @@ const Confirm: FunctionComponent = () => {
         </div>
       </div>
       <div className="flex bg-white p-4 justify-between">
-        <Button className="btn-secondary" onPress={() => respondTx('rejected')}>
+        <Button
+          className="btn-secondary"
+          onPress={() => respondTx(TransactionStatus.REJECTED)}
+        >
           <div className="flex justify-between gap-3">
             Reject All <X size={20} className="self-center" />
           </div>
         </Button>
 
-        <Button className="btn-primary" onPress={() => respondTx('approved')}>
+        <Button
+          className="btn-primary"
+          onPress={() => respondTx(TransactionStatus.APPROVED)}
+        >
           <div className="flex justify-between gap-3">
             Confirm All <Check size={20} className="self-center" />
           </div>

--- a/extension/source/Confirm/Confirm.tsx
+++ b/extension/source/Confirm/Confirm.tsx
@@ -5,10 +5,10 @@ import { runtime, storage } from 'webextension-polyfill';
 import { Check, X, CaretLeft, CaretRight } from 'phosphor-react';
 import { ethers } from 'ethers';
 import Button from '../components/Button';
-import { TransactionStatus } from '../background/TransactionsController';
 import { SendTransactionParams } from '../types/Rpc';
 import TransactionCard from './TransactionCard';
 import onAction from '../helpers/onAction';
+import type { PromptMessage } from '../background/TransactionsController';
 
 const Confirm: FunctionComponent = () => {
   const [id, setId] = useState<string | null>();
@@ -31,7 +31,7 @@ const Confirm: FunctionComponent = () => {
     fetchTx();
   }, []);
 
-  const respondTx = (result: string) => {
+  const respondTx = (result: PromptMessage['result']) => {
     runtime.sendMessage(undefined, { id, result });
   };
 
@@ -102,19 +102,13 @@ const Confirm: FunctionComponent = () => {
         </div>
       </div>
       <div className="flex bg-white p-4 justify-between">
-        <Button
-          className="btn-secondary"
-          onPress={() => respondTx(TransactionStatus.REJECTED)}
-        >
+        <Button className="btn-secondary" onPress={() => respondTx('rejected')}>
           <div className="flex justify-between gap-3">
             Reject All <X size={20} className="self-center" />
           </div>
         </Button>
 
-        <Button
-          className="btn-primary"
-          onPress={() => respondTx(TransactionStatus.APPROVED)}
-        >
+        <Button className="btn-primary" onPress={() => respondTx('approved')}>
           <div className="flex justify-between gap-3">
             Confirm All <Check size={20} className="self-center" />
           </div>

--- a/extension/source/QuillStorageCells.ts
+++ b/extension/source/QuillStorageCells.ts
@@ -13,30 +13,7 @@ import AsyncReturnType from './types/AsyncReturnType';
 import { DEFAULT_CHAIN_ID_HEX } from './env';
 import { FormulaCell } from './cells/FormulaCell';
 import assert from './helpers/assert';
-import { SendTransactionParams } from './types/Rpc';
-
-export const TransactionStatus = io.union([
-  io.literal('new'),
-  io.literal('approved'),
-  io.literal('rejected'),
-  io.literal('cancelled'),
-  io.literal('confirmed'),
-  io.literal('failed'),
-]);
-
-export type TransactionStatus = io.TypeOf<typeof TransactionStatus>;
-
-export const QuillTransaction = io.type({
-  id: io.string,
-  chainId: io.string,
-  from: io.string,
-  status: TransactionStatus,
-  createdAt: io.number,
-  bundleHash: io.string,
-  actions: io.array(SendTransactionParams),
-});
-
-export type QuillTransaction = io.TypeOf<typeof QuillTransaction>;
+import { QuillTransaction } from './types/Rpc';
 
 // FIXME: If defaults were built into our io types, we could easily add new
 // fields that always have concrete values incrementally without breaking

--- a/extension/source/QuillStorageCells.ts
+++ b/extension/source/QuillStorageCells.ts
@@ -15,6 +15,29 @@ import { FormulaCell } from './cells/FormulaCell';
 import assert from './helpers/assert';
 import { SendTransactionParams } from './types/Rpc';
 
+export const TransactionStatus = io.union([
+  io.literal('new'),
+  io.literal('approved'),
+  io.literal('rejected'),
+  io.literal('cancelled'),
+  io.literal('confirmed'),
+  io.literal('failed'),
+]);
+
+export type TransactionStatus = io.TypeOf<typeof TransactionStatus>;
+
+export const QuillTransaction = io.type({
+  id: io.string,
+  chainId: io.string,
+  from: io.string,
+  status: TransactionStatus,
+  createdAt: io.number,
+  bundleHash: io.string,
+  actions: io.array(SendTransactionParams),
+});
+
+export type QuillTransaction = io.TypeOf<typeof QuillTransaction>;
+
 // FIXME: If defaults were built into our io types, we could easily add new
 // fields that always have concrete values incrementally without breaking
 // existing clients.
@@ -53,17 +76,7 @@ function QuillStorageCells(storage: CellCollection) {
     transactions: storage.Cell(
       'transactions',
       io.type({
-        outgoing: io.array(
-          io.type({
-            id: io.string,
-            chainId: io.string,
-            from: io.string,
-            status: io.string,
-            createdAt: io.number,
-            bundleHash: io.string,
-            actions: io.array(SendTransactionParams),
-          }),
-        ),
+        outgoing: io.array(QuillTransaction),
       }),
       () => ({ outgoing: [] }),
     ),

--- a/extension/source/background/AggregatorController.ts
+++ b/extension/source/background/AggregatorController.ts
@@ -41,6 +41,10 @@ export default class AggregatorController {
     eth_sendTransaction: async (request) => {
       const { providerId, params } = request;
 
+      const userAction = await this.transactionsController
+        .InternalRpc()
+        .requestTransaction(...params);
+
       // FIXME: We should not be assuming that the first from is the same as all
       // the other froms!
       // Supporting multiple froms is actually super awesome - we can show off
@@ -64,10 +68,6 @@ export default class AggregatorController {
         NETWORK_CONFIG.addresses.verificationGateway,
         this.ethersProvider,
       );
-
-      const userAction = await this.transactionsController
-        .InternalRpc()
-        .requestTransaction(...params);
 
       if (userAction === TransactionStatus.APPROVED) {
         // const nonce = (await wallet.Nonce()).toString();

--- a/extension/source/background/AggregatorController.ts
+++ b/extension/source/background/AggregatorController.ts
@@ -10,9 +10,7 @@ import { PartialRpcImpl, RpcClient, SendTransactionParams } from '../types/Rpc';
 import KeyringController from './KeyringController';
 import NetworkController from './NetworkController';
 import optional from '../types/optional';
-import TransactionsController, {
-  TransactionStatus,
-} from './TransactionsController';
+import TransactionsController from './TransactionsController';
 
 export default class AggregatorController {
   // This is just kept in memory because it supports setting the preferred
@@ -67,7 +65,7 @@ export default class AggregatorController {
         this.ethersProvider,
       );
 
-      if (userAction === TransactionStatus.APPROVED) {
+      if (userAction === 'approved') {
         // const nonce = (await wallet.Nonce()).toString();
         const nonce = (
           await BlsWalletWrapper.Nonce(

--- a/extension/source/background/AggregatorController.ts
+++ b/extension/source/background/AggregatorController.ts
@@ -36,10 +36,10 @@ export default class AggregatorController {
   ) {}
 
   rpc = ensureType<PartialRpcImpl>()({
-    eth_sendTransaction: async (request) => {
-      const { providerId, params } = request;
-
-      await this.InternalRpc().requestTransaction(...params);
+    eth_sendTransaction: async ({ providerId, params, origin }) => {
+      if (origin !== window.location.origin) {
+        await this.InternalRpc().requestTransaction(...params);
+      }
 
       // FIXME: We should not be assuming that the first from is the same as all
       // the other froms!

--- a/extension/source/background/AggregatorController.ts
+++ b/extension/source/background/AggregatorController.ts
@@ -36,10 +36,11 @@ export default class AggregatorController {
   ) {}
 
   rpc = ensureType<PartialRpcImpl>()({
-    eth_sendTransaction: async ({ providerId, params, origin }) => {
-      if (origin !== window.location.origin) {
-        await this.InternalRpc().requestTransaction(...params);
-      }
+    eth_sendTransaction: async ({ providerId, params }) => {
+      // TODO: If `origin === window.location.origin` (ie the tx is coming from
+      // inside Quill), then we should really inline the information from the
+      // dialog rather than using it.
+      await this.InternalRpc().requestTransaction(...params);
 
       // FIXME: We should not be assuming that the first from is the same as all
       // the other froms!

--- a/extension/source/background/AggregatorController.ts
+++ b/extension/source/background/AggregatorController.ts
@@ -41,9 +41,7 @@ export default class AggregatorController {
     eth_sendTransaction: async (request) => {
       const { providerId, params } = request;
 
-      const userAction = await this.transactionsController
-        .InternalRpc()
-        .requestTransaction(...params);
+      const userAction = await this.InternalRpc().requestTransaction(...params);
 
       // FIXME: We should not be assuming that the first from is the same as all
       // the other froms!

--- a/extension/source/background/TransactionsController.ts
+++ b/extension/source/background/TransactionsController.ts
@@ -1,4 +1,3 @@
-import { v4 as uuidv4 } from 'uuid';
 import { windows, runtime } from 'webextension-polyfill';
 import ensureType from '../helpers/ensureType';
 import QuillStorageCells from '../QuillStorageCells';
@@ -6,6 +5,7 @@ import { PartialRpcImpl, RpcClient } from '../types/Rpc';
 import assert from '../helpers/assert';
 import TaskQueue from '../helpers/TaskQueue';
 import getPropOrUndefined from '../helpers/getPropOrUndefined';
+import RandomId from '../helpers/RandomId';
 
 export enum TransactionStatus {
   'NEW' = 'new',
@@ -83,7 +83,7 @@ export default class TransactionsController {
     },
 
     createTransaction: async ({ params }) => {
-      const id = uuidv4().toString();
+      const id = RandomId();
 
       const newTransaction = {
         id,

--- a/extension/source/background/TransactionsController.ts
+++ b/extension/source/background/TransactionsController.ts
@@ -1,23 +1,15 @@
 import * as io from 'io-ts';
 import { windows, runtime } from 'webextension-polyfill';
 import ensureType from '../helpers/ensureType';
-import QuillStorageCells from '../QuillStorageCells';
+import QuillStorageCells, {
+  QuillTransaction,
+  TransactionStatus,
+} from '../QuillStorageCells';
 import { PartialRpcImpl, RpcClient } from '../types/Rpc';
 import assert from '../helpers/assert';
 import TaskQueue from '../helpers/TaskQueue';
 import RandomId from '../helpers/RandomId';
 import isType from '../cells/isType';
-
-export const TransactionStatus = io.union([
-  io.literal('new'),
-  io.literal('approved'),
-  io.literal('rejected'),
-  io.literal('cancelled'),
-  io.literal('confirmed'),
-  io.literal('failed'),
-]);
-
-export type TransactionStatus = io.TypeOf<typeof TransactionStatus>;
 
 export const PromptMessage = io.type({
   id: io.string,
@@ -95,7 +87,7 @@ export default class TransactionsController {
     createTransaction: async ({ params }) => {
       const id = RandomId();
 
-      const newTransaction = {
+      const newTransaction: QuillTransaction = {
         id,
         chainId: await this.InternalRpc().eth_chainId(),
         from: (await this.selectedAddress.read()) || '',

--- a/extension/source/types/Rpc.ts
+++ b/extension/source/types/Rpc.ts
@@ -31,22 +31,24 @@ export const SendTransactionParams = io.type({
 
 export type SendTransactionParams = io.TypeOf<typeof SendTransactionParams>;
 
-export const TransactionStatus = io.union([
-  io.literal('new'),
-  io.literal('approved'),
-  io.literal('rejected'),
-  io.literal('cancelled'),
-  io.literal('confirmed'),
-  io.literal('failed'),
-]);
+export enum TransactionStatus {
+  NEW = 'new',
+  APPROVED = 'approved',
+  REJECTED = 'rejected',
+  CANCELLED = 'cancelled',
+  CONFIRMED = 'confirmed',
+  FAILED = 'failed',
+}
 
-export type TransactionStatus = io.TypeOf<typeof TransactionStatus>;
+export const TransactionStatusType: io.Type<TransactionStatus> = io.union(
+  Object.values(TransactionStatus).map((v) => io.literal(v)) as ExplicitAny,
+);
 
 export const QuillTransaction = io.type({
   id: io.string,
   chainId: io.string,
   from: io.string,
-  status: TransactionStatus,
+  status: TransactionStatusType,
   createdAt: io.number,
   bundleHash: io.string,
   actions: io.array(SendTransactionParams),
@@ -56,7 +58,10 @@ export type QuillTransaction = io.TypeOf<typeof QuillTransaction>;
 
 export const PromptMessage = io.type({
   id: io.string,
-  result: io.union([io.literal('approved'), io.literal('rejected')]),
+  result: io.union([
+    io.literal(TransactionStatus.APPROVED),
+    io.literal(TransactionStatus.REJECTED),
+  ]),
 });
 
 export type PromptMessage = io.TypeOf<typeof PromptMessage>;
@@ -188,7 +193,7 @@ export const rpcMap = {
   },
   updateTransactionStatus: {
     origin: '<quill>',
-    Params: io.tuple([io.string, TransactionStatus]),
+    Params: io.tuple([io.string, TransactionStatusType]),
     Response: io.void,
   },
   promptUser: {

--- a/extension/source/types/Rpc.ts
+++ b/extension/source/types/Rpc.ts
@@ -31,6 +31,29 @@ export const SendTransactionParams = io.type({
 
 export type SendTransactionParams = io.TypeOf<typeof SendTransactionParams>;
 
+export const TransactionStatus = io.union([
+  io.literal('new'),
+  io.literal('approved'),
+  io.literal('rejected'),
+  io.literal('cancelled'),
+  io.literal('confirmed'),
+  io.literal('failed'),
+]);
+
+export type TransactionStatus = io.TypeOf<typeof TransactionStatus>;
+
+export const QuillTransaction = io.type({
+  id: io.string,
+  chainId: io.string,
+  from: io.string,
+  status: TransactionStatus,
+  createdAt: io.number,
+  bundleHash: io.string,
+  actions: io.array(SendTransactionParams),
+});
+
+export type QuillTransaction = io.TypeOf<typeof QuillTransaction>;
+
 export const rpcMap = {
   // QuillController
   // - ALL rpc methods are technically implemented by QuillController. It
@@ -157,7 +180,7 @@ export const rpcMap = {
   },
   updateTransactionStatus: {
     origin: '<quill>',
-    Params: io.tuple([io.string, io.string]),
+    Params: io.tuple([io.string, TransactionStatus]),
     Response: io.void,
   },
   promptUser: {

--- a/extension/source/types/Rpc.ts
+++ b/extension/source/types/Rpc.ts
@@ -127,12 +127,12 @@ export const rpcMap = {
 
   // TransactionController
   createTransaction: {
-    origin: '*',
+    origin: '<quill>',
     Params: io.array(SendTransactionParams),
     Response: io.string,
   },
   getTransactionById: {
-    origin: '*',
+    origin: '<quill>',
     Params: io.array(io.string),
     Response: io.type({
       id: io.string,
@@ -144,7 +144,7 @@ export const rpcMap = {
     }),
   },
   getTransactionByHash: {
-    origin: '*',
+    origin: '<quill>',
     Params: io.array(io.string),
     Response: io.type({
       id: io.string,
@@ -161,12 +161,12 @@ export const rpcMap = {
     Response: io.void,
   },
   promptUser: {
-    origin: '*',
+    origin: '<quill>',
     Params: io.array(io.string),
     Response: io.unknown,
   },
   requestTransaction: {
-    origin: '*',
+    origin: '<quill>',
     Params: io.array(SendTransactionParams),
     Response: io.unknown,
   },

--- a/extension/source/types/Rpc.ts
+++ b/extension/source/types/Rpc.ts
@@ -54,6 +54,13 @@ export const QuillTransaction = io.type({
 
 export type QuillTransaction = io.TypeOf<typeof QuillTransaction>;
 
+export const PromptMessage = io.type({
+  id: io.string,
+  result: io.union([io.literal('approved'), io.literal('rejected')]),
+});
+
+export type PromptMessage = io.TypeOf<typeof PromptMessage>;
+
 export const rpcMap = {
   // QuillController
   // - ALL rpc methods are technically implemented by QuillController. It
@@ -149,6 +156,7 @@ export const rpcMap = {
   },
 
   // TransactionController
+
   createTransaction: {
     origin: '<quill>',
     Params: io.array(SendTransactionParams),
@@ -186,12 +194,12 @@ export const rpcMap = {
   promptUser: {
     origin: '<quill>',
     Params: io.array(io.string),
-    Response: io.unknown,
+    Response: PromptMessage.props.result,
   },
   requestTransaction: {
     origin: '<quill>',
     Params: io.array(SendTransactionParams),
-    Response: io.unknown,
+    Response: io.string,
   },
 
   // AggregatorController

--- a/extension/tsconfig.json
+++ b/extension/tsconfig.json
@@ -12,8 +12,7 @@
     /* Additional Checks */
     "useDefineForClassFields": true,
     "skipLibCheck": true,
-    "jsx": "preserve",
-    "noUnusedLocals": false
+    "jsx": "preserve"
   },
   "include": ["source", "webpack.config.js"]
 }

--- a/extension/tsconfig.json
+++ b/extension/tsconfig.json
@@ -12,7 +12,8 @@
     /* Additional Checks */
     "useDefineForClassFields": true,
     "skipLibCheck": true,
-    "jsx": "preserve"
+    "jsx": "preserve",
+    "noUnusedLocals": false
   },
   "include": ["source", "webpack.config.js"]
 }

--- a/extension/yarn.lock
+++ b/extension/yarn.lock
@@ -1953,11 +1953,6 @@
   dependencies:
     source-map "^0.6.1"
 
-"@types/uuid@^8.3.4":
-  version "8.3.4"
-  resolved "https://registry.yarnpkg.com/@types/uuid/-/uuid-8.3.4.tgz#bd86a43617df0594787d38b735f55c805becf1bc"
-  integrity sha512-c/I8ZRb51j+pYGAu5CrFMRxqZ2ke4y2grEBO5AUjgSkSk+qT2Ea+OdWElz/OiMf5MNpn2b17kuVBwZLQJXzihw==
-
 "@types/webextension-polyfill@^0.8.2":
   version "0.8.2"
   resolved "https://registry.yarnpkg.com/@types/webextension-polyfill/-/webextension-polyfill-0.8.2.tgz#d909371d332ce3e1a94684624deb0a8693eee900"
@@ -7024,11 +7019,6 @@ utila@~0.4:
   version "0.4.0"
   resolved "https://registry.yarnpkg.com/utila/-/utila-0.4.0.tgz#8a16a05d445657a3aea5eecc5b12a4fa5379772c"
   integrity sha512-Z0DbgELS9/L/75wZbro8xAnT50pBVFQZ+hUEueGDU5FN51YSCYM+jdxsfCiHjwNP/4LCDD0i/graKpeBnOXKRA==
-
-uuid@^8.3.2:
-  version "8.3.2"
-  resolved "https://registry.yarnpkg.com/uuid/-/uuid-8.3.2.tgz#80d5b5ced271bb9af6c445f21a1a04c606cefbe2"
-  integrity sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==
 
 v8-compile-cache@^2.0.3:
   version "2.1.1"


### PR DESCRIPTION
## What is this PR doing?

Implements some followup improvements to the [confirmation dialog PR](https://github.com/web3well/bls-wallet/pull/254).

In particular:
- Display the confirm dialog faster
- Don't require the confirm dialog for sending ETH within Quill

See code comments for more changes and details.

## How can these changes be manually tested?

Check that Kautuk's functionality all still works: https://youtu.be/Ya7WdBNmK8Q

With one exception:
- Sending ETH within quill no longer uses the confirm dialog

## Does this PR resolve or contribute to any issues?

Nope.

## Checklist
- [x] I have manually tested these changes
- [x] Post a link to the PR in the group chat

## Guidelines
- If your PR is not ready, mark it as a draft
- The `resolve conversation` button is for reviewers, not authors
  - (But add a 'done' comment or similar)
