### PR TITLE
Adding an encrypted vault to local storage 

### DIFF
--- a/extension/package.json
+++ b/extension/package.json
@@ -37,6 +37,7 @@
     "async-mutex": "^0.3.2",
     "axios": "^0.27.2",
     "bls-wallet-clients": "0.6.0",
+    "browser-passworder": "^2.0.3",
     "bs58check": "^2.1.2",
     "crypto-browserify": "^3.12.0",
     "emoji-log": "^1.0.2",

--- a/extension/source/Home/Onboarding/PasswordCreationPanel.tsx
+++ b/extension/source/Home/Onboarding/PasswordCreationPanel.tsx
@@ -3,11 +3,22 @@ import { FunctionComponent, useState } from 'react';
 
 import Button from '../../components/Button';
 import PasswordCreationForm from './PasswordCreationForm';
+import { useQuill } from '../../QuillContext';
 
 const PasswordCreationPanel: FunctionComponent<{
   onComplete: () => void;
 }> = ({ onComplete }) => {
+  const { cells } = useQuill();
+
   const [password, setPassword] = useState<string>();
+
+  const handleNext = async () => {
+    // Temporary solution to save the password until the phrase
+    // is created. We could create the HDPhrase at the point the
+    // password is created to avoid temporarily storing the password.
+    await cells.onboarding.update({ tempPassword: password });
+    onComplete();
+  };
 
   return (
     <>
@@ -26,7 +37,7 @@ const PasswordCreationPanel: FunctionComponent<{
           className={`w-32 ${
             password === undefined ? 'btn-disabled' : 'btn-primary'
           }`}
-          onPress={() => password && onComplete()}
+          onPress={() => password && handleNext()}
           icon={<ArrowRight className="icon-md" />}
         >
           Continue

--- a/extension/source/Home/Onboarding/ReviewSecretPhrasePanel.tsx
+++ b/extension/source/Home/Onboarding/ReviewSecretPhrasePanel.tsx
@@ -94,10 +94,16 @@ const ReviewSecretPhrasePanel: FunctionComponent<{
   const navigate = useNavigate();
 
   const setHDWalletPhrase = async () => {
+    // Temporary solution to get the password after the phrase
+    // is created. We could create the HDPhrase at the point the
+    // password is created to avoid this.
+    const password = (await cells.onboarding.read()).tempPassword;
+
     await rpc.setHDPhrase(secretPhrase.join(' '));
     const address = await rpc.addHDAccount();
     await rpc.setSelectedAddress(address);
-    await cells.onboarding.update({ completed: true });
+    await rpc.createNewVault(password);
+    await cells.onboarding.update({ completed: true, tempPassword: '' });
 
     navigate('/wallets');
   };

--- a/extension/source/QuillStorageCells.ts
+++ b/extension/source/QuillStorageCells.ts
@@ -26,10 +26,12 @@ function QuillStorageCells(storage: CellCollection) {
       io.type({
         autoOpened: io.boolean,
         completed: io.boolean,
+        tempPassword: io.string,
       }),
       () => ({
         autoOpened: false,
         completed: false,
+        tempPassword: '',
       }),
     ),
     keyring: storage.Cell(
@@ -43,11 +45,13 @@ function QuillStorageCells(storage: CellCollection) {
             address: io.string,
           }),
         ),
+        vault: io.string,
       }),
       () => ({
         HDPhrase: ethers.Wallet.createRandom().mnemonic.phrase,
         nextHDIndex: 0,
         wallets: [],
+        vault: '',
       }),
     ),
     transactions: storage.Cell(

--- a/extension/source/background/KeyringController.ts
+++ b/extension/source/background/KeyringController.ts
@@ -1,5 +1,7 @@
 import { BlsWalletWrapper } from 'bls-wallet-clients';
 import { ethers } from 'ethers';
+import encryptor from 'browser-passworder';
+
 import generateRandomHex from '../helpers/generateRandomHex';
 import { NETWORK_CONFIG } from '../env';
 import QuillStorageCells from '../QuillStorageCells';
@@ -98,6 +100,21 @@ export default class KeyringController {
       );
 
       await this.keyring.update({ wallets: newWallets });
+    },
+
+    createNewVault: async ({ params: [password] }) => {
+      const { HDPhrase, nextHDIndex } = await this.keyring.read();
+      const HDPath = "m/44'/60'/0'/0";
+
+      const vaultData = {
+        HDPhrase,
+        HDPath,
+        numberOfAccounts: nextHDIndex,
+      };
+
+      const encryptedString = await encryptor.encrypt(password, vaultData);
+
+      await this.keyring.update({ vault: encryptedString });
     },
   });
 

