### PR TITLE
Bls provider json rpc provider methods

### DIFF
--- a/contracts/clients-tests/BlsProvider.test.ts
+++ b/contracts/clients-tests/BlsProvider.test.ts
@@ -461,6 +461,38 @@ describe("BlsProvider", () => {
     // Assert
     expect(accounts).to.deep.equal(expectedAccounts);
   });
+
+  it("should send an rpc request to the provider", async () => {
+    // Arrange
+    const expectedBlockNumber = await regularProvider.send(
+      "eth_blockNumber",
+      [],
+    );
+    const expectedChainId = await regularProvider.send("eth_chainId", []);
+    const expectedAccounts = await regularProvider.send("eth_accounts", []);
+
+    const recipient = signers[1].address;
+    const transactionAmount = parseEther("1");
+    const hexTx = ethers.providers.JsonRpcProvider.hexlifyTransaction({
+      to: recipient,
+      value: transactionAmount,
+    });
+    const balanceBefore = await regularProvider.getBalance(recipient);
+
+    // Act
+    const blockNumber = await blsProvider.send("eth_blockNumber", []);
+    const chainId = await blsProvider.send("eth_chainId", []);
+    const accounts = await blsProvider.send("eth_accounts", []);
+    await blsProvider.send("eth_sendTransaction", [hexTx]);
+
+    // Assert
+    expect(blockNumber).to.equal(expectedBlockNumber);
+    expect(chainId).to.equal(expectedChainId);
+    expect(accounts).to.deep.equal(expectedAccounts);
+    expect(
+      (await regularProvider.getBalance(signers[1].address)).sub(balanceBefore),
+    ).to.equal(transactionAmount);
+  });
 });
 
 describe("JsonRpcProvider", () => {

--- a/contracts/clients-tests/BlsProvider.test.ts
+++ b/contracts/clients-tests/BlsProvider.test.ts
@@ -2,7 +2,7 @@
 import { ethers as hardhatEthers } from "hardhat";
 import chai, { expect } from "chai";
 import spies from "chai-spies";
-import { ethers } from "ethers";
+import { ethers, BigNumber } from "ethers";
 import { parseEther, formatEther, id } from "ethers/lib/utils";
 import { SignerWithAddress } from "@nomiclabs/hardhat-ethers/signers";
 
@@ -13,6 +13,7 @@ import {
   NetworkConfig,
 } from "../clients/src";
 import getNetworkConfig from "../shared/helpers/getNetworkConfig";
+import BlsSigner, { UncheckedBlsSigner } from "../clients/src/BlsSigner";
 
 chai.use(spies);
 
@@ -76,6 +77,16 @@ describe("BlsProvider", () => {
 
     // Assert
     expect(blsSigner._isSigner).to.be.true;
+    expect(blsSigner).to.be.instanceOf(BlsSigner);
+  });
+
+  it("should return a valid unchecked bls signer", async () => {
+    // Arrange & Act
+    const uncheckedBlsSigner = blsProvider.getUncheckedSigner(privateKey);
+
+    // Assert
+    expect(uncheckedBlsSigner._isSigner).to.be.true;
+    expect(uncheckedBlsSigner).to.be.instanceOf(UncheckedBlsSigner);
   });
 
   it("should return a new signer if one has not been instantiated", async () => {
@@ -324,9 +335,9 @@ describe("BlsProvider", () => {
       type: 2,
     });
 
-    expect(transactionReceipt.gasUsed).to.equal(parseEther("0"));
-    expect(transactionReceipt.cumulativeGasUsed).to.equal(parseEther("0"));
-    expect(transactionReceipt.effectiveGasPrice).to.equal(parseEther("0"));
+    expect(transactionReceipt.gasUsed).to.equal(BigNumber.from("0"));
+    expect(transactionReceipt.cumulativeGasUsed).to.equal(BigNumber.from("0"));
+    expect(transactionReceipt.effectiveGasPrice).to.equal(BigNumber.from("0"));
 
     expect(transactionReceipt).to.include.keys(
       "transactionIndex",
@@ -362,9 +373,9 @@ describe("BlsProvider", () => {
       type: 2,
     });
 
-    expect(transactionReceipt.gasUsed).to.equal(parseEther("0"));
-    expect(transactionReceipt.cumulativeGasUsed).to.equal(parseEther("0"));
-    expect(transactionReceipt.effectiveGasPrice).to.equal(parseEther("0"));
+    expect(transactionReceipt.gasUsed).to.equal(BigNumber.from("0"));
+    expect(transactionReceipt.cumulativeGasUsed).to.equal(BigNumber.from("0"));
+    expect(transactionReceipt.effectiveGasPrice).to.equal(BigNumber.from("0"));
 
     expect(transactionReceipt).to.include.keys(
       "transactionIndex",

--- a/contracts/clients-tests/BlsProvider.test.ts
+++ b/contracts/clients-tests/BlsProvider.test.ts
@@ -71,7 +71,7 @@ describe("BlsProvider", () => {
     });
   });
 
-  it("should return a valid signer", async () => {
+  it("should return a valid signer", () => {
     // Arrange & Act
     const blsSigner = blsProvider.getSigner(privateKey);
 
@@ -80,7 +80,7 @@ describe("BlsProvider", () => {
     expect(blsSigner).to.be.instanceOf(BlsSigner);
   });
 
-  it("should return a valid unchecked bls signer", async () => {
+  it("should return a valid unchecked bls signer", () => {
     // Arrange & Act
     const uncheckedBlsSigner = blsProvider.getUncheckedSigner(privateKey);
 
@@ -440,7 +440,7 @@ describe("BlsProvider", () => {
     );
   });
 
-  it("should return the connection info for the provider", async () => {
+  it("should return the connection info for the provider", () => {
     // Arrange
     const expectedConnection = regularProvider.connection;
 
@@ -449,6 +449,17 @@ describe("BlsProvider", () => {
 
     // Assert
     expect(connection).to.deep.equal(expectedConnection);
+  });
+
+  it("should return the list of accounts managed by the provider", async () => {
+    // Arrange
+    const expectedAccounts = await regularProvider.listAccounts();
+
+    // Act
+    const accounts = await blsProvider.listAccounts();
+
+    // Assert
+    expect(accounts).to.deep.equal(expectedAccounts);
   });
 });
 

--- a/contracts/clients-tests/BlsProvider.test.ts
+++ b/contracts/clients-tests/BlsProvider.test.ts
@@ -428,6 +428,17 @@ describe("BlsProvider", () => {
       "wait",
     );
   });
+
+  it("should return the connection info for the provider", async () => {
+    // Arrange
+    const expectedConnection = regularProvider.connection;
+
+    // Act
+    const connection = blsProvider.connection;
+
+    // Assert
+    expect(connection).to.deep.equal(expectedConnection);
+  });
 });
 
 describe("JsonRpcProvider", () => {

--- a/contracts/clients-tests/BlsSigner.test.ts
+++ b/contracts/clients-tests/BlsSigner.test.ts
@@ -408,9 +408,10 @@ describe("BlsSigner", () => {
     ).to.equal(transactionAmount);
   });
 
-  it("should throw an error getting the transaction receipt when using a new provider and connecting to an unchecked bls signer", async () => {
+  // TODO (merge-ok) https://github.com/web3well/bls-wallet/issues/427
+  // This test is identical to the above test except this one uses a new instance of a provider, yet fails to find the tx receipt
+  it.skip("should get the transaction receipt when using a new provider and connecting to an unchecked bls signer", async () => {
     // Arrange & Act
-    // This test is identical to the above test except this one uses a new instance of a provider, yet fails to find the tx receipt
     const newBlsProvider = new Experimental.BlsProvider(
       aggregatorUrl,
       verificationGateway,
@@ -429,18 +430,18 @@ describe("BlsSigner", () => {
       value: transactionAmount,
       to: recipient,
     };
+    const balanceBefore = await blsProvider.getBalance(recipient);
 
     // Act
     const uncheckedResponse = await uncheckedBlsSigner.sendTransaction(
       transaction,
     );
-    const result = async () => await uncheckedResponse.wait();
+    await uncheckedResponse.wait();
 
     // Assert
-    expect(result()).to.be.rejectedWith(
-      Error,
-      `Could not find bundle receipt for transaction hash: ${uncheckedResponse.hash}.`,
-    );
+    expect(
+      (await blsProvider.getBalance(recipient)).sub(balanceBefore),
+    ).to.equal(transactionAmount);
   });
 
   it("should send ETH (empty call) via an unchecked transaction", async () => {

--- a/contracts/clients-tests/BlsSigner.test.ts
+++ b/contracts/clients-tests/BlsSigner.test.ts
@@ -359,7 +359,7 @@ describe("BlsSigner", () => {
     expect(RLP.decode(signedMessage)).to.deep.equal(blsWalletSignerSignature);
   });
 
-  it("should connect to an unchecked bls signer", async () => {
+  it("should connect to an unchecked bls signer", () => {
     // Arrange & Act
     const uncheckedBlsSigner = blsSigner.connectBlsUnchecked(privateKey);
 
@@ -368,7 +368,7 @@ describe("BlsSigner", () => {
     expect(uncheckedBlsSigner).to.be.instanceOf(UncheckedBlsSigner);
   });
 
-  it("should throw an error when calling connectUnchecked", async () => {
+  it("should throw an error when calling connectUnchecked", () => {
     // Arrange & Act
     const result = () => blsSigner.connectUnchecked();
 

--- a/contracts/clients/src/BlsProvider.ts
+++ b/contracts/clients/src/BlsProvider.ts
@@ -3,7 +3,7 @@ import { parseEther, Deferrable } from "ethers/lib/utils";
 
 import { ActionDataDto, BundleDto } from "./signer/types";
 import Aggregator, { BundleReceipt } from "./Aggregator";
-import BlsSigner, { _constructorGuard } from "./BlsSigner";
+import BlsSigner, { UncheckedBlsSigner, _constructorGuard } from "./BlsSigner";
 import poll from "./helpers/poll";
 
 export default class BlsProvider extends ethers.providers.JsonRpcProvider {
@@ -93,6 +93,15 @@ export default class BlsProvider extends ethers.providers.JsonRpcProvider {
     );
     this.signer = signer;
     return signer;
+  }
+
+  override getUncheckedSigner(
+    privateKey: string,
+    addressOrIndex?: string,
+  ): UncheckedBlsSigner {
+    return this.getSigner(privateKey, addressOrIndex).connectBlsUnchecked(
+      privateKey,
+    );
   }
 
   override async getTransactionReceipt(

--- a/contracts/clients/src/BlsProvider.ts
+++ b/contracts/clients/src/BlsProvider.ts
@@ -99,9 +99,7 @@ export default class BlsProvider extends ethers.providers.JsonRpcProvider {
     privateKey: string,
     addressOrIndex?: string,
   ): UncheckedBlsSigner {
-    return this.getSigner(privateKey, addressOrIndex).connectBlsUnchecked(
-      privateKey,
-    );
+    return this.getSigner(privateKey, addressOrIndex).connectUnchecked();
   }
 
   override async getTransactionReceipt(

--- a/contracts/clients/src/BlsSigner.ts
+++ b/contracts/clients/src/BlsSigner.ts
@@ -19,7 +19,7 @@ export default class BlsSigner extends Signer {
   constructor(
     constructorGuard: Record<string, unknown>,
     provider: BlsProvider,
-    privateKey: string,
+    privateKey: string | Promise<string>,
     readonly addressOrIndex?: string | number,
   ) {
     super();
@@ -205,7 +205,6 @@ export default class BlsSigner extends Signer {
     return new UncheckedBlsSigner(
       _constructorGuard,
       this.provider,
-      // Modify this arg to take a priv key OR promise that will eventually resolve to one, then do similar initPromise guards in this class.
       this.wallet?.privateKey ??
         (async () => {
           await this.initPromise;

--- a/contracts/clients/src/BlsSigner.ts
+++ b/contracts/clients/src/BlsSigner.ts
@@ -206,7 +206,7 @@ export default class BlsSigner extends Signer {
       _constructorGuard,
       this.provider,
       this.wallet?.privateKey ??
-        (async () => {
+        (async (): Promise<string> => {
           await this.initPromise;
           return this.wallet.privateKey;
         })(),


### PR DESCRIPTION
## What is this PR doing?
This PR is concerned with adding/testing the [JsonRpcProvider methods](https://docs.ethers.io/v5/api/providers/jsonrpc-provider/#JsonRpcProvider).

Relevant methods:

```ts
jsonRpcProvider.connection
getSigner()
getUncheckedSigner()
listAccounts()
send()
```

**Notes:**

**getSigner()** - was needed in previous work, so implementation and tests have already been added.

**getUncheckedSigner()** - in order to test this method fully, I had to add several additional methods to the signer along with tests to ensure the unchecked signer worked as expected. This includes adding the `UncheckedBlsSigner` class itself. Methods added/changed:

- `signer.connectBlsUnchecked()` - see [comment](https://github.com/web3well/bls-wallet/pull/422#discussion_r1044535148) on why I added this
- `signer.sendUncheckedTransaction()`
- `uncheckedBlsSigner.sendTransaction()`

For more information on what the unchecked signer is and why it was added to ethers see this [part of the docs](https://docs.ethers.io/v5/api/providers/jsonrpc-provider/#UncheckedJsonRpcSigner) and this [github issue](https://github.com/ethers-io/ethers.js/issues/340)

**send()** - added some tests here to ensure we called the underlying ethers logic, and got the expected results for some common rpc requests. See [this comment](https://github.com/web3well/bls-wallet/pull/422/files#r1044535148) for further discussion.

## How can these changes be manually tested?
1. run local hardhat node
2. Spin up a local aggregator
3. in the `./contracts` directory, run `yarn test-clients`

## Does this PR resolve or contribute to any issues?
#381  

## Checklist
- [x] I have manually tested these changes
- [x] Post a link to the PR in the group chat

## Guidelines
- If your PR is not ready, mark it as a draft
- The `resolve conversation` button is for reviewers, not authors
  - (But add a 'done' comment or similar)

