### PR TITLE
Switch extension upload to more relevant GH action

### DIFF
--- a/.github/actions/build-upload-extension/action.yml
+++ b/.github/actions/build-upload-extension/action.yml
@@ -39,9 +39,10 @@ runs:
       shell: bash
       run: mv ./extension/${{ inputs.file-name }} ./extension/quill-${{ inputs.file-name }}
 
-    - uses: softprops/action-gh-release@v1
+    - uses: svenstaro/upload-release-action@v2
       with:
-        tag_name: ${{ inputs.tag-name }}
+        tag: ${{ inputs.tag-name }}
         # Note: This path is from repo root
-        # working-directory is not applied 
-        files: ./extension/extension/quill-${{ inputs.file-name }}
+        # working-directory is not applied
+        file: ./extension/extension/quill-${{ inputs.file-name }}
+        overwrite: true


### PR DESCRIPTION
## What is this PR doing?

Fixing extension artifact uploads to releases by using a GH action that works better with uploading files to existing releases.

## How can these changes be manually tested?

- Create an empty prerelease targeting this branch.
- Ensure the extension archives are uploaded to the release.

See https://github.com/web3well/bls-wallet/actions/runs/2794472651 for a previous run.

## Does this PR resolve or contribute to any issues?

No

## Checklist
- [x] I have manually tested these changes
- [x] Post a link to the PR in the group chat

## Guidelines
- If your PR is not ready, mark it as a draft
- The `resolve conversation` button is for reviewers, not authors
  - (But add a 'done' comment or similar)
