### PR TITLE
Add checkout commands to contract deployment and explanation

### DIFF
--- a/docs/local_development.md
+++ b/docs/local_development.md
@@ -47,8 +47,12 @@ yarn hardhat fundDeployer --network gethDev
 
 Deploy all `bls-wallet` contracts.
 ```sh
+git checkout 45def922036c441aa1559419470a131de3ce8ae4
 yarn hardhat run scripts/deploy_all.ts --network gethDev
+git checkout - # Switches back to the previous branch
 ```
+
+***Note***: We currently advise deploying contracts from version 45def9 using the `checkout` commands above for compatibility with the extension and contracts deployed to arbitrum testnet. This isn't necessary if you're working on the contracts in isolation or otherwise know how to workaround this issue. This should be improved in the future. [More information](https://github.com/web3well/bls-wallet/issues/295).
 
 ## Run
 


### PR DESCRIPTION
## What is this PR doing?

Currently if you deploy contracts from `main` they are incompatible with the extension. This resolves that by including instructions to deploy the compatible version of the contracts.

It's just a temporary fix until we start cutting releases for the contracts:
https://github.com/web3well/bls-wallet/issues/295#issuecomment-1216127340

## How can these changes be manually tested?

Follow instructions for [local development](https://github.com/web3well/bls-wallet/blob/main/docs/local_development.md) and make an ETH transfer in the extension.

## Does this PR resolve or contribute to any issues?

Contributes (but does not resolve) #295.

## Checklist
- [x] I have manually tested these changes
- [x] Post a link to the PR in the group chat

## Guidelines
- If your PR is not ready, mark it as a draft
- The `resolve conversation` button is for reviewers, not authors
  - (But add a 'done' comment or similar)
