### PR TITLE
Change port to --net=host in startup script

### DIFF
--- a/aggregator/programs/start-docker.sh
+++ b/aggregator/programs/start-docker.sh
@@ -36,7 +36,7 @@ echo "Creating $CONTAINER_NAME using $IMAGE_NAME"
 docker run \
   --name "$CONTAINER_NAME" \
   -d \
-  -p$PORT:$PORT \
+  --net=host
   --restart=unless-stopped \
   --mount type=bind,source="$ENV_PATH",target=/app/.env \
   --mount type=bind,source="$NETWORK_CONFIG_PATH",target=/app/networkConfig.json \


### PR DESCRIPTION
## What is this PR doing?
I was trying to update the optimism aggregator with the latest changes in main.  Two big things included my change to add a status column and the change to take the env vars out of the docker image.

I noticed when starting up the container with the the new start-docker script that the aggregator was failing to connect to postgres.  I had to make this change and I also had to change the PG_HOST to `PG_HOST=127.0.0.1` instead of using localhost.  I got the idea about the PG_HOST from this [thread](https://community.fly.io/t/deno-app-getting-connection-failed-connection-refused-os-error-111-when-connecting-to-external-mongo/1170).  Not sure why it wasn't working before.

## How can these changes be manually tested?
Build a docker image and try to start it up

## Does this PR resolve or contribute to any issues?
No

## Checklist
- [ ] I have manually tested these changes
- [ ] Post a link to the PR in the group chat

## Guidelines
- If your PR is not ready, mark it as a draft
- The `resolve conversation` button is for reviewers, not authors
  - (But add a 'done' comment or similar)
