### PR TITLE
Import pre-existing seed phrase during Onboarding

### DIFF
--- a/extension/source/Home/Onboarding/SecretPhrasePanel.tsx
+++ b/extension/source/Home/Onboarding/SecretPhrasePanel.tsx
@@ -17,8 +17,8 @@ const SecretPhrasePanel: FunctionComponent<{
     setMnemonic(mnemonicPhrase.split(' '));
   };
 
-  const validateAndSetMnemonic = (mnemonic: string) => {
-    const split = mnemonic.split(' ');
+  const validateAndSetMnemonic = (m: string) => {
+    const split = m.split(' ');
     if (split.length === 12) {
       setMnemonic(split);
     }

--- a/extension/source/Home/Onboarding/SecretPhrasePanel.tsx
+++ b/extension/source/Home/Onboarding/SecretPhrasePanel.tsx
@@ -1,4 +1,4 @@
-import { ethers, wordlists } from 'ethers';
+import { ethers } from 'ethers';
 import { FunctionComponent, useEffect, useState } from 'react';
 import { FilePlus, Cardholder, Warning } from 'phosphor-react';
 import Button from '../../components/Button';
@@ -23,7 +23,7 @@ const SecretPhrasePanel: FunctionComponent<{
       try {
         ethers.Wallet.fromMnemonic(mnemonicInput);
         setError(false);
-      } catch (error) {
+      } catch (e) {
         setError(true);
       }
     }
@@ -89,7 +89,18 @@ const SecretPhrasePanel: FunctionComponent<{
             )}
 
             {error && (
-              <div className="bg-alert-400 p-4 mt-4 text-[10pt] rounded-md flex gap-4 bg-opacity-20">
+              <div
+                className={[
+                  'bg-alert-400',
+                  'p-4',
+                  'mt-4',
+                  'text-[10pt]',
+                  'rounded-md',
+                  'flex',
+                  'gap-4',
+                  'bg-opacity-20',
+                ].join(' ')}
+              >
                 <Warning className="text-alert-500 mt-1" size={64} />
                 <div className="align-text-top">
                   Please enter correct 12 word mnemonic compatible with BIP-39

--- a/extension/source/Home/Onboarding/SecretPhrasePanel.tsx
+++ b/extension/source/Home/Onboarding/SecretPhrasePanel.tsx
@@ -1,5 +1,7 @@
 import { ethers } from 'ethers';
-import { FunctionComponent, useEffect, useState } from 'react';
+import { FunctionComponent, useState } from 'react';
+import { FilePlus, Cardholder } from 'phosphor-react';
+import Button from '../../components/Button';
 
 import ReviewSecretPhrasePanel from './ReviewSecretPhrasePanel';
 import ViewSecretPhrasePanel from './ViewSecretPhrasePanel';
@@ -8,14 +10,69 @@ const SecretPhrasePanel: FunctionComponent<{
   secretPhrase?: string[];
 }> = () => {
   const [mnemonic, setMnemonic] = useState<string[]>([]);
+  const [mnemonicInput, setMnemonicInput] = useState<string>('');
 
-  useEffect(() => {
+  const createMnemonic = () => {
     const mnemonicPhrase = ethers.Wallet.createRandom().mnemonic.phrase;
     setMnemonic(mnemonicPhrase.split(' '));
-  }, []);
+  };
+
+  const validateAndSetMnemonic = (mnemonic: string) => {
+    const split = mnemonic.split(' ');
+    if (split.length === 12) {
+      setMnemonic(split);
+    }
+  };
 
   const [inReview, setInReview] = useState(false);
 
+  if (mnemonic.length === 0) {
+    return (
+      <div className="">
+        <div className="mb-10">
+          <div className="font-bold">One Last step!</div>
+          <span>
+            You can use an existing seed phrase to generate BLS keypair,
+            Otherwise we will create a new fresh one for you
+          </span>
+        </div>
+
+        <div className="flex flex-col justify-center align-middle gap-3">
+          <Button
+            className="btn-primary"
+            onPress={createMnemonic}
+            iconLeft={<FilePlus size={20} />}
+          >
+            Generate New
+          </Button>
+
+          <div className="text-center text-grey-800"> - OR - </div>
+
+          <div className="">
+            <textarea
+              className={[
+                'mt-2',
+                'bg-opacity-5',
+                'border-opacity-25',
+                'focus:border-opacity-25',
+              ].join(' ')}
+              placeholder="12 word Mnemonic (space separated)"
+              onChange={(e) => {
+                setMnemonicInput(e.target.value);
+              }}
+            />
+            <Button
+              className="btn-secondary"
+              onPress={() => validateAndSetMnemonic(mnemonicInput)}
+              iconLeft={<Cardholder size={20} />}
+            >
+              Use Existing Mnemonic
+            </Button>
+          </div>
+        </div>
+      </div>
+    );
+  }
   if (!inReview) {
     return (
       <ViewSecretPhrasePanel

--- a/extension/source/Home/Onboarding/SecretPhrasePanel.tsx
+++ b/extension/source/Home/Onboarding/SecretPhrasePanel.tsx
@@ -1,6 +1,6 @@
-import { ethers } from 'ethers';
-import { FunctionComponent, useState } from 'react';
-import { FilePlus, Cardholder } from 'phosphor-react';
+import { ethers, wordlists } from 'ethers';
+import { FunctionComponent, useEffect, useState } from 'react';
+import { FilePlus, Cardholder, Warning } from 'phosphor-react';
 import Button from '../../components/Button';
 
 import ReviewSecretPhrasePanel from './ReviewSecretPhrasePanel';
@@ -11,6 +11,23 @@ const SecretPhrasePanel: FunctionComponent<{
 }> = () => {
   const [mnemonic, setMnemonic] = useState<string[]>([]);
   const [mnemonicInput, setMnemonicInput] = useState<string>('');
+  const [error, setError] = useState<boolean>(false);
+
+  useEffect(() => {
+    if (mnemonicInput !== '') {
+      if (mnemonicInput.split(' ').length !== 12) {
+        setError(true);
+        return;
+      }
+
+      try {
+        ethers.Wallet.fromMnemonic(mnemonicInput);
+        setError(false);
+      } catch (error) {
+        setError(true);
+      }
+    }
+  }, [mnemonicInput]);
 
   const createMnemonic = () => {
     const mnemonicPhrase = ethers.Wallet.createRandom().mnemonic.phrase;
@@ -19,7 +36,7 @@ const SecretPhrasePanel: FunctionComponent<{
 
   const validateAndSetMnemonic = (m: string) => {
     const split = m.split(' ');
-    if (split.length === 12) {
+    if (!error) {
       setMnemonic(split);
     }
   };
@@ -56,18 +73,30 @@ const SecretPhrasePanel: FunctionComponent<{
                 'border-opacity-25',
                 'focus:border-opacity-25',
               ].join(' ')}
-              placeholder="12 word Mnemonic (space separated)"
+              placeholder="existing 12 word Mnemonic (space separated)"
               onChange={(e) => {
                 setMnemonicInput(e.target.value);
               }}
             />
-            <Button
-              className="btn-secondary"
-              onPress={() => validateAndSetMnemonic(mnemonicInput)}
-              iconLeft={<Cardholder size={20} />}
-            >
-              Use Existing Mnemonic
-            </Button>
+            {mnemonicInput !== '' && !error && (
+              <Button
+                className="btn-secondary"
+                onPress={() => validateAndSetMnemonic(mnemonicInput)}
+                iconLeft={<Cardholder size={20} />}
+              >
+                Use Existing Mnemonic
+              </Button>
+            )}
+
+            {error && (
+              <div className="bg-alert-400 p-4 mt-4 text-[10pt] rounded-md flex gap-4 bg-opacity-20">
+                <Warning className="text-alert-500 mt-1" size={64} />
+                <div className="align-text-top">
+                  Please enter correct 12 word mnemonic compatible with BIP-39
+                  standard, separated by space.
+                </div>
+              </div>
+            )}
           </div>
         </div>
       </div>


### PR DESCRIPTION
## What is this PR doing?
Adds ability to use existing seed phrase during wallet generation
<img width="531" alt="Screenshot 2022-10-16 at 9 01 14 PM" src="https://user-images.githubusercontent.com/23727056/196044064-35c3fdfa-17d2-4a2f-90c7-604754a2f990.png">


## How can these changes be manually tested?
pull latest version, remove older extension, import again, use any seed

## Does this PR resolve or contribute to any issues?
closes #318 

## Checklist
- [x] I have manually tested these changes
- [ ] Post a link to the PR in the group chat

## Guidelines
- If your PR is not ready, mark it as a draft
- The `resolve conversation` button is for reviewers, not authors
  - (But add a 'done' comment or similar)
