### PR TITLE
Fix aggregator test stalls

### DIFF
--- a/aggregator/src/app/BundleService.ts
+++ b/aggregator/src/app/BundleService.ts
@@ -71,19 +71,16 @@ export default class BundleService {
       () => this.runSubmission(),
     );
 
-    (async () => {
-      await delay(100);
-
-      while (!this.stopping) {
-        this.tryAggregating();
-        // TODO (merge-ok): Stop if there aren't any bundles?
-        await this.ethereumService.waitForNextBlock();
-      }
-    })();
+    this.ethereumService.provider.on("block", this.handleBlock);
   }
+
+  handleBlock = () => {
+    this.addTask(() => this.tryAggregating());
+  };
 
   async stop() {
     this.stopping = true;
+    this.ethereumService.provider.off("block", this.handleBlock);
     await Promise.all(Array.from(this.pendingTaskPromises));
     this.stopped = true;
   }


### PR DESCRIPTION
## What is this PR doing?

Fixes aggregator tests stalling by ensuring that we stop listening for blocks when the bundle service is stopped.

(Suspected cause of stallage is that deno is waiting for this to be cleaned up.)

## How can these changes be manually tested?

Run the tests on CI.

## Does this PR resolve or contribute to any issues?

Resolves https://github.com/web3well/bls-wallet/issues/445

## Checklist
- [x] I have manually tested these changes
- [x] Post a link to the PR in the group chat

## Guidelines
- If your PR is not ready, mark it as a draft
- The `resolve conversation` button is for reviewers, not authors
  - (But add a 'done' comment or similar)
