### PR TITLE
Ignore watching node_modules during extension dev

### DIFF
--- a/docs/local_development.md
+++ b/docs/local_development.md
@@ -90,6 +90,20 @@ cd ../extension
 yarn link bls-wallet-clients
 ```
 
+If you would like live updates to from the clients package to trigger reloads of the extension, be sure to comment out this section of `./extension/weback.config.js`:
+```javascript
+...
+module.exports = {
+  ...
+  watchOptions: {
+    // Remove this if you want to watch for changes
+    // from a linked package, such as bls-wallet-clients.
+    ignored: /node_modules/,
+  },
+  ...
+};
+```
+
 ### aggregator
 
 You will need to push up an `@experimental` version to 'bls-wallet-clients' on npm and update the version in `./aggregtor/src/deps.ts` until a local linking solution for deno is found. See https://github.com/alephjs/esm.sh/discussions/216 for details.

--- a/extension/webpack.config.js
+++ b/extension/webpack.config.js
@@ -56,6 +56,11 @@ const networkConfigPath =
 
 module.exports = {
   devtool: 'source-map', // https://github.com/webpack/webpack/issues/1194#issuecomment-560382342
+  watchOptions: {
+    // Remove this if you want to watch for changes
+    // from a linked package, such as bls-wallet-clients.
+    ignored: /node_modules/,
+  },
 
   stats: {
     all: false,


### PR DESCRIPTION
## What is this PR doing?

Ignoring `node_modules` when watching files with webpack dev. Some OS's (such as Ubuntu) have lower file watch limits by default. It also seems unnecessary to have the overhead of watching those files in most cases. I added comments & setup instructions for how to turn it off if you need to `yarn link bls-wallet-clients`.

## How can these changes be manually tested?

```sh
cd ./extension
yarn
yarn dev:chrome # or another browser
```

## Does this PR resolve or contribute to any issues?

No

## Checklist
- [x] I have manually tested these changes
- [x] Post a link to the PR in the group chat

## Guidelines
- If your PR is not ready, mark it as a draft
- The `resolve conversation` button is for reviewers, not authors
  - (But add a 'done' comment or similar)
