### PR TITLE
Export decode error function from the client module

### DIFF
--- a/contracts/clients/README.md
+++ b/contracts/clients/README.md
@@ -83,7 +83,7 @@ await verificationGateway.processBundle(bundle);
 You can get the results of the operations in a bundle using `getOperationResults`.
 
 ```ts
-import { getOperationResults } from 'bls-wallet-clients';
+import { getOperationResults, decodeError } from 'bls-wallet-clients';
 
 ...
 
@@ -96,6 +96,13 @@ const opResults = getOperationResults(txnReceipt);
 const { error } = opResults[0];
 console.log(error?.actionIndex); // ex. 0 (as BigNumber)
 console.log(error?.message); // ex. "some require failure message"
+
+// If you want more granular ability to decode an error message
+// you can use the decodeError function.
+const errorData = '0x5c66760100000000.............000000000000';
+const opResultError = decodeError(errorData);
+console.log(opResultError.actionIndex); // ex. 0 (as BigNumber)
+console.log(opResultError.message); // ex. "ERC20: insufficient allowance"
 ```
 
 ## Signer

--- a/contracts/clients/src/OperationResults.ts
+++ b/contracts/clients/src/OperationResults.ts
@@ -33,7 +33,13 @@ export type OperationResult = {
   error?: OperationResultError;
 };
 
-export const decodeError = (errorData: string) => {
+/**
+ * Checks if a operation result error string is valid and returns
+ * the decoded error.
+ *
+ * @param errorData An error string returned by an operation result.
+ */
+export const decodeError = (errorData: string): OperationResultError => {
   if (!errorData.startsWith(errorSelectors.ActionError)) {
     throw new Error(
       [

--- a/contracts/clients/src/OperationResults.ts
+++ b/contracts/clients/src/OperationResults.ts
@@ -19,7 +19,7 @@ const actionErrorId = utils
 
 assert(actionErrorId === "0x5c667601");
 
-type OperationResultError = {
+export type OperationResultError = {
   actionIndex?: BigNumber;
   message: string;
 };
@@ -28,23 +28,12 @@ export type OperationResult = {
   walletAddress: string;
   nonce: BigNumber;
   actions: ActionData[];
-  success: Boolean;
+  success: boolean;
   results: string[];
   error?: OperationResultError;
 };
 
-const getError = (
-  success: boolean,
-  results: string[],
-): OperationResultError | undefined => {
-  if (success) {
-    return undefined;
-  }
-
-  // Single event "WalletOperationProcessed(address indexed wallet, uint256 nonce, bool success, bytes[] results)"
-  // Get the first (only) result from "results" argument.
-  const [errorData] = results;
-
+export const decodeError = (errorData: string) => {
   if (!errorData.startsWith(errorSelectors.ActionError)) {
     throw new Error(
       [
@@ -95,6 +84,21 @@ const getError = (
     actionIndex,
     message,
   };
+};
+
+const getError = (
+  success: boolean,
+  results: string[],
+): OperationResultError | undefined => {
+  if (success) {
+    return undefined;
+  }
+
+  // Single event "WalletOperationProcessed(address indexed wallet, uint256 nonce, bool success, bytes[] results)"
+  // Get the first (only) result from "results" argument.
+  const [errorData] = results;
+
+  return decodeError(errorData);
 };
 
 export const getOperationResults = (

--- a/contracts/clients/src/index.ts
+++ b/contracts/clients/src/index.ts
@@ -24,7 +24,12 @@ import {
   validateMultiConfig,
 } from "./MultiNetworkConfig";
 
-import { OperationResult, getOperationResults } from "./OperationResults";
+import {
+  OperationResult,
+  getOperationResults,
+  decodeError,
+  OperationResultError,
+} from "./OperationResults";
 
 export * from "./signer";
 
@@ -38,7 +43,9 @@ export {
   getMultiConfig,
   validateMultiConfig,
   OperationResult,
+  OperationResultError,
   getOperationResults,
+  decodeError,
   // eslint-disable-next-line camelcase
   VerificationGateway__factory,
   VerificationGateway,


### PR DESCRIPTION
## What is this PR doing?
Splitting out the decode logic for error messages into its own function and exporting it.

## How can these changes be manually tested?
No logic changes

## Does this PR resolve or contribute to any issues?
No

## Checklist
- [x] I have manually tested these changes
- [x] Post a link to the PR in the group chat

## Guidelines
- If your PR is not ready, mark it as a draft
- The `resolve conversation` button is for reviewers, not authors
  - (But add a 'done' comment or similar)
