### PR TITLE
Use QuillContext in Confirm dialog

### DIFF
--- a/extension/source/Confirm/index.tsx
+++ b/extension/source/Confirm/index.tsx
@@ -1,7 +1,21 @@
-import ReactDOM from 'react-dom';
-
-import Confirm from './Confirm';
 import '../styles/index.scss';
 import './styles.scss';
 
-ReactDOM.render(<Confirm />, document.getElementById('confirm-root'));
+import ReactDOM from 'react-dom';
+import Browser from 'webextension-polyfill';
+
+import QuillEthereumProvider from '../QuillEthereumProvider';
+import Confirm from './Confirm';
+import { QuillContextProvider } from '../QuillContext';
+
+window.ethereum = new QuillEthereumProvider(true);
+
+window.debug ??= {};
+window.debug.Browser = Browser;
+
+ReactDOM.render(
+  <QuillContextProvider>
+    <Confirm />
+  </QuillContextProvider>,
+  document.getElementById('confirm-root'),
+);

--- a/extension/source/Home/Home.tsx
+++ b/extension/source/Home/Home.tsx
@@ -3,7 +3,7 @@ import { HashRouter, Route, Routes } from 'react-router-dom';
 
 import OnboardingPage from './Onboarding/OnboardingPage';
 import { WalletsPage } from './Wallet/WalletsPage';
-import { QuillContextProvider } from './QuillContext';
+import { QuillContextProvider } from '../QuillContext';
 import Theme from './Theme';
 import LoadingPage from './LoadingPage';
 

--- a/extension/source/Home/LoadingPage.tsx
+++ b/extension/source/Home/LoadingPage.tsx
@@ -2,7 +2,7 @@ import { FunctionComponent, useEffect } from 'react';
 
 import { useNavigate } from 'react-router-dom';
 import Loading from '../components/Loading';
