### PR TITLE
Bls signer blockchain methods

### DIFF
--- a/contracts/clients-tests/BlsProvider.test.ts
+++ b/contracts/clients-tests/BlsProvider.test.ts
@@ -14,6 +14,8 @@ import {
 } from "../clients/src";
 import getNetworkConfig from "../shared/helpers/getNetworkConfig";
 
+// TODO: bls-wallet 414 Setup integration tests for BlsProvider & BlsSigner
+// Can this be put in a test config/init file?
 chai.use(spies);
 
 let networkConfig: NetworkConfig;
@@ -118,6 +120,7 @@ describe("BlsProvider", () => {
     expect(formatEther(result)).to.equal(expectedSupply);
   });
 
+  // TODO: bls-wallet #410 estimate gas for a transaction
   it("should estimate gas without throwing an error", async () => {
     // Arrange
     const recipient = signers[1].address;

--- a/contracts/clients/src/BlsProvider.ts
+++ b/contracts/clients/src/BlsProvider.ts
@@ -22,6 +22,7 @@ export default class BlsProvider extends ethers.providers.JsonRpcProvider {
     this.verificationGatewayAddress = verificationGatewayAddress;
   }
 
+  // TODO: bls-wallet #410 estimate gas for a transaction
   override async estimateGas(
     transaction: Deferrable<ethers.providers.TransactionRequest>,
   ): Promise<BigNumber> {

--- a/contracts/clients/src/BlsSigner.ts
+++ b/contracts/clients/src/BlsSigner.ts
@@ -169,7 +169,7 @@ export default class BlsSigner extends Signer {
     const nonce = await BlsWalletWrapper.Nonce(
       this.wallet.PublicKey(),
       this.verificationGatewayAddress,
-      this,
+      this.provider,
     );
 
     const bundle = this.wallet.sign({ nonce, actions: [action] });


### PR DESCRIPTION
## What is this PR doing?
This PR is concerned with adding/tesing the signer blockchain methods. 

```ts
getBalance()
getChainId()
getGasPrice()
getTransactionCount()
call()
estimateGas()
resolveName()
```

Notes:

**estimateGas** - We are currently not getting an accurate value here, so I just added tests to ensure the method does not error. We have an issue in the backlog to more accurately estimate gas for transactions. See #410 

**resolveName** - ENS records are not supported by hardhat so we have decided to omit an override and test that the underlying ethers logic throws the correct errors. ENS are working on L2 support that allows ENS records to be stored on L2s while retaining the ability to be resolved, so we should keep an eye on these developments.

## How can these changes be manually tested?
1. run local hardhat node
2. Spin up a local aggregator (Make sure to delete bundle table in aggregator db if you haven't already)
3. in the `./contracts` directory, run `yarn test-clients`

## Does this PR resolve or contribute to any issues?
Resolves #374 

## Checklist
- [x] I have manually tested these changes
- [x] Post a link to the PR in the group chat

## Guidelines
- If your PR is not ready, mark it as a draft
- The `resolve conversation` button is for reviewers, not authors
  - (But add a 'done' comment or similar)