### PR TITLE
Restore aggregatorLogs.txt artifact

### DIFF
--- a/.github/actions/local-aggregator-deploy/action.yml
+++ b/.github/actions/local-aggregator-deploy/action.yml
@@ -14,4 +14,4 @@ runs:
 
     - working-directory: ./aggregator
       shell: bash
-      run: deno run --allow-read --allow-env --allow-net ./programs/aggregator.ts &
+      run: deno run --allow-read --allow-env --allow-net ./programs/aggregator.ts 2>&1 | tee -a aggregatorLogs.txt &

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -56,3 +56,11 @@ jobs:
     # - name: integration tests
     - working-directory: ./contracts
       run: yarn test-integration
+
+    # - name: upload artifacts
+    - uses: actions/upload-artifact@v3
+      if: always()
+      with:
+        name: aggregator-logs
+        path: ./aggregator/aggregatorLogs.txt
+        retention-days: 5


### PR DESCRIPTION
## What is this PR doing?

Restores aggregatorLogs.txt when running test-integration on CI.

Turns out that normal output on github actions kinda works but it truncates the output. With this PR we have both :).

## How can these changes be manually tested?

Check that the aggregatorLogs.txt file is produced correctly on CI.

## Does this PR resolve or contribute to any issues?

Nope.

## Checklist
- [x] I have manually tested these changes
- [ ] Post a link to the PR in the group chat

## Guidelines
- If your PR is not ready, mark it as a draft
- The `resolve conversation` button is for reviewers, not authors
  - (But add a 'done' comment or similar)
