### PR TITLE
Publish aggregator images using CI

### DIFF
--- a/.github/workflows/aggregator-dockerhub.yml
+++ b/.github/workflows/aggregator-dockerhub.yml
@@ -1,0 +1,29 @@
+name: aggregator-dockerhub
+
+on:
+  push:
+    branches:
+      - 'main'
+    paths:
+      - 'aggregator/**'
+      - '.github/workflows/aggregator-dockerhub.yml'
+
+defaults:
+  run:
+    working-directory: ./aggregator
+
+env:
+  DENO_VERSION: 1.x
+
+jobs:
+  push:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v3
+    - uses: denoland/setup-deno@v1
+      with:
+        deno-version: ${{ env.DENO_VERSION }}
+    - run: git show HEAD
+    - run: echo ${{ secrets.DOCKERHUB_TOKEN }} | docker login --username blswalletghactions --password-stdin
+    - run: ./programs/build.ts --image-name blswallet/aggregator --image-only --also-tag-latest --push

--- a/aggregator/Dockerfile
+++ b/aggregator/Dockerfile
@@ -1,4 +1,4 @@
-FROM denoland/deno:1.23.4
+FROM denoland/deno:1.30.1
 
 ADD build /app
 WORKDIR /app

--- a/aggregator/programs/build.ts
+++ b/aggregator/programs/build.ts
@@ -98,6 +98,10 @@ async function buildDockerImage() {
     `aggregator:${buildName}`,
   );
 
+  if (args["image-only"]) {
+    return;
+  }
+
   const dockerImageName = `aggregator-${buildName}-docker-image`;
 
   await shell.run(

--- a/aggregator/programs/build.ts
+++ b/aggregator/programs/build.ts
@@ -104,6 +104,16 @@ async function buildDockerImage() {
     imageNameAndTag,
   );
 
+  if (args["also-tag-latest"]) {
+    await shell.run(
+      ...sudoDockerArg,
+      "docker",
+      "tag",
+      `${imageName}:${buildName}`,
+      `${imageName}:latest`,
+    );
+  }
+
   console.log("\nDocker image created:", imageNameAndTag);
 
   if (args["image-only"]) {
@@ -145,4 +155,8 @@ async function pushDockerImage() {
   const imageNameAndTag = `${imageName}:${buildName}`;
 
   await shell.run("docker", "push", imageNameAndTag);
+
+  if (args["also-tag-latest"]) {
+    await shell.run("docker", "push", `${imageName}:latest`);
+  }
 }

--- a/aggregator/programs/build.ts
+++ b/aggregator/programs/build.ts
@@ -33,7 +33,7 @@ async function allFiles() {
   ];
 }
 
-async function BuildName() {
+async function Tag() {
   const commitShort = (await shell.Line("git", "rev-parse", "HEAD")).slice(
     0,
     7,
@@ -89,9 +89,9 @@ async function tarballTypescriptFiles() {
 }
 
 async function buildDockerImage() {
-  const buildName = await BuildName();
+  const tag = await Tag();
   const imageName = args["image-name"] ?? "aggregator";
-  const imageNameAndTag = `${imageName}:${buildName}`;
+  const imageNameAndTag = `${imageName}:${tag}`;
 
   const sudoDockerArg = args["sudo-docker"] === true ? ["sudo"] : [];
 
@@ -109,7 +109,7 @@ async function buildDockerImage() {
       ...sudoDockerArg,
       "docker",
       "tag",
-      `${imageName}:${buildName}`,
+      `${imageName}:${tag}`,
       `${imageName}:latest`,
     );
   }
@@ -120,7 +120,7 @@ async function buildDockerImage() {
     return;
   }
 
-  const dockerImageFileName = `${imageName}-${buildName}-docker-image`;
+  const dockerImageFileName = `${imageName}-${tag}-docker-image`;
   const tarFilePath = `${repoDir}/build/${dockerImageFileName}.tar`;
 
   await shell.run(
@@ -150,9 +150,9 @@ async function buildDockerImage() {
 }
 
 async function pushDockerImage() {
-  const buildName = await BuildName();
+  const tag = await Tag();
   const imageName = args["image-name"] ?? "aggregator";
-  const imageNameAndTag = `${imageName}:${buildName}`;
+  const imageNameAndTag = `${imageName}:${tag}`;
 
   await shell.run("docker", "push", imageNameAndTag);
 

--- a/aggregator/programs/build.ts
+++ b/aggregator/programs/build.ts
@@ -15,6 +15,10 @@ await copyTypescriptFiles();
 await buildDockerImage();
 await tarballTypescriptFiles();
 
+if (args["push"]) {
+  await pushDockerImage();
+}
+
 console.log("\nAggregator build complete");
 
 async function allFiles() {
@@ -133,4 +137,12 @@ async function buildDockerImage() {
   await shell.run("gzip", tarFilePath);
 
   console.log(`Docker image saved: ${tarFilePath}.gz`);
+}
+
+async function pushDockerImage() {
+  const buildName = await BuildName();
+  const imageName = args["image-name"] ?? "aggregator";
+  const imageNameAndTag = `${imageName}:${buildName}`;
+
+  await shell.run("docker", "push", imageNameAndTag);
 }

--- a/aggregator/programs/build.ts
+++ b/aggregator/programs/build.ts
@@ -86,7 +86,8 @@ async function tarballTypescriptFiles() {
 
 async function buildDockerImage() {
   const buildName = await BuildName();
-  const imageName = `aggregator:${buildName}`;
+  const imageName = args["image-name"] ?? "aggregator";
+  const imageNameAndTag = `${imageName}:${buildName}`;
 
   const sudoDockerArg = args["sudo-docker"] === true ? ["sudo"] : [];
 
@@ -96,17 +97,17 @@ async function buildDockerImage() {
     "build",
     repoDir,
     "-t",
-    imageName,
+    imageNameAndTag,
   );
 
-  console.log("\nDocker image created:", imageName);
+  console.log("\nDocker image created:", imageNameAndTag);
 
   if (args["image-only"]) {
     return;
   }
 
-  const dockerImageName = `aggregator-${buildName}-docker-image`;
-  const tarFilePath = `${repoDir}/build/${dockerImageName}.tar`;
+  const dockerImageFileName = `${imageName}-${buildName}-docker-image`;
+  const tarFilePath = `${repoDir}/build/${dockerImageFileName}.tar`;
 
   await shell.run(
     ...sudoDockerArg,
@@ -114,7 +115,7 @@ async function buildDockerImage() {
     "save",
     "--output",
     tarFilePath,
-    `aggregator:${buildName}`,
+    imageNameAndTag,
   );
 
   if (sudoDockerArg.length > 0) {


### PR DESCRIPTION
## What is this PR doing?

- Adds functionality to `build.ts` for pushing docker images to dockerhub
- Adds a github action for doing this when main is updated

## How can these changes be manually tested?

1. Run the github action and make sure the container is pushed to dockerhub
2. Test the container by running `./manualTests/mint1ViaAggregator.ts` against it

## Does this PR resolve or contribute to any issues?

Resolves #91.

## Checklist
- [x] I have manually tested these changes
- [x] Post a link to the PR in the group chat

## Guidelines
- If your PR is not ready, mark it as a draft
- The `resolve conversation` button is for reviewers, not authors
  - (But add a 'done' comment or similar)
