### PR TITLE
Fix encodedFunction type and update client pins

### DIFF
--- a/aggregator-proxy/package.json
+++ b/aggregator-proxy/package.json
@@ -21,7 +21,7 @@
     "@types/koa__cors": "^3.3.0",
     "@types/koa__router": "^8.0.11",
     "@types/node-fetch": "^2.6.1",
-    "bls-wallet-clients": "0.8.0-bc3d146",
+    "bls-wallet-clients": "0.8.0-940dd11",
     "fp-ts": "^2.12.1",
     "io-ts": "^2.2.16",
     "io-ts-reporters": "^2.0.1",

--- a/aggregator-proxy/yarn.lock
+++ b/aggregator-proxy/yarn.lock
@@ -885,10 +885,10 @@ bech32@1.1.4:
   resolved "https://registry.yarnpkg.com/bech32/-/bech32-1.1.4.tgz#e38c9f37bf179b8eb16ae3a772b40c356d4832e9"
   integrity sha512-s0IrSOzLlbvX7yp4WBfPITzpAU8sqQcpsmwXDiKwrG4r491vwCO/XpejasRNl0piBMe/DvP4Tz0mIS/X1DPJBQ==
 
-bls-wallet-clients@0.8.0-bc3d146:
-  version "0.8.0-bc3d146"
-  resolved "https://registry.yarnpkg.com/bls-wallet-clients/-/bls-wallet-clients-0.8.0-bc3d146.tgz#2e9343607f30c3891c616e0b77f4e00a12774c52"
-  integrity sha512-DgFPCVCLZ1xqBpLqztI0PldBZc3s37wm1LBqGvHQqcJfjRHP+DO6wahq7BtoiZ5sz7SeMiORCkFWPdh3rlaF0w==
+bls-wallet-clients@0.8.0-940dd11:
+  version "0.8.0-940dd11"
+  resolved "https://registry.yarnpkg.com/bls-wallet-clients/-/bls-wallet-clients-0.8.0-940dd11.tgz#6488e58b1fad12e577ec06d10a3c4f9763c1e395"
+  integrity sha512-f5zqGf5dAq7IPXbrsNLdvEX0lJx2/7DBOqbkvHABGEWEKnHd32tMKDZxUeGt/cPV+2W0nKmQk3uYPNGCEuC6EA==
   dependencies:
     "@thehubbleproject/bls" "^0.5.1"
     ethers "5.5.4"

--- a/aggregator/deps.ts
+++ b/aggregator/deps.ts
@@ -49,7 +49,7 @@ export type {
   PublicKey,
   Signature,
   VerificationGateway,
-} from "https://esm.sh/bls-wallet-clients@0.8.0-bc3d146";
+} from "https://esm.sh/bls-wallet-clients@0.8.0-940dd11";
 
 export {
   Aggregator as AggregatorClient,
@@ -59,10 +59,10 @@ export {
   getConfig,
   MockERC20__factory,
   VerificationGateway__factory,
-} from "https://esm.sh/bls-wallet-clients@0.8.0-bc3d146";
+} from "https://esm.sh/bls-wallet-clients@0.8.0-940dd11";
 
 // Workaround for esbuild's export-star bug
-import blsWalletClients from "https://esm.sh/bls-wallet-clients@0.8.0-bc3d146";
+import blsWalletClients from "https://esm.sh/bls-wallet-clients@0.8.0-940dd11";
 const {
   bundleFromDto,
   bundleToDto,

--- a/contracts/clients/src/signer/types.ts
+++ b/contracts/clients/src/signer/types.ts
@@ -1,9 +1,9 @@
-import { BigNumberish } from "ethers";
+import { BigNumberish, BytesLike } from "ethers";
 
 export type ActionData = {
   ethValue: BigNumberish;
   contractAddress: string;
-  encodedFunction: string;
+  encodedFunction: BytesLike;
 };
 
 export type Operation = {

--- a/extension/package.json
+++ b/extension/package.json
@@ -36,7 +36,7 @@
     "advanced-css-reset": "^1.2.2",
     "async-mutex": "^0.3.2",
     "axios": "^0.27.2",
-    "bls-wallet-clients": "0.8.0-bc3d146",
+    "bls-wallet-clients": "0.8.0-940dd11",
     "browser-passworder": "^2.0.3",
     "bs58check": "^2.1.2",
     "crypto-browserify": "^3.12.0",

--- a/extension/yarn.lock
+++ b/extension/yarn.lock
@@ -2649,10 +2649,10 @@ blakejs@^1.1.0:
   resolved "https://registry.yarnpkg.com/blakejs/-/blakejs-1.2.1.tgz#5057e4206eadb4a97f7c0b6e197a505042fc3814"
   integrity sha512-QXUSXI3QVc/gJME0dBpXrag1kbzOqCjCX8/b54ntNyW6sjtoqxqRk3LTmXzaJoh71zMsDCjM+47jS7XiwN/+fQ==
 
-bls-wallet-clients@0.8.0-bc3d146:
-  version "0.8.0-bc3d146"
-  resolved "https://registry.yarnpkg.com/bls-wallet-clients/-/bls-wallet-clients-0.8.0-bc3d146.tgz#2e9343607f30c3891c616e0b77f4e00a12774c52"
-  integrity sha512-DgFPCVCLZ1xqBpLqztI0PldBZc3s37wm1LBqGvHQqcJfjRHP+DO6wahq7BtoiZ5sz7SeMiORCkFWPdh3rlaF0w==
+bls-wallet-clients@0.8.0-940dd11:
+  version "0.8.0-940dd11"
+  resolved "https://registry.yarnpkg.com/bls-wallet-clients/-/bls-wallet-clients-0.8.0-940dd11.tgz#6488e58b1fad12e577ec06d10a3c4f9763c1e395"
+  integrity sha512-f5zqGf5dAq7IPXbrsNLdvEX0lJx2/7DBOqbkvHABGEWEKnHd32tMKDZxUeGt/cPV+2W0nKmQk3uYPNGCEuC6EA==
   dependencies:
     "@thehubbleproject/bls" "^0.5.1"
     ethers "5.5.4"


### PR DESCRIPTION
## What is this PR doing?

- Fixes type of `ActionData.encodedFunction`
- Updates pinned versions of `bls-wallet-clients` (unlike [this similar recent PR](https://github.com/web3well/bls-wallet/pull/393), a new deployment was not needed because the contracts haven't changed)

When typechain was updated, we had to switch from the inferred type of `Operation` to our explicit types, which meant that `ActionData.encodedFunction` went from `BytesLike` to `string`.

This caused the following code to break:
https://github.com/web3well/bls-wallet/blob/02298b8/aggregator/test/EthereumService.test.ts#L247

And in general, `BytesLike` is a better interface since it also allows the user to use `Uint8Array` (as well as strings beginning with `0x`).

## How can these changes be manually tested?

- Test `EthereumService.test.ts`
- Run aggregator+extension and do a transfer

## Does this PR resolve or contribute to any issues?

Resolves https://github.com/web3well/bls-wallet/issues/396.

## Checklist
- [x] I have manually tested these changes
- [x] Post a link to the PR in the group chat

## Guidelines
- If your PR is not ready, mark it as a draft
- The `resolve conversation` button is for reviewers, not authors
  - (But add a 'done' comment or similar)
