### PR TITLE
When wrapping className, use one class per line

### DIFF
--- a/extension/source/Confirm/Confirm.tsx
+++ b/extension/source/Confirm/Confirm.tsx
@@ -77,7 +77,11 @@ const Confirm: FunctionComponent = () => {
             {current + 1} of {tx.actions?.length}
             <div
               className={[
-                'bg-grey-400 rounded-md p-1 hover:bg-grey-500 cursor-pointer',
+                'bg-grey-400',
+                'rounded-md',
+                'p-1',
+                'hover:bg-grey-500',
+                'cursor-pointer',
               ].join(' ')}
               {...onAction(prevTx)}
             >
@@ -85,7 +89,11 @@ const Confirm: FunctionComponent = () => {
             </div>
             <div
               className={[
-                'bg-grey-400 rounded-md p-1 hover:bg-grey-500 cursor-pointer',
+                'bg-grey-400',
+                'rounded-md',
+                'p-1',
+                'hover:bg-grey-500',
+                'cursor-pointer',
               ].join(' ')}
               {...onAction(nextTx)}
             >
@@ -103,7 +111,13 @@ const Confirm: FunctionComponent = () => {
 
           <div
             className={[
-              'mt-4 p-4 bg-grey-300 rounded-md flex justify-between h-20',
+              'mt-4',
+              'p-4',
+              'bg-grey-300',
+              'rounded-md',
+              'flex',
+              'justify-between',
+              'h-20',
             ].join(' ')}
           >
             <div className="">Total Transaction Fees</div>

--- a/extension/source/Home/Onboarding/OnboardingActionPanel.tsx
+++ b/extension/source/Home/Onboarding/OnboardingActionPanel.tsx
@@ -23,7 +23,13 @@ const OnboardingActionPanel: FunctionComponent = () => {
   return (
     <div
       className={[
-        'h-screen p-32 flex flex-col flex-grow space-y-16 items-center',
+        'h-screen',
+        'p-32',
+        'flex',
+        'flex-col',
+        'flex-grow',
+        'space-y-16',
+        'items-center',
       ].join(' ')}
     >
       <WorkflowNumbers max={3} />

--- a/extension/source/Home/Onboarding/PasswordCreationForm.tsx
+++ b/extension/source/Home/Onboarding/PasswordCreationForm.tsx
@@ -84,23 +84,35 @@ const PasswordCreationForm: FunctionComponent<{
 
   const passwordStrength = measurePasswordStrength(passwordFieldValue);
 
-  const getConfirmPasswordClass = () => {
+  const getConfirmPasswordClasses = () => {
     if (confirmPasswordFieldValue === '') {
-      return '';
+      return [];
     }
+
     if (confirmPasswordFieldValue === passwordFieldValue) {
       return [
-        'border-2 border-positive-500 bg-positive-500',
+        'border-2',
+        'border-positive-500',
+        'bg-positive-500',
         'focus:border-positive-500',
-      ].join(' ');
+      ];
     }
+
     if (passwordFieldValue.startsWith(confirmPasswordFieldValue)) {
       return [
-        'border-2 border-neutral-500 bg-neutral-500',
+        'border-2',
+        'border-neutral-500',
+        'bg-neutral-500',
         'focus:border-neutral-500',
-      ].join(' ');
+      ];
     }
-    return 'border-2 border-alert-500 bg-alert-500 focus:border-alert-500';
+
+    return [
+      'border-2',
+      'border-alert-500',
+      'bg-alert-500',
+      'focus:border-alert-500',
+    ];
   };
 
   return (
@@ -118,8 +130,11 @@ const PasswordCreationForm: FunctionComponent<{
           type="password"
           placeholder="Confirm password"
           className={[
-            'mt-2 bg-opacity-5 border-opacity-25 focus:border-opacity-25',
-            getConfirmPasswordClass(),
+            'mt-2',
+            'bg-opacity-5',
+            'border-opacity-25',
+            'focus:border-opacity-25',
+            ...getConfirmPasswordClasses(),
           ].join(' ')}
           disabled={!passwordFieldValue}
           onInput={(e: ChangeEvent<HTMLInputElement>) => {

--- a/extension/source/Home/Onboarding/ReviewSecretPhrasePanel.tsx
+++ b/extension/source/Home/Onboarding/ReviewSecretPhrasePanel.tsx
@@ -21,28 +21,44 @@ const WordInReview: FunctionComponent<{
 
   const getConfirmWordClass = () => {
     if (guess === '') {
-      return '';
+      return [];
     }
+
     if (guess === word) {
       return [
-        'border-2 border-positive-500 bg-positive-500',
+        'border-2',
+        'border-positive-500',
+        'bg-positive-500',
         'focus:border-positive-500',
-      ].join(' ');
+      ];
     }
+
     if (word.startsWith(guess)) {
       return [
-        'border-2 border-neutral-500 bg-neutral-500 focus:border-neutral-500',
-      ].join(' ');
+        'border-2',
+        'border-neutral-500',
+        'bg-neutral-500',
+        'focus:border-neutral-500',
+      ];
     }
-    return 'border-2 border-alert-500 bg-alert-500 focus:border-alert-500';
+
+    return [
+      'border-2',
+      'border-alert-500',
+      'bg-alert-500',
+      'focus:border-alert-500',
+    ];
   };
 
   return (
     <input
       type="text"
       className={[
-        'mt-2 bg-opacity-5 border-opacity-25 focus:border-opacity-25',
-        getConfirmWordClass(),
+        'mt-2',
+        'bg-opacity-5',
+        'border-opacity-25',
+        'focus:border-opacity-25',
+        ...getConfirmWordClass(),
       ].join(' ')}
       placeholder={`Secret word ${sampleIndex + 1} ${word}`}
       onInput={(e: ChangeEvent<HTMLInputElement>) => {

--- a/extension/source/Home/Onboarding/ViewSecretPhrasePanel.tsx
+++ b/extension/source/Home/Onboarding/ViewSecretPhrasePanel.tsx
@@ -39,7 +39,12 @@ const ViewSecretPhrasePanel: FunctionComponent<{
               {Range(3).map((j) => (
                 <div
                   className={[
-                    'bg-grey-200 w-1/3 mb-2 py-2 px-4 rounded-md',
+                    'bg-grey-200',
+                    'w-1/3',
+                    'mb-2',
+                    'py-2',
+                    'px-4',
+                    'rounded-md',
                     'hover:bg-grey-300',
                   ].join(' ')}
                   key={`column${j}`}

--- a/extension/source/Home/Onboarding/WorkflowNumbers.tsx
+++ b/extension/source/Home/Onboarding/WorkflowNumbers.tsx
@@ -32,8 +32,14 @@ const WorkflowNumbers: FunctionComponent<{
         <div
           key={i}
           className={[
-            'icon-lg rounded-full text-center leading-8 cursor-pointer',
-            i + 1 <= currentPage ? 'bg-blue-500 text-white' : 'text-black',
+            'icon-lg',
+            'rounded-full',
+            'text-center',
+            'leading-8',
+            'cursor-pointer',
+            ...(i + 1 <= currentPage
+              ? ['bg-blue-500', 'text-white']
+              : ['text-black']),
           ].join(' ')}
           {...onAction(() => onSelect(i))}
         >

--- a/extension/source/Home/Wallet/Wallets/AssetsTable.tsx
+++ b/extension/source/Home/Wallet/Wallets/AssetsTable.tsx
@@ -127,7 +127,13 @@ export const AssetsTable: React.FunctionComponent<IAssetsTable> = ({
 
       <div
         className={[
-          'bg-grey-100 px-4 py-2 border-t border-grey-300 flex justify-end',
+          'bg-grey-100',
+          'px-4',
+          'py-2',
+          'border-t',
+          'border-grey-300',
+          'flex',
+          'justify-end',
           'gap-8',
         ].join(' ')}
       >

--- a/extension/source/Home/Wallet/Wallets/SendDetail/AssetSelector.tsx
+++ b/extension/source/Home/Wallet/Wallets/SendDetail/AssetSelector.tsx
@@ -20,9 +20,19 @@ const AssetSelector: FunctionComponent<{
       <div className="grid grid-cols-2 gap-4">
         <div
           className={[
-            'flex flex-row p-4 gap-4 rounded-lg bg-white border',
-            'border-grey-400 shadow-md cursor-pointer active:bg-grey-200',
-            'select-none cursor-pointer',
+            'flex',
+            'flex-row',
+            'p-4',
+            'gap-4',
+            'rounded-lg',
+            'bg-white',
+            'border',
+            'border-grey-400',
+            'shadow-md',
+            'cursor-pointer',
+            'active:bg-grey-200',
+            'select-none',
+            'cursor-pointer',
           ].join(' ')}
           {...onAction(() => selectedAsset.write('ETH'))}
         >

--- a/extension/source/Home/Wallet/Wallets/SendDetail/RecipientSelector.tsx
+++ b/extension/source/Home/Wallet/Wallets/SendDetail/RecipientSelector.tsx
@@ -59,9 +59,19 @@ const RecipientSelector: FunctionComponent<{
             <div
               key={`${r.name}:${r.address}`}
               className={[
-                'flex flex-row p-4 gap-4 rounded-lg bg-white border',
-                'border-grey-400 shadow-md cursor-pointer active:bg-grey-200',
-                'select-none cursor-pointer',
+                'flex',
+                'flex-row',
+                'p-4',
+                'gap-4',
+                'rounded-lg',
+                'bg-white',
+                'border',
+                'border-grey-400',
+                'shadow-md',
+                'cursor-pointer',
+                'active:bg-grey-200',
+                'select-none',
+                'cursor-pointer',
               ].join(' ')}
               {...onAction(() => recipient.write(r.address))}
             >

--- a/extension/source/Home/Wallet/Wallets/WalletSummary.tsx
+++ b/extension/source/Home/Wallet/Wallets/WalletSummary.tsx
@@ -109,8 +109,14 @@ export const WalletSummary: React.FunctionComponent<IWalletSummary> = ({
           {/* <div className="mt-4 flex flex-col gap-3">
             <div
               className={[
-                'bg-blue-100 bg-opacity-30 px-4 py-2 flex gap-2',
-                'place-items-center rounded-md',
+                'bg-blue-100',
+                'bg-opacity-30',
+                'px-4',
+                'py-2',
+                'flex',
+                'gap-2',
+                'place-items-center',
+                'rounded-md'
               ].join(' ')}
             >
               <Circle weight="fill" fill="#689F38" />
@@ -118,8 +124,14 @@ export const WalletSummary: React.FunctionComponent<IWalletSummary> = ({
             </div>
             <div
               className={[
-                'bg-blue-100 bg-opacity-30 px-4 py-2 flex gap-2',
-                'place-items-center rounded-md',
+                'bg-blue-100',
+                'bg-opacity-30',
+                'px-4',
+                'py-2',
+                'flex',
+                'gap-2',
+                'place-items-center',
+                'rounded-md'
               ].join(' ')}
             >
               <Circle weight="fill" fill="#689F38" />
@@ -127,8 +139,14 @@ export const WalletSummary: React.FunctionComponent<IWalletSummary> = ({
             </div>
             <div
               className={[
-                'bg-blue-100 bg-opacity-30 px-4 py-2 flex gap-2',
-                'place-items-center rounded-md',
+                'bg-blue-100',
+                'bg-opacity-30',
+                'px-4',
+                'py-2',
+                'flex',
+                'gap-2',
+                'place-items-center',
+                'rounded-md'
               ].join(' ')}
             >
               <Circle weight="fill" fill="#F44336" />

--- a/extension/source/Home/Wallet/WalletsPage.tsx
+++ b/extension/source/Home/Wallet/WalletsPage.tsx
@@ -78,7 +78,12 @@ export const WalletsPage: React.FunctionComponent = () => (
       {/* summary pane */}
       <div
         className={[
-          'w-1/3 bg-grey-100 border-x border-grey-300 p-8 overflow-y-scroll',
+          'w-1/3',
+          'bg-grey-100',
+          'border-x',
+          'border-grey-300',
+          'p-8',
+          'overflow-y-scroll',
         ].join(' ')}
       >
         <Routes>


### PR DESCRIPTION
## What is this PR doing?

Followup for https://github.com/web3well/bls-wallet/pull/267#discussion_r922880131.

I haven't included `className`s that don't require any wrapping, since that seems very unlikely to be maintained going forward and is probably overkill. If only `className` was just an array 😵.

## How can these changes be manually tested?

Check the UI looks normal. (No visible changes intended).

## Does this PR resolve or contribute to any issues?

Resolves #272.

## Checklist
- [x] I have manually tested these changes
- [x] Post a link to the PR in the group chat

## Guidelines
- If your PR is not ready, mark it as a draft
- The `resolve conversation` button is for reviewers, not authors
  - (But add a 'done' comment or similar)
