### PR TITLE
Fix deterministic creation of VG using ProxyAdminGenerator

### DIFF
--- a/contracts/contracts/ProxyAdminGenerator.sol
+++ b/contracts/contracts/ProxyAdminGenerator.sol
@@ -1,0 +1,25 @@
+//SPDX-License-Identifier: Unlicense
+pragma solidity >=0.8.4 <0.9.0;
+
+import "@openzeppelin/contracts/proxy/transparent/ProxyAdmin.sol";
+
+/**
+ * Generates a ProxyAdmin and transfers its ownership to msg.sender.
+ * 
+ * This is useful to avoid including ProxyAdmin in your contract bytecode.
+ * Instead ProxyAdmin is included in this contract, and this contract's address
+ * can be provided to your contract's constructor.
+ */
+contract ProxyAdminGenerator {
+  function generate(bytes32 salt) external returns (ProxyAdmin) {
+    // This salting technique ensures two things:
+    // 1. Your ProxyAdmin has a predetermined address
+    // 2. No one else can generate or prevent access to your ProxyAdmin
+    bytes32 fullSalt = keccak256(abi.encode(msg.sender, salt));
+
+    ProxyAdmin pa = new ProxyAdmin{salt: fullSalt}();
+    pa.transferOwnership(msg.sender);
+
+    return pa;
+  }
+}

--- a/contracts/contracts/VerificationGateway.sol
+++ b/contracts/contracts/VerificationGateway.sol
@@ -19,8 +19,11 @@ is the calling wallet's address.
  */
 contract VerificationGateway
 {
-    /** Domain chosen arbitrarily */
-    bytes32 BLS_DOMAIN = keccak256(abi.encodePacked(uint32(0xfeedbee5)));
+    /**
+     * Chosen arbitrarily
+     * =keccak256(abi.encodePacked(uint32(0xfeedbee5)))
+     */
+    bytes32 BLS_DOMAIN = 0x0054159611832e24cdd64c6a133e71d373c5f8553dde6c762e6bffe707ad83cc;
     uint8 constant BLS_KEY_LEN = 4;
 
     IBLS public immutable blsLib;

--- a/contracts/test/upgrade-test.ts
+++ b/contracts/test/upgrade-test.ts
@@ -3,7 +3,7 @@ import { BigNumber, ContractReceipt } from "ethers";
 import { solidityPack } from "ethers/lib/utils";
 import { ethers, network } from "hardhat";
 
-import { BLSOpen, ProxyAdmin } from "../typechain-types";
+import { BLSOpen, ProxyAdminGenerator } from "../typechain-types";
 import {
   ActionData,
   BlsWalletWrapper,
@@ -101,9 +101,10 @@ describe("Upgrade", async function () {
     // Deploy new verification gateway
     const create2Fixture = Create2Fixture.create();
     const bls = (await create2Fixture.create2Contract("BLSOpen")) as BLSOpen;
-    const ProxyAdmin = await ethers.getContractFactory("ProxyAdmin");
-    const proxyAdmin2 = (await ProxyAdmin.deploy()) as ProxyAdmin;
-    await proxyAdmin2.deployed();
+
+    const proxyAdminGenerator = (await create2Fixture.create2Contract(
+      "ProxyAdminGenerator",
+    )) as ProxyAdminGenerator;
 
     const blsWalletImpl = await create2Fixture.create2Contract("BLSWallet");
     const VerificationGateway = await ethers.getContractFactory(
@@ -112,9 +113,8 @@ describe("Upgrade", async function () {
     const vg2 = await VerificationGateway.deploy(
       bls.address,
       blsWalletImpl.address,
-      proxyAdmin2.address,
+      proxyAdminGenerator.address,
     );
-    await (await proxyAdmin2.transferOwnership(vg2.address)).wait();
 
     // Recreate hubble bls signer
     const walletOldVg = await fx.lazyBlsWallets[0]();


### PR DESCRIPTION
## What is this PR doing?

Extracted from https://github.com/web3well/bls-wallet/pull/464:

> In making the switch, I've also fixed the deterministic generation of VerificationGateway's ProxyAdmin using the new [ProxyAdminGenerator](https://github.com/web3well/bls-wallet/blob/bw-394-use-safe-singleton-factory/contracts/contracts/ProxyAdminGenerator.sol). This was critical to getting a predetermined address for VerificationGateway because proxyAdmin was a constructor parameter, which affects VerificationGateway's address. This was a pre-existing issue: https://github.com/web3well/bls-wallet/issues/332.

I had to inline `BLS_DOMAIN` and shorten some revert messages to stay inside the 30m deployment limit. These changes weren't needed in the original PR, I expect because deploying SafeSingletonFactory contract is more efficient. We can probably undo these changes later if we want to (or just benefit from the extra headroom).

## How can these changes be manually tested?

`yarn test`

## Does this PR resolve or contribute to any issues?

Resolves #332, #334.

## Checklist
- [x] I have manually tested these changes
- [x] Post a link to the PR in the group chat

## Guidelines
- If your PR is not ready, mark it as a draft
- The `resolve conversation` button is for reviewers, not authors
  - (But add a 'done' comment or similar)
