### PR TITLE
Update markup and guidelines in PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -12,7 +12,7 @@
 - [ ] Post a link to the PR in the group chat
 
 # Guidelines
-- Sometimes PRs are a source of conflict, please be mindful of your colleagues
+- Please be careful when handling disagreements and stay mindful of others
 - If your PR is not ready, mark it as a draft
 - Prefer to seek followup instead of requiring changes, especially if the PR is already a clear net improvement
 - If appropriate, consider implementing followup changes yourself instead of waiting for them from the author and open a new PR against this one.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,17 +1,22 @@
-## What is this PR doing?
+# What is this PR doing?
 
 
-## How can these changes be manually tested?
+# How can these changes be manually tested?
 
 
-## Does this PR resolve or contribute to any issues?
+# Does this PR resolve or contribute to any issues?
 
 
-## Checklist
+# Checklist
 - [ ] I have manually tested these changes
 - [ ] Post a link to the PR in the group chat
 
-## Guidelines
+# Guidelines
+- Sometimes PRs are a source of conflict, please be mindful of your colleagues
 - If your PR is not ready, mark it as a draft
+- Prefer to seek followup instead of requiring changes, especially if the PR is
+  already clear improvement overall
+- If appropriate, consider implementing followup changes yourself instead of
+  waiting for them from the original author
 - The `resolve conversation` button is for reviewers, not authors
   - (But add a 'done' comment or similar)

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -15,6 +15,6 @@
 - Sometimes PRs are a source of conflict, please be mindful of your colleagues
 - If your PR is not ready, mark it as a draft
 - Prefer to seek followup instead of requiring changes, especially if the PR is already a clear net improvement
-- If appropriate, consider implementing followup changes yourself instead of waiting for them from the author
+- If appropriate, consider implementing followup changes yourself instead of waiting for them from the author and open a new PR against this one.
 - The `resolve conversation` button is for reviewers, not authors
   - (But add a 'done' comment or similar)

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -14,9 +14,7 @@
 # Guidelines
 - Sometimes PRs are a source of conflict, please be mindful of your colleagues
 - If your PR is not ready, mark it as a draft
-- Prefer to seek followup instead of requiring changes, especially if the PR is
-  already clear improvement overall
-- If appropriate, consider implementing followup changes yourself instead of
-  waiting for them from the original author
+- Prefer to seek followup instead of requiring changes, especially if the PR is already clear improvement overall
+- If appropriate, consider implementing followup changes yourself instead of waiting for them from the original author
 - The `resolve conversation` button is for reviewers, not authors
   - (But add a 'done' comment or similar)

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -14,7 +14,7 @@
 # Guidelines
 - Sometimes PRs are a source of conflict, please be mindful of your colleagues
 - If your PR is not ready, mark it as a draft
-- Prefer to seek followup instead of requiring changes, especially if the PR is already clear improvement overall
-- If appropriate, consider implementing followup changes yourself instead of waiting for them from the original author
+- Prefer to seek followup instead of requiring changes, especially if the PR is already a clear net improvement
+- If appropriate, consider implementing followup changes yourself instead of waiting for them from the author
 - The `resolve conversation` button is for reviewers, not authors
   - (But add a 'done' comment or similar)


### PR DESCRIPTION
# What is this PR doing?

## Uses top-level markdown headings

This allows subheadings to be more prominent, including underlines, as demonstrated here (otherwise probably overkill - dot points are still good).

## Added guidelines

`Please be careful when handling disagreements and stay mindful of others`.

I don't think we've run into this in our team, but I've definitely seen it at other companies and feel something like this is very much worth including.

`Prefer to seek followup instead of requiring changes, especially if the PR is already a clear net improvement`.

I think requiring changes unnecessarily is a very common mistake that creates unnecessary delays. This is trying to address that so that we keep the ball rolling rather than perfecting things before they're added.

Of course, sometimes it is appropriate to require changes instead. Things like bugs and change requests that reduce future merge issues come to mind.

`If appropriate, consider implementing followup changes yourself instead of waiting for them from the author and open a new PR against this one`.

When it makes sense to do this, I really feel this is the ideal way to keep things moving. Like all these things, sometimes it makes less sense ofc, eg changes for the benefit of training, changes that you can't (easily) do yourself, and changes that you don't have time to do yourself.

# How can these changes be manually tested?

Only by merging this PR 😉.

# Does this PR resolve or contribute to any issues?

Nope.

# Checklist
- ~I have manually tested these changes~
- [x] Post a link to the PR in the group chat

# Guidelines
- Sometimes PRs are a source of conflict, please be mindful of your colleagues
- If your PR is not ready, mark it as a draft
- Prefer to seek followup instead of requiring changes, especially if the PR is already a clear net improvement
- If appropriate, consider implementing followup changes yourself instead of waiting for them from the author
- The `resolve conversation` button is for reviewers, not authors
  - (But add a 'done' comment or similar)