--- a/extension/source/background/QuillController.ts
+++ b/extension/source/background/QuillController.ts
@@ -157,6 +157,7 @@ export default class QuillController {
       setHDPhrase: this.keyringController.rpc.setHDPhrase,
       lookupPrivateKey: this.keyringController.rpc.lookupPrivateKey,
       removeAccount: this.keyringController.rpc.removeAccount,
+      createNewVault: this.keyringController.rpc.createNewVault,
 
       // TransactionsController
       createTransaction: this.transactionsController.rpc.createTransaction,

--- a/extension/source/types/Rpc.ts
+++ b/extension/source/types/Rpc.ts
@@ -159,6 +159,11 @@ export const rpcMap = {
     Params: io.tuple([io.string]),
     Response: io.void,
   },
+  createNewVault: {
+    origin: '<quill>',
+    Params: io.tuple([io.string]),
+    Response: io.void,
+  },
 
   // TransactionController
 

--- a/extension/source/types/browser-passworder.d.ts
+++ b/extension/source/types/browser-passworder.d.ts
@@ -1,0 +1,1 @@
+declare module 'browser-passworder';

--- a/extension/yarn.lock
+++ b/extension/yarn.lock
@@ -2692,6 +2692,13 @@ brorand@^1.0.1, brorand@^1.1.0:
   resolved "https://registry.yarnpkg.com/brorand/-/brorand-1.1.0.tgz#12c25efe40a45e3c323eb8675a0a0ce57b22371f"
   integrity sha512-cKV8tMCEpQs4hK/ik71d6LrPOnpkpGBR0wzxqr68g2m/LB2GxVYQroAjMJZRVM1Y4BCjCKc3vAamxSzOY2RP+w==
 
+browser-passworder@^2.0.3:
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/browser-passworder/-/browser-passworder-2.0.3.tgz#6fdd2082e516a176edbcb3dcee0b7f9fce4f7917"
+  integrity sha512-8mTcGjsVqYkRW0qLmdussBjf/5joBUpvZfR8jUojITBJVVZIS5BL41Qt/xehS+n2ChA2YJHHLPhlkXziK+gvsw==
+  dependencies:
+    browserify-unibabel "^3.0.0"
+
 browserify-aes@^1.0.0, browserify-aes@^1.0.4, browserify-aes@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/browserify-aes/-/browserify-aes-1.2.0.tgz#326734642f403dabc3003209853bb70ad428ef48"
@@ -2745,6 +2752,11 @@ browserify-sign@^4.0.0:
     parse-asn1 "^5.1.5"
     readable-stream "^3.6.0"
     safe-buffer "^5.2.0"
+
+browserify-unibabel@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/browserify-unibabel/-/browserify-unibabel-3.0.0.tgz#5a6b8f0f704ce388d3927df47337e25830f71dda"
+  integrity sha512-j3MX0k2dC1/DEo9jSUyj7zpv5wLd1+klpFwYlM0E5mr7MX6LblQOWb+jkBEKV2iRszmhJuLHAtNuqranlGnpNQ==
 
 browserslist@^4.0.0, browserslist@^4.14.5, browserslist@^4.16.6, browserslist@^4.20.2, browserslist@^4.20.3, browserslist@^4.21.2:
   version "4.21.2"


### PR DESCRIPTION
## What is this PR doing?

Adding a vault to local storage.  The vault is an encrypted string (encrypted with the users pw) that contains the `HDPhrase`, `HDPath`, and the `numberOfAccounts`.  My understanding from looking into stuff the past couple days is if you have the three of those you can always recreate the Private and Public keys.

This PR is in draft because I want to confirm that this is the direction we want to go with this.  Some next steps I could think of if we go this way.

1.  Update the onboarding flow so we don't have to temporarily store the password in local storage.
2. Remove all private keys from local storage.  They should not be persisted and should only be in memory or the user must re-enter their password.
3. Update existing logic to keep the vault up to date with edits to a users wallet (like adding a new address).

## How can these changes be manually tested?

Yes.  There should be no visible changes.  After creating the account you should be able to see the vault in local storage.

## Does this PR resolve or contribute to any issues?

[277](https://github.com/web3well/bls-wallet/issues/277)

## Checklist
- [x] I have manually tested these changes
- [x] Post a link to the PR in the group chat

## Guidelines
- If your PR is not ready, mark it as a draft
- The `resolve conversation` button is for reviewers, not authors
  - (But add a 'done' comment or similar)
