### PR TITLE
Fix issue with fetch in client in browser

### DIFF
--- a/aggregator-proxy/package.json
+++ b/aggregator-proxy/package.json
@@ -21,7 +21,7 @@
     "@types/koa__cors": "^3.3.0",
     "@types/koa__router": "^8.0.11",
     "@types/node-fetch": "^2.6.1",
-    "bls-wallet-clients": "0.8.1-758c7c4",
+    "bls-wallet-clients": "0.8.2-add1351",
     "fp-ts": "^2.12.1",
     "io-ts": "^2.2.16",
     "io-ts-reporters": "^2.0.1",

--- a/aggregator-proxy/yarn.lock
+++ b/aggregator-proxy/yarn.lock
@@ -882,10 +882,10 @@ bech32@1.1.4:
   resolved "https://registry.yarnpkg.com/bech32/-/bech32-1.1.4.tgz#e38c9f37bf179b8eb16ae3a772b40c356d4832e9"
   integrity sha512-s0IrSOzLlbvX7yp4WBfPITzpAU8sqQcpsmwXDiKwrG4r491vwCO/XpejasRNl0piBMe/DvP4Tz0mIS/X1DPJBQ==
 
-bls-wallet-clients@0.8.1-758c7c4:
-  version "0.8.1-758c7c4"
-  resolved "https://registry.yarnpkg.com/bls-wallet-clients/-/bls-wallet-clients-0.8.1-758c7c4.tgz#1366b8c704912bdacc933c44061a3198dec80ec5"
-  integrity sha512-bvI0BJVKZow1y/0BDmhFSlr3ScQQDofUX+6J+BB9pLMu2WIQogmfpLqHsH5oOOq+RQbR/ivNoknR+YU4Un0HRQ==
+bls-wallet-clients@0.8.2-add1351:
+  version "0.8.2-add1351"
+  resolved "https://registry.yarnpkg.com/bls-wallet-clients/-/bls-wallet-clients-0.8.2-add1351.tgz#64481aa7af9fd3b361108ce50b92b838b3b539ac"
+  integrity sha512-XWSSxrmJHr4wu+IEL+AMlgMkqSxpD1yOKhPwyiKJ2vU8wRMcudBJqJzJgT/jS+JSXwypMXy2zZ+Mata8zVHztQ==
   dependencies:
     "@thehubbleproject/bls" "^0.5.1"
     ethers "5.5.4"

--- a/aggregator/deps.ts
+++ b/aggregator/deps.ts
@@ -50,7 +50,7 @@ export type {
   Signature,
   VerificationGateway,
   OperationResultError,
-} from "https://esm.sh/bls-wallet-clients@0.8.1-758c7c4";
+} from "https://esm.sh/bls-wallet-clients@0.8.2-add1351";
 
 export {
   Aggregator as AggregatorClient,
@@ -61,10 +61,10 @@ export {
   MockERC20__factory,
   VerificationGateway__factory,
   decodeError,
-} from "https://esm.sh/bls-wallet-clients@0.8.1-758c7c4";
+} from "https://esm.sh/bls-wallet-clients@0.8.2-add1351";
 
 // Workaround for esbuild's export-star bug
