### PR TITLE
Show nonce on transactions tab

### DIFF
--- a/extension/source/Home/Wallet/Wallets/DisplayNonce.tsx
+++ b/extension/source/Home/Wallet/Wallets/DisplayNonce.tsx
@@ -1,0 +1,31 @@
+import { BlsWalletWrapper } from 'bls-wallet-clients';
+import { FunctionComponent, useMemo } from 'react';
+import { FormulaCell } from '../../../cells/FormulaCell';
+import useCell from '../../../cells/useCell';
+import { NETWORK_CONFIG } from '../../../env';
+import { useQuill } from '../../QuillContext';
+
+const DisplayNonce: FunctionComponent<{ address: string }> = ({ address }) => {
+  const quill = useQuill();
+
+  const nonce = useMemo(() => {
+    return new FormulaCell(
+      { blockNumber: quill.cells.blockNumber },
+      async () => {
+        const wallet = await BlsWalletWrapper.connect(
+          await quill.rpc.lookupPrivateKey(address),
+          NETWORK_CONFIG.addresses.verificationGateway,
+          quill.ethersProvider,
+        );
+
+        return (await wallet.Nonce()).toNumber();
+      },
+    );
+  }, [quill.cells.blockNumber, quill.ethersProvider, quill.rpc, address]);
+
+  const nonceValue = useCell(nonce);
+
+  return <>{nonceValue}</>;
+};
+
+export default DisplayNonce;

--- a/extension/source/Home/Wallet/Wallets/WalletDetail.tsx
+++ b/extension/source/Home/Wallet/Wallets/WalletDetail.tsx
@@ -1,5 +1,10 @@
-import * as React from 'react';
+import { FunctionComponent, useMemo } from 'react';
+import ICell from '../../../cells/ICell';
+import MemoryCell from '../../../cells/MemoryCell';
+import useCell from '../../../cells/useCell';
 import onAction from '../../../helpers/onAction';
+import { useQuill } from '../../QuillContext';
+import DisplayNonce from './DisplayNonce';
 // import { AssetsTable } from './AssetsTable';
 
 export interface TokenData {
@@ -55,10 +60,18 @@ export interface TokenData {
 //   },
 // ];
 
-const tabs = [{ name: 'Assets' }, { name: 'Outbox' }, { name: 'Transactions' }];
+type TabName = 'Assets' | 'Outbox' | 'Transactions';
 
-const WalletTabs: React.FunctionComponent = () => {
-  const [activeTab, setActiveTab] = React.useState<string>('Assets');
+const tabs: { name: TabName }[] = [
+  { name: 'Assets' },
+  { name: 'Outbox' },
+  { name: 'Transactions' },
+];
+
+const WalletTabs: FunctionComponent<{ activeTab: ICell<TabName> }> = ({
+  activeTab,
+}) => {
+  const activeTabValue = useCell(activeTab);
 
   return (
     <div className="flex border-b border-grey-300 gap-4 mb-4">
@@ -66,9 +79,10 @@ const WalletTabs: React.FunctionComponent = () => {
         <div
           key={tab.name}
           className={`py-2 px-4 cursor-pointer ${
-            tab.name === activeTab && 'border-b-2 border-blue-500 text-blue-500'
+            tab.name === activeTabValue &&
+            'border-b-2 border-blue-500 text-blue-500'
           }`}
-          {...onAction(() => setActiveTab(tab.name))}
+          {...onAction(() => activeTab.write(tab.name))}
         >
           {tab.name}
         </div>
@@ -77,12 +91,28 @@ const WalletTabs: React.FunctionComponent = () => {
   );
 };
 
-export const WalletDetail: React.FunctionComponent = () => {
+export const WalletDetail: FunctionComponent = () => {
+  const quill = useQuill();
+
+  const activeTab = useMemo(
+    () => new MemoryCell<'Assets' | 'Outbox' | 'Transactions'>('Assets'),
+    [],
+  );
+
+  const activeTabValue = useCell(activeTab);
+  const selectedAddress = useCell(quill.cells.selectedAddress);
+
   return (
     <div className="">
-      <WalletTabs />
+      <WalletTabs {...{ activeTab }} />
 
       <input placeholder="Search" />
+
+      {activeTabValue === 'Transactions' && selectedAddress && (
+        <>
+          Total: <DisplayNonce address={selectedAddress} />
+        </>
+      )}
 
       {/* <AssetsTable data={data} /> */}
       {/* <AssetsTable data={data} /> */}

--- a/extension/source/cells/useCell.ts
+++ b/extension/source/cells/useCell.ts
@@ -14,7 +14,11 @@ export default function useCell<C extends IReadableCell<unknown>>(
 
   useEffect(() => {
     const { stop } = forEach(cell, setValue);
-    return stop;
+
+    return () => {
+      setValue(undefined);
+      stop();
+    };
   }, [cell]);
 
   return value;


### PR DESCRIPTION
## What is this PR doing?

See title.

Also: Minor improvement to `useCell`: Resets `useState` to `undefined` when cleaning up. This matters when you switch to using a different cell, which should produce `undefined` until a value from that cell has loaded. Without this change, react reuses the `useState` (🤯... although thinking about how hooks work, I guess you can't avoid it), which means you get the value from the previous cell while the new cell is loading. This is a problem e.g. when you change your selected address which completes instantly but then UI elements based on the selected address continue to show the stale value.

## How can these changes be manually tested?

Check the expected nonce is displayed when viewing the transactions tab:

![Screen Shot 2022-07-11 at 6 10 34 pm](https://user-images.githubusercontent.com/9291586/178218491-64f6c502-97b5-4246-8c31-f83d0a77f3f3.png)

## Does this PR resolve or contribute to any issues?

Contributes to https://github.com/web3well/bls-wallet/issues/262

## Checklist
- [x] I have manually tested these changes
- [x] Post a link to the PR in the group chat

## Guidelines
- If your PR is not ready, mark it as a draft
- The `resolve conversation` button is for reviewers, not authors
  - (But add a 'done' comment or similar)
