### PR TITLE
Add accounts, blocks, & network status method tests

### DIFF
--- a/contracts/test-integration/BlsProvider.test.ts
+++ b/contracts/test-integration/BlsProvider.test.ts
@@ -600,7 +600,7 @@ describe("BlsProvider", () => {
 
   it("should return the network the provider is connected to", async () => {
     // Arrange
-    const expectedNetwork = { name: "localhost", chainId: 31337 };
+    const expectedNetwork = { name: "localhost", chainId: 1337 };
 
     // Act
     const network = await blsProvider.getNetwork();
@@ -651,7 +651,7 @@ describe("BlsProvider", () => {
 
   it("should a return a promise which will stall until the network has heen established", async () => {
     // Arrange
-    const expectedReady = { name: "localhost", chainId: 31337 };
+    const expectedReady = { name: "localhost", chainId: 1337 };
 
     // Act
     const ready = await blsProvider.ready;

--- a/contracts/test-integration/BlsProviderContractInteraction.test.ts
+++ b/contracts/test-integration/BlsProviderContractInteraction.test.ts
@@ -258,8 +258,6 @@ describe("Provider tests", function () {
 
       // Act
       const storage1 = await blsProvider.getStorageAt(mockERC20.address, 1);
-      console.log(storage1);
-
       const storage2 = await blsProvider.getStorageAt(mockERC20.address, 2);
 
       // Assert

--- a/contracts/test-integration/BlsProviderContractInteraction.test.ts
+++ b/contracts/test-integration/BlsProviderContractInteraction.test.ts
@@ -214,5 +214,57 @@ describe("Provider tests", function () {
       expect(transferEvent.args.from).to.equal(await blsSigner.getAddress());
       expect(transferEvent.args.to).to.equal(recipient);
     });
+
+    it("should get code located at address and block number", async function () {
+      // Arrange
+      const provider = new ethers.providers.JsonRpcProvider();
+      const expectedCode = await provider.getCode(mockERC20.address);
+
+      // Act
+      const code = await blsProvider.getCode(mockERC20.address);
+
+      // Assert
+      expect(code).to.equal(expectedCode);
+    });
+
+    it("should return '0x' if no code located at address", async function () {
+      // Arrange
+      const fakeAddress = ethers.Wallet.createRandom().address;
+      const expectedCode = "0x";
+
+      // Act
+      const invalidAddress = await blsProvider.getCode(fakeAddress);
+      const realAddressBeforeDeployment = await blsProvider.getCode(
+        mockERC20.address,
+        "earliest",
+      );
+
+      // Assert
+      expect(invalidAddress).to.equal(expectedCode);
+      expect(realAddressBeforeDeployment).to.equal(expectedCode);
+    });
+
+    it("should return the Bytes32 value of the storage slot position at erc20 address", async function () {
+      // Arrange
+      const provider = new ethers.providers.JsonRpcProvider();
+      const expectedStorage1 = await provider.getStorageAt(
+        mockERC20.address,
+        1,
+      );
+      const expectedStorage2 = await provider.getStorageAt(
+        mockERC20.address,
+        2,
+      );
+
+      // Act
+      const storage1 = await blsProvider.getStorageAt(mockERC20.address, 1);
+      console.log(storage1);
+
+      const storage2 = await blsProvider.getStorageAt(mockERC20.address, 2);
+
+      // Assert
+      expect(storage1).to.equal(expectedStorage1); // 0x0000000000000000000000000000000000000000000000000000000000000000
+      expect(storage2).to.equal(expectedStorage2); // 0x00000000000000000000000000000000000000000000d3c21bcecceda1000000
+    });
   });
 });

--- a/contracts/test-integration/BlsSigner.test.ts
+++ b/contracts/test-integration/BlsSigner.test.ts
@@ -574,26 +574,30 @@ describe("BlsSigner", () => {
 
   it("should get the number of transactions the account has sent", async () => {
     // Arrange
-    const expectedTransactionCount = await regularProvider.getTransactionCount(
-      blsSigner.wallet.address,
-    );
+    const expectedTransactionCount = await blsSigner.wallet.Nonce();
 
     // Act
-    const result = await blsSigner.getTransactionCount();
+    const transactionCount = await blsSigner.getTransactionCount();
 
     // Assert
-    expect(result).to.equal(expectedTransactionCount);
+    expect(transactionCount).to.equal(expectedTransactionCount);
   });
 
   it("should get the number of transactions the account has sent at the specified block tag", async () => {
     // Arrange
     const expectedTransactionCount = 0;
 
+    const sendTransaction = await blsSigner.sendTransaction({
+      value: BigNumber.from(1),
+      to: ethers.Wallet.createRandom().address,
+    });
+    await sendTransaction.wait();
+
     // Act
-    const result = await blsSigner.getTransactionCount("earliest");
+    const transactionCount = await blsSigner.getTransactionCount("earliest");
 
     // Assert
-    expect(result).to.equal(expectedTransactionCount);
+    expect(transactionCount).to.equal(expectedTransactionCount);
   });
 
   it("should return the result of call using the transactionRequest, with the signer account address being used as the from field", async () => {


### PR DESCRIPTION
## What is this PR doing?
Add tests for provider Accounts, Blocks & Network Status Methods.

**Relevant methods:**
- getBalance - no test added as implicitly tested in many places
- getCode - test added
- getStorageAt - test added
- getTransactionCount - method & test added
- getBlock - test added
- getBlockWithTransactions - test added
- getNetwork - test added
- getBlockNumber - test added
- getGasPrice - test added
- getFeeData - test added
- .ready - test added

## How can these changes be manually tested?
Run integration tests

## Does this PR resolve or contribute to any issues?
#380 

## Checklist
- [x] I have manually tested these changes
- [x] Post a link to the PR in the group chat

## Guidelines
- If your PR is not ready, mark it as a draft
- The `resolve conversation` button is for reviewers, not authors
  - (But add a 'done' comment or similar)
