### PR TITLE
Use .eventually in contracts

### DIFF
--- a/contracts/test-integration/BlsSignerContractInteraction.test.ts
+++ b/contracts/test-integration/BlsSignerContractInteraction.test.ts
@@ -8,7 +8,7 @@ import getNetworkConfig from "../shared/helpers/getNetworkConfig";
 
 async function getRandomSigners(
   numSigners: number,
-): Promise<(typeof Experimental.BlsSigner[])> {
+): Promise<(typeof Experimental.BlsSigner)[]> {
   const networkConfig = await getNetworkConfig("local");
 
   const aggregatorUrl = "http://localhost:3000";

--- a/contracts/test-integration/BlsSignerContractInteraction.test.ts
+++ b/contracts/test-integration/BlsSignerContractInteraction.test.ts
@@ -8,7 +8,7 @@ import getNetworkConfig from "../shared/helpers/getNetworkConfig";
 
 async function getRandomSigners(
   numSigners: number,
-): Promise<(typeof Experimental.BlsSigner)[]> {
+): Promise<(typeof Experimental.BlsSigner[])> {
   const networkConfig = await getNetworkConfig("local");
 
   const aggregatorUrl = "http://localhost:3000";
@@ -244,9 +244,9 @@ describe("Signer contract interaction tests", function () {
         .safeMint(recipient, tokenId);
       await mint.wait();
 
-      expect(await mockERC721.connect(blsSigners[1]).ownerOf(tokenId)).to.equal(
-        recipient,
-      );
+      await expect(
+        mockERC721.connect(blsSigners[1]).ownerOf(tokenId),
+      ).to.eventually.equal(recipient);
     });
 
     it("mint() call", async function () {
@@ -258,9 +258,9 @@ describe("Signer contract interaction tests", function () {
         .mint(recipient, tokenId);
       await mint.wait();
 
-      expect(await mockERC721.connect(blsSigners[1]).ownerOf(tokenId)).to.equal(
-        recipient,
-      );
+      await expect(
+        mockERC721.connect(blsSigners[1]).ownerOf(tokenId),
+      ).to.eventually.equal(recipient);
     });
 
     it("balanceOf() call", async function () {
@@ -288,7 +288,7 @@ describe("Signer contract interaction tests", function () {
       await mint.wait();
 
       // Check signer[3] owns the token
-      expect(await mockERC721.ownerOf(tokenId)).to.equal(owner);
+      await expect(mockERC721.ownerOf(tokenId)).to.eventually.equal(owner);
 
       // Transfer the token from signer 3 to signer 2
       const transfer = await mockERC721
@@ -297,7 +297,7 @@ describe("Signer contract interaction tests", function () {
       await transfer.wait();
 
       // Check signer[2] now owns the token
-      expect(await mockERC721.ownerOf(tokenId)).to.equal(recipient);
+      await expect(mockERC721.ownerOf(tokenId)).to.eventually.equal(recipient);
     });
 
     it("approve() call", async function () {
@@ -318,7 +318,9 @@ describe("Signer contract interaction tests", function () {
       await approve.wait();
 
       // Check signer[1]'s address is now an approved address for the token
-      expect(await mockERC721.getApproved(tokenId)).to.equal(spender);
+      await expect(mockERC721.getApproved(tokenId)).to.eventually.equal(
+        spender,
+      );
     });
   });
 });

--- a/contracts/test/recovery-test.ts
+++ b/contracts/test/recovery-test.ts
@@ -75,7 +75,7 @@ describe("Recovery", async function () {
   });
 
   it("should update bls key", async function () {
-    expect(await vg.hashFromWallet(wallet1.address)).to.eql(hash1);
+    await expect(vg.hashFromWallet(wallet1.address)).to.eventually.eql(hash1);
 
     const addressSignature = await signWalletAddress(
       fx,
@@ -95,7 +95,7 @@ describe("Recovery", async function () {
     await fx.advanceTimeBy(safetyDelaySeconds + 1);
     await fx.call(wallet1, vg, "setPendingBLSKeyForWallet", [], 2, 30_000_000);
 
-    expect(await vg.hashFromWallet(wallet1.address)).to.eql(hash2);
+    await expect(vg.hashFromWallet(wallet1.address)).to.eventually.eql(hash2);
   });
 
   it("should NOT override public key hash after creation", async function () {
@@ -126,7 +126,7 @@ describe("Recovery", async function () {
       1,
       30_000_000,
     );
-    expect(await blsWallet.recoveryHash()).to.equal(recoveryHash);
+    await expect(blsWallet.recoveryHash()).to.eventually.equal(recoveryHash);
 
     // new value set after delay from non-zero value
     salt = "0x" + "AB".repeat(32);
@@ -142,10 +142,10 @@ describe("Recovery", async function () {
       2,
       30_000_000,
     );
-    expect(await blsWallet.recoveryHash()).to.equal(recoveryHash);
+    await expect(blsWallet.recoveryHash()).to.eventually.equal(recoveryHash);
     await fx.advanceTimeBy(safetyDelaySeconds + 1);
     await (await blsWallet.setAnyPending()).wait();
-    expect(await blsWallet.recoveryHash()).to.equal(newRecoveryHash);
+    await expect(blsWallet.recoveryHash()).to.eventually.equal(newRecoveryHash);
   });
 
   it("should recover blswallet via blswallet to new bls key", async function () {
@@ -187,8 +187,8 @@ describe("Recovery", async function () {
 
     // don't trust, verify
     const hash3 = wallet3.blsWalletSigner.getPublicKeyHash(wallet3.privateKey);
-    expect(await vg.hashFromWallet(wallet1.address)).to.eql(hash3);
-    expect(await vg.walletFromHash(hash3)).to.eql(wallet1.address);
+    await expect(vg.hashFromWallet(wallet1.address)).to.eventually.eql(hash3);
+    await expect(vg.walletFromHash(hash3)).to.eventually.eql(wallet1.address);
   });
 
   it("should recover before bls key update", async function () {
@@ -253,8 +253,8 @@ describe("Recovery", async function () {
     ).wait();
 
     // key reset via recovery
-    expect(await vg.hashFromWallet(wallet1.address)).to.eql(hash2);
-    expect(await vg.walletFromHash(hash2)).to.eql(wallet1.address);
+    await expect(vg.hashFromWallet(wallet1.address)).to.eventually.eql(hash2);
+    await expect(vg.walletFromHash(hash2)).to.eventually.eql(wallet1.address);
 
     await fx.advanceTimeBy(safetyDelaySeconds / 2 + 1); // wait remainder the time
     // NB: advancing the time makes an empty tx with lazywallet[1]
@@ -290,11 +290,15 @@ describe("Recovery", async function () {
       30_000_000,
     );
 
-    expect(await vg.walletFromHash(hash1)).to.not.equal(blsWallet.address);
-    expect(await vg.walletFromHash(hashAttacker)).to.not.equal(
+    await expect(vg.walletFromHash(hash1)).to.eventually.not.equal(
       blsWallet.address,
     );
-    expect(await vg.walletFromHash(hash2)).to.equal(blsWallet.address);
+    await expect(vg.walletFromHash(hashAttacker)).to.eventually.not.equal(
+      blsWallet.address,
+    );
+    await expect(vg.walletFromHash(hash2)).to.eventually.equal(
+      blsWallet.address,
+    );
 
     // // verify recovered bls key can successfully call wallet-only function (eg setTrustedGateway)
     const res = await fx.callStatic(
@@ -332,7 +336,7 @@ describe("Recovery", async function () {
     // Attacker waits out safety delay
     await fx.advanceTimeBy(safetyDelaySeconds + 1);
     await (await attackerWalletContract.setAnyPending()).wait();
-    expect(await attackerWalletContract.recoveryHash()).to.equal(
+    await expect(attackerWalletContract.recoveryHash()).to.eventually.equal(
       attackerRecoveryHash,
     );
 

--- a/contracts/test/upgrade-test.ts
+++ b/contracts/test/upgrade-test.ts
@@ -94,7 +94,7 @@ describe("Upgrade", async function () {
 
     const newBLSWallet = MockWalletUpgraded.attach(wallet.address);
     await (await newBLSWallet.setNewData(wallet.address)).wait();
-    expect(await newBLSWallet.newData()).to.equal(wallet.address);
+    await expect(newBLSWallet.newData()).to.eventually.equal(wallet.address);
   });
 
   it("should register with new verification gateway", async function () {
@@ -237,7 +237,9 @@ describe("Upgrade", async function () {
       expect(successes).to.deep.equal([true]);
     }
 
-    expect(await vg2.walletFromHash(hash)).not.to.equal(walletAddress);
+    await expect(vg2.walletFromHash(hash)).to.eventually.not.equal(
+      walletAddress,
+    );
 
     // Now actually perform the upgrade so we can perform some more detailed
     // checks.
@@ -264,15 +266,15 @@ describe("Upgrade", async function () {
     );
 
     // Direct checks corresponding to each action
-    expect(await vg2.walletFromHash(hash)).to.equal(walletAddress);
-    expect(await vg2.hashFromWallet(walletAddress)).to.equal(hash);
-    expect(await proxyAdmin.getProxyAdmin(walletAddress)).to.equal(
+    await expect(vg2.walletFromHash(hash)).to.eventually.equal(walletAddress);
+    await expect(vg2.hashFromWallet(walletAddress)).to.eventually.equal(hash);
+    await expect(proxyAdmin.getProxyAdmin(walletAddress)).to.eventually.equal(
       proxyAdmin.address,
     );
 
     const blsWallet = await ethers.getContractAt("BLSWallet", walletAddress);
     // New verification gateway pending
-    expect(await blsWallet.trustedBLSGateway()).to.equal(
+    await expect(blsWallet.trustedBLSGateway()).to.eventually.equal(
       fx.verificationGateway.address,
     );
     // Advance time one week
@@ -280,7 +282,9 @@ describe("Upgrade", async function () {
     // set pending
     await (await blsWallet.setAnyPending()).wait();
     // Check new verification gateway was set
-    expect(await blsWallet.trustedBLSGateway()).to.equal(vg2.address);
+    await expect(blsWallet.trustedBLSGateway()).to.eventually.equal(
+      vg2.address,
+    );
 
     // Check new gateway has wallet via static call through new gateway
     const bundleResult = await vg2.callStatic.processBundle(
@@ -328,8 +332,12 @@ describe("Upgrade", async function () {
 
     const hash1 = wallet1.blsWalletSigner.getPublicKeyHash(wallet1.privateKey);
 
-    expect(await vg1.walletFromHash(hash1)).to.equal(wallet1.address);
-    expect(await vg1.hashFromWallet(wallet1.address)).to.equal(hash1);
+    await expect(vg1.walletFromHash(hash1)).to.eventually.equal(
+      wallet1.address,
+    );
+    await expect(vg1.hashFromWallet(wallet1.address)).to.eventually.equal(
+      hash1,
+    );
 
     // wallet 2 bls key signs message containing address of wallet 1
     const addressMessage = solidityPack(["address"], [wallet1.address]);
@@ -376,11 +384,15 @@ describe("Upgrade", async function () {
     await fx.advanceTimeBy(safetyDelaySeconds + 1);
     await fx.call(wallet1, vg1, "setPendingBLSKeyForWallet", [], 2, 30_000_000);
 
-    expect(await vg1.walletFromHash(hash1)).to.equal(
+    await expect(vg1.walletFromHash(hash1)).to.eventually.equal(
       ethers.constants.AddressZero,
     );
-    expect(await vg1.walletFromHash(hash2)).to.equal(wallet1.address);
-    expect(await vg1.hashFromWallet(wallet1.address)).to.equal(hash2);
+    await expect(vg1.walletFromHash(hash2)).to.eventually.equal(
+      wallet1.address,
+    );
+    await expect(vg1.hashFromWallet(wallet1.address)).to.eventually.equal(
+      hash2,
+    );
   });
 
   it("should NOT allow walletAdminCall where first param is not calling wallet", async function () {

--- a/contracts/test/walletAction-test.ts
+++ b/contracts/test/walletAction-test.ts
@@ -153,10 +153,12 @@ describe("WalletActions", async function () {
     const mockAuction = await MockAuction.deploy();
     await mockAuction.deployed();
 
-    expect(await fx.provider.getBalance(sendWallet.address)).to.equal(
-      ethToTransfer,
-    );
-    expect(await fx.provider.getBalance(mockAuction.address)).to.equal(0);
+    await expect(
+      fx.provider.getBalance(sendWallet.address),
+    ).to.eventually.equal(ethToTransfer);
+    await expect(
+      fx.provider.getBalance(mockAuction.address),
+    ).to.eventually.equal(0);
 
     await fx.verificationGateway.processBundle(
       fx.blsWalletSigner.aggregate([
@@ -174,10 +176,12 @@ describe("WalletActions", async function () {
       ]),
     );
 
-    expect(await fx.provider.getBalance(sendWallet.address)).to.equal(0);
-    expect(await fx.provider.getBalance(mockAuction.address)).to.equal(
-      ethToTransfer,
-    );
+    await expect(
+      fx.provider.getBalance(sendWallet.address),
+    ).to.eventually.equal(0);
+    await expect(
+      fx.provider.getBalance(mockAuction.address),
+    ).to.eventually.equal(ethToTransfer);
   });
 
   it("should send ETH with function call via fallback expander", async function () {
@@ -193,10 +197,12 @@ describe("WalletActions", async function () {
     const mockAuction = await MockAuction.deploy();
     await mockAuction.deployed();
 
-    expect(await fx.provider.getBalance(sendWallet.address)).to.equal(
-      ethToTransfer,
-    );
-    expect(await fx.provider.getBalance(mockAuction.address)).to.equal(0);
+    await expect(
+      fx.provider.getBalance(sendWallet.address),
+    ).to.eventually.equal(ethToTransfer);
+    await expect(
+      fx.provider.getBalance(mockAuction.address),
+    ).to.eventually.equal(0);
 
     const bundle = await sendWallet.signWithGasEstimate({
       nonce: BigNumber.from(1),
@@ -224,10 +230,12 @@ describe("WalletActions", async function () {
       )
     ).wait();
 
-    expect(await fx.provider.getBalance(sendWallet.address)).to.equal(0);
-    expect(await fx.provider.getBalance(mockAuction.address)).to.equal(
-      ethToTransfer,
-    );
+    await expect(
+      fx.provider.getBalance(sendWallet.address),
+    ).to.eventually.equal(0);
+    await expect(
+      fx.provider.getBalance(mockAuction.address),
+    ).to.eventually.equal(ethToTransfer);
   });
 
   it("should check signature", async function () {


### PR DESCRIPTION
## What is this PR doing?

```ts
// bad
expect(await foo()).to.eq('bar');

// good
await expect(foo()).to.eventually.eq('bar');
```

This allows better errors to be surfaced - when the promise rejects, instead of emitting a naked exception, chai can capture it and give it more context.

## How can these changes be manually tested?

`yarn test`

## Does this PR resolve or contribute to any issues?

Nope.

## Checklist
- [x] I have manually tested these changes
- [x] Post a link to the PR in the group chat

## Guidelines
- If your PR is not ready, mark it as a draft
- The `resolve conversation` button is for reviewers, not authors
  - (But add a 'done' comment or similar)