-import { useQuill } from './QuillContext';
+import { useQuill } from '../QuillContext';
 
 const LoadingPage: FunctionComponent = () => {
   const navigate = useNavigate();

--- a/extension/source/Home/Onboarding/ReviewSecretPhrasePanel.tsx
+++ b/extension/source/Home/Onboarding/ReviewSecretPhrasePanel.tsx
@@ -4,7 +4,7 @@ import { ArrowRight } from 'phosphor-react';
 import { useNavigate } from 'react-router-dom';
 import Button from '../../components/Button';
 import Range from '../../helpers/Range';
-import { useQuill } from '../QuillContext';
+import { useQuill } from '../../QuillContext';
 
 const WordInReview: FunctionComponent<{
   index: number;

--- a/extension/source/Home/Theme.tsx
+++ b/extension/source/Home/Theme.tsx
@@ -1,6 +1,6 @@
 import { FunctionComponent } from 'react';
 import useCell from '../cells/useCell';
-import { useQuill } from './QuillContext';
+import { useQuill } from '../QuillContext';
 
 const Theme: FunctionComponent = ({ children }) => {
   const quill = useQuill();

--- a/extension/source/Home/Wallet/Settings/DeveloperSettings.tsx
+++ b/extension/source/Home/Wallet/Settings/DeveloperSettings.tsx
@@ -1,6 +1,6 @@
 import { FunctionComponent } from 'react';
 import CheckBox from '../../../cells/components/CheckBox';
-import { useQuill } from '../../QuillContext';
+import { useQuill } from '../../../QuillContext';
 
 const DeveloperSettings: FunctionComponent = () => {
   const { cells } = useQuill();

--- a/extension/source/Home/Wallet/Settings/GeneralSettings.tsx
+++ b/extension/source/Home/Wallet/Settings/GeneralSettings.tsx
@@ -1,6 +1,6 @@
 import { FunctionComponent } from 'react';
 import Display from '../../../cells/components/Display';
-import { useQuill } from '../../QuillContext';
+import { useQuill } from '../../../QuillContext';
 
 const GeneralSettings: FunctionComponent = () => {
   const { cells } = useQuill();

--- a/extension/source/Home/Wallet/Settings/NetworkSettings.tsx
+++ b/extension/source/Home/Wallet/Settings/NetworkSettings.tsx
@@ -1,6 +1,6 @@
 import { FunctionComponent } from 'react';
 import Display from '../../../cells/components/Display';
-import { useQuill } from '../../QuillContext';
+import { useQuill } from '../../../QuillContext';
 
 const NetworkSettings: FunctionComponent = () => {
   const { cells } = useQuill();

--- a/extension/source/Home/Wallet/Wallets/Balance.tsx
+++ b/extension/source/Home/Wallet/Wallets/Balance.tsx
@@ -8,7 +8,7 @@ import { IReadableCell } from '../../../cells/ICell';
 import useCell from '../../../cells/useCell';
 import Loading from '../../../components/Loading';
 import assert from '../../../helpers/assert';
-import { useQuill } from '../../QuillContext';
+import { useQuill } from '../../../QuillContext';
 
 const Balance: FunctionComponent<{ address: string }> = ({ address }) => {
   const quill = useQuill();

--- a/extension/source/Home/Wallet/Wallets/DisplayNonce.tsx
+++ b/extension/source/Home/Wallet/Wallets/DisplayNonce.tsx
@@ -3,7 +3,7 @@ import { FunctionComponent, useMemo } from 'react';
 import { FormulaCell } from '../../../cells/FormulaCell';
 import useCell from '../../../cells/useCell';
 import { NETWORK_CONFIG } from '../../../env';
-import { useQuill } from '../../QuillContext';
+import { useQuill } from '../../../QuillContext';
 
 const DisplayNonce: FunctionComponent<{ address: string }> = ({ address }) => {
   const quill = useQuill();

--- a/extension/source/Home/Wallet/Wallets/SendDetail/AssetSelector.tsx
+++ b/extension/source/Home/Wallet/Wallets/SendDetail/AssetSelector.tsx
@@ -5,7 +5,7 @@ import ICell from '../../../../cells/ICell';
 import useCell from '../../../../cells/useCell';
 import Loading from '../../../../components/Loading';
 import onAction from '../../../../helpers/onAction';
-import { useQuill } from '../../../QuillContext';
+import { useQuill } from '../../../../QuillContext';
 import Balance from '../Balance';
 
 const AssetSelector: FunctionComponent<{

--- a/extension/source/Home/Wallet/Wallets/SendDetail/RecipientSelector.tsx
+++ b/extension/source/Home/Wallet/Wallets/SendDetail/RecipientSelector.tsx
@@ -9,7 +9,7 @@ import MemoryCell from '../../../../cells/MemoryCell';
 import useCell from '../../../../cells/useCell';
 import Loading from '../../../../components/Loading';
 import onAction from '../../../../helpers/onAction';
-import { useQuill } from '../../../QuillContext';
+import { useQuill } from '../../../../QuillContext';
 import Balance from '../Balance';
 
 const RecipientSelector: FunctionComponent<{

--- a/extension/source/Home/Wallet/Wallets/SendDetail/SendDetail.tsx
+++ b/extension/source/Home/Wallet/Wallets/SendDetail/SendDetail.tsx
@@ -6,7 +6,7 @@ import MemoryCell from '../../../../cells/MemoryCell';
 import assert from '../../../../helpers/assert';
 import AsyncReturnType from '../../../../types/AsyncReturnType';
 import { RpcClient } from '../../../../types/Rpc';
-import { QuillContextValue, useQuill } from '../../../QuillContext';
+import { QuillContextValue, useQuill } from '../../../../QuillContext';
 
 import BigSendButton from './BigSendButton';
 import SendDetailSelectors from './SendDetailSelectors';

--- a/extension/source/Home/Wallet/Wallets/SendDetail/SendProgress.tsx
+++ b/extension/source/Home/Wallet/Wallets/SendDetail/SendProgress.tsx
@@ -4,7 +4,7 @@ import { useNavigate } from 'react-router-dom';
 
 import useCell from '../../../../cells/useCell';
 import Button from '../../../../components/Button';
-import { useQuill } from '../../../QuillContext';
+import { useQuill } from '../../../../QuillContext';
 
 import type { SendState } from './SendDetail';
 

--- a/extension/source/Home/Wallet/Wallets/WalletDetail.tsx
+++ b/extension/source/Home/Wallet/Wallets/WalletDetail.tsx
@@ -3,7 +3,7 @@ import ICell from '../../../cells/ICell';
 import MemoryCell from '../../../cells/MemoryCell';
 import useCell from '../../../cells/useCell';
 import onAction from '../../../helpers/onAction';
-import { useQuill } from '../../QuillContext';
+import { useQuill } from '../../../QuillContext';
 import DisplayNonce from './DisplayNonce';
 // import { AssetsTable } from './AssetsTable';
 

--- a/extension/source/Home/Wallet/Wallets/WalletWrapper.tsx
+++ b/extension/source/Home/Wallet/Wallets/WalletWrapper.tsx
@@ -1,7 +1,7 @@
 import { FunctionComponent } from 'react';
 import useCell from '../../../cells/useCell';
 import Button from '../../../components/Button';
-import { useQuill } from '../../QuillContext';
+import { useQuill } from '../../../QuillContext';
 /* eslint import/no-cycle: "warn" -- TODO (merge-ok) Fix import cycle */
 import { WalletSummary } from './WalletSummary';
 

--- a/extension/source/QuillContext.tsx
+++ b/extension/source/QuillContext.tsx
@@ -1,15 +1,15 @@
 import React, { useMemo } from 'react';
 
-import elcc from '../cells/extensionLocalCellCollection';
-import assert from '../helpers/assert';
-import QuillStorageCells from '../QuillStorageCells';
-import QuillEthereumProvider from '../QuillEthereumProvider';
-import EthersProvider from '../EthersProvider';
-import CellCollection from '../cells/CellCollection';
-import { FormulaCell } from '../cells/FormulaCell';
-import QuillLongPollingCell from '../QuillLongPollingCell';
-import TransformCell from '../cells/TransformCell';
-import forEach from '../cells/forEach';
+import elcc from './cells/extensionLocalCellCollection';
+import assert from './helpers/assert';
+import QuillStorageCells from './QuillStorageCells';
+import QuillEthereumProvider from './QuillEthereumProvider';
+import EthersProvider from './EthersProvider';
+import CellCollection from './cells/CellCollection';
+import { FormulaCell } from './cells/FormulaCell';
+import QuillLongPollingCell from './QuillLongPollingCell';
+import TransformCell from './cells/TransformCell';
+import forEach from './cells/forEach';
 
 export type QuillContextValue = ReturnType<typeof getQuillContextValue>;
 

--- a/extension/source/types/window.d.ts
+++ b/extension/source/types/window.d.ts
@@ -1,7 +1,7 @@
 import type { providers } from 'ethers';
 import type { Browser } from 'webextension-polyfill';
 import type QuillEthereumProvider from '../QuillEthereumProvider';
-import type { QuillContextValue } from '../Home/QuillContext';
+import type { QuillContextValue } from '../QuillContext';
 import QuillStorageCells from '../QuillStorageCells';
 
 declare global {


### PR DESCRIPTION
## What is this PR doing?

See title. This fixes the usage of `any` and also makes future development of the confirm dialog (eg showing currency conversion) easier because we have access to our stuff.

## How can these changes be manually tested?

Check the confirm dialog still works, eg by sending eth within the extension.

## Does this PR resolve or contribute to any issues?

Nope.

## Checklist
- [x] I have manually tested these changes
- [x] Post a link to the PR in the group chat

## Guidelines
- If your PR is not ready, mark it as a draft
- The `resolve conversation` button is for reviewers, not authors
  - (But add a 'done' comment or similar)