-import blsWalletClients from "https://esm.sh/bls-wallet-clients@0.8.1-758c7c4";
+import blsWalletClients from "https://esm.sh/bls-wallet-clients@0.8.2-add1351";
 const {
   bundleFromDto,
   bundleToDto,

--- a/contracts/clients/package.json
+++ b/contracts/clients/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bls-wallet-clients",
-  "version": "0.8.1",
+  "version": "0.8.2",
   "description": "Client libraries for interacting with BLS Wallet components",
   "main": "dist/src/index.js",
   "types": "dist/src/index.d.ts",

--- a/contracts/clients/src/Aggregator.ts
+++ b/contracts/clients/src/Aggregator.ts
@@ -1,4 +1,4 @@
-import fetch from "node-fetch";
+import nodeFetch from "node-fetch";
 import { Bundle, bundleToDto } from "./signer";
 
 // TODO: Rename to BundleFailure?
@@ -68,7 +68,7 @@ export default class Aggregator {
 
     this.origin = new URL(url).origin;
     // Prefer runtime's imeplmentation of fetch over node-fetch
-    this.fetchImpl = "fetch" in globalThis ? fetch.bind(globalThis) : fetch;
+    this.fetchImpl = "fetch" in globalThis ? fetch.bind(globalThis) : nodeFetch;
   }
 
   /**
@@ -145,8 +145,12 @@ export default class Aggregator {
 
   private async jsonGet<T>(path: string): Promise<T | undefined> {
     const resp = await this.fetchImpl(path);
-    const json = await resp.json();
+    const respText = await resp.text();
+    if (!respText) {
+      return undefined;
+    }
 
+    const json = JSON.parse(respText);
     const isValidNonEmptyJson = json && Object.keys(json).length;
     if (isValidNonEmptyJson) {
       return json as T;

--- a/contracts/clients/src/Aggregator.ts
+++ b/contracts/clients/src/Aggregator.ts
@@ -68,7 +68,7 @@ export default class Aggregator {
 
     this.origin = new URL(url).origin;
     // Prefer runtime's imeplmentation of fetch over node-fetch
-    this.fetchImpl = globalThis.fetch ?? fetch;
+    this.fetchImpl = "fetch" in globalThis ? fetch.bind(globalThis) : fetch;
   }
 
   /**

--- a/extension/package.json
+++ b/extension/package.json
@@ -36,7 +36,7 @@
     "advanced-css-reset": "^1.2.2",
     "async-mutex": "^0.3.2",
     "axios": "^0.27.2",
-    "bls-wallet-clients": "0.8.1-758c7c4",
+    "bls-wallet-clients": "0.8.2-add1351",
     "browser-passworder": "^2.0.3",
     "bs58check": "^2.1.2",
     "crypto-browserify": "^3.12.0",

--- a/extension/yarn.lock
+++ b/extension/yarn.lock
@@ -2646,10 +2646,10 @@ blakejs@^1.1.0:
   resolved "https://registry.yarnpkg.com/blakejs/-/blakejs-1.2.1.tgz#5057e4206eadb4a97f7c0b6e197a505042fc3814"
   integrity sha512-QXUSXI3QVc/gJME0dBpXrag1kbzOqCjCX8/b54ntNyW6sjtoqxqRk3LTmXzaJoh71zMsDCjM+47jS7XiwN/+fQ==
 
-bls-wallet-clients@0.8.1-758c7c4:
-  version "0.8.1-758c7c4"
-  resolved "https://registry.yarnpkg.com/bls-wallet-clients/-/bls-wallet-clients-0.8.1-758c7c4.tgz#1366b8c704912bdacc933c44061a3198dec80ec5"
-  integrity sha512-bvI0BJVKZow1y/0BDmhFSlr3ScQQDofUX+6J+BB9pLMu2WIQogmfpLqHsH5oOOq+RQbR/ivNoknR+YU4Un0HRQ==
+bls-wallet-clients@0.8.2-add1351:
+  version "0.8.2-add1351"
+  resolved "https://registry.yarnpkg.com/bls-wallet-clients/-/bls-wallet-clients-0.8.2-add1351.tgz#64481aa7af9fd3b361108ce50b92b838b3b539ac"
+  integrity sha512-XWSSxrmJHr4wu+IEL+AMlgMkqSxpD1yOKhPwyiKJ2vU8wRMcudBJqJzJgT/jS+JSXwypMXy2zZ+Mata8zVHztQ==
   dependencies:
     "@thehubbleproject/bls" "^0.5.1"
     ethers "5.5.4"


### PR DESCRIPTION
## What is this PR doing?
- Bind `fetch` function to `window`/`global` scope to prevent the below:

![image](https://user-images.githubusercontent.com/10394161/209389785-a5d9ad6f-b753-45d4-a6db-2d8eff73b285.png)

- Use `fetchResponse.text()` instead of `,json()` to handle empty responses without a JSON parsing error. 

## How can these changes be manually tested?
- Import `bls-wallet-clients` into https://github.com/web3well/bls-browser-wallet and send a bundle or lookup a transaction
- Was unable at the moment to add test coverage as this only occurs in browsers. Will need to look into something like https://mochajs.org/#running-mocha-in-the-browser to properly cover.

## Does this PR resolve or contribute to any issues?
No

## Checklist
- [x] I have manually tested these changes
- [x] Post a link to the PR in the group chat

## Guidelines
- If your PR is not ready, mark it as a draft
- The `resolve conversation` button is for reviewers, not authors
  - (But add a 'done' comment or similar)
