### PR TITLE
4337 exploration

### DIFF
--- a/contracts/clients/src/BlsWalletWrapper.ts
+++ b/contracts/clients/src/BlsWalletWrapper.ts
@@ -57,6 +57,7 @@ export default class BlsWalletWrapper {
     const initFunctionParams =
       BLSWallet__factory.createInterface().encodeFunctionData("initialize", [
         verificationGatewayAddress,
+        ethers.constants.AddressZero, // TODO: 4337 EntryPoint address
       ]);
 
     return ethers.utils.getCreate2Address(

--- a/contracts/contracts/VerificationGateway.sol
+++ b/contracts/contracts/VerificationGateway.sol
@@ -358,7 +358,7 @@ contract VerificationGateway
     }
 
     function getInitializeData() private view returns (bytes memory) {
-        return abi.encodeWithSignature("initialize(address)", address(this));
+        return abi.encodeWithSignature("initialize(address,address)", address(this), address(0));
     }
 
     modifier onlyWallet(bytes32 hash) {

--- a/contracts/contracts/interfaces/IWallet.sol
+++ b/contracts/contracts/interfaces/IWallet.sol
@@ -17,7 +17,7 @@ interface IWallet {
         bytes encodedFunction;
     }
 
-    function initialize(address gateway) external;
+    function initialize(address gateway, address entryPoint) external;
     function nonce() external returns (uint256);
 
     function performOperation(

--- a/contracts/contracts/interfaces/UserOperation4337.sol
+++ b/contracts/contracts/interfaces/UserOperation4337.sol
@@ -1,0 +1,16 @@
+//SPDX-License-Identifier: Unlicense
+pragma solidity >=0.8.4 <0.9.0;
+
+struct UserOperation4337 {
+    address sender;
+    uint256 nonce;
+    bytes initCode;
+    bytes callData;
+    uint256 callGasLimit;
+    uint256 verificationGasLimit;
+    uint256 preVerificationGas;
+    uint256 maxFeePerGas;
+    uint256 maxPriorityFeePerGas;
+    bytes paymasterAndData;
+    bytes signature;
+}

--- a/contracts/hardhat.config.ts
+++ b/contracts/hardhat.config.ts
@@ -107,7 +107,7 @@ const config: HardhatUserConfig = {
     hardhat: {
       initialBaseFeePerGas: 0, // workaround from https://github.com/sc-forks/solidity-coverage/issues/652#issuecomment-896330136 . Remove when that issue is closed.
       accounts,
-      blockGasLimit: 30_000_000,
+      blockGasLimit: 200_000_000,
     },
     gethDev: {
       url: `http://localhost:8545`,


### PR DESCRIPTION
## What is this PR doing?

*These are early ideas and not intended for merging at this stage.*

This is a draft of how we might integrate [eth-infinitism's version of 4337](https://github.com/eth-infinitism/account-abstraction/blob/develop/eip/EIPS/eip-4337.md). I'm referencing this version specifically because the [official EIP](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-4337.md) doesn't currently have the signature aggregation support we need.

A wallet integrating us as a 4337 wallet would still need to understand how to rewrite a transaction as (or otherwise generate) a [`UserOperation`](https://github.com/eth-infinitism/account-abstraction/blob/42b643c/contracts/interfaces/UserOperation.sol#L19-L32) (aka [`UserOperation4337`](https://github.com/web3well/bls-wallet/blob/2e68505/contracts/contracts/interfaces/UserOperation4337.sol)). Critically, this means knowing how to do a BLS signature.

A `UserOperation` looks like this:

```solidity
    struct UserOperation {

        address sender;
        uint256 nonce;
        bytes initCode;
        bytes callData;
        uint256 callGasLimit;
        uint256 verificationGasLimit;
        uint256 preVerificationGas;
        uint256 maxFeePerGas;
        uint256 maxPriorityFeePerGas;
        bytes paymasterAndData;
        bytes signature;
    }
```
https://github.com/eth-infinitism/account-abstraction/blob/42b643c/contracts/interfaces/UserOperation.sol#L19-L32

Gas is a big thing we're doing differently. Currently our idea is still to reward `tx.origin` in an unspecified way (ie `tx.origin` just detects that they'll get paid by simulating the tx), so we'd be opting out of the 4337 gas mechanisms by setting gas limits high and fee per gas fields to zero.

`initCode` can be left as an empty byte array, but it means doing the creation step explicitly.

`callData` is an encoded call to [`BLSWallet#performOperation`](https://github.com/web3well/bls-wallet/blob/2e68505/contracts/contracts/BLSWallet.sol#L148) which has been changed to allow calls from the 4337 entry point as well as the verification gateway.

`signature` is the result of signing the `UserOperation` with an empty `signature` field (TODO: there's a bit of a wrinkle here, need to update based on `requestId`). (Note: This means signing for a 4337 `UserOperation` is different for signing an equivalent `Bundle`. It might be possible to make these signatures equal but it would mean doing more data wrangling on-chain which means more gas and it doesn't seem to have much benefit (might need to prevent collisions by using a different bls domain though).)

As it stands, when these `UserOperation`s go into the mempool they won't work out-of-the-box with clients designed for 4337 for two reasons:
- We're not explicitly offering any gas compensation
- 4337 relies on on-chain code for defining how the off-chain signature aggregation works ([ref](https://github.com/eth-infinitism/account-abstraction/blob/8083c53/eip/EIPS/eip-4337.md?plain=1#L126-L128)), and we're not supplying that on-chain code right now (it's missing from blsLib but can hopefully be added)

This means that we either need to:
- convince 4337 implementers (in clients aka nodes) to also implement our alternative reward mechanism and specifically add BLS signature aggregation
- OR add independent nodes that find our `UserOperation`s and aggregate+submit them (ie - something like the aggregator we have now)
- OR pivot to 4337's gas compensation (and just being a 4337 wallet in general?) and add the on-chain BLS signature aggregation code ([ref](https://github.com/eth-infinitism/account-abstraction/blob/8083c53/eip/EIPS/eip-4337.md?plain=1#L126-L128))

## How can these changes be manually tested?

NA

## Does this PR resolve or contribute to any issues?

Nope.

## Checklist
- ~[ ] I have manually tested these changes~
- [x] Post a link to the PR in the group chat

## Guidelines
- If your PR is not ready, mark it as a draft
- The `resolve conversation` button is for reviewers, not authors
  - (But add a 'done' comment or similar)
