### PR TITLE
Fix intermittent test failure by using normalized hex strings

### DIFF
--- a/contracts/test/recovery-test.ts
+++ b/contracts/test/recovery-test.ts
@@ -252,12 +252,18 @@ describe("Recovery", async function () {
       [attackSignature, walletAttacker.PublicKey()],
       recoveredWalletNonce++,
     );
+
     const pendingKey = await Promise.all(
       [0, 1, 2, 3].map(async (i) =>
         (await vg.pendingBLSPublicKeyFromHash(hash1, i)).toHexString(),
       ),
     );
-    expect(pendingKey).to.deep.equal(walletAttacker.PublicKey());
+
+    const attackerPublicKeyHexStrings = walletAttacker
+      .PublicKey()
+      .map((keyElement) => BigNumber.from(keyElement).toHexString());
+
+    expect(pendingKey).to.deep.equal(attackerPublicKeyHexStrings);
 
     await fx.advanceTimeBy(safetyDelaySeconds / 2); // wait half the time
     // NB: advancing the time makes an empty tx with lazywallet[1]


### PR DESCRIPTION
## What is this PR doing?

Fixes intermittent test failure caused by differences in how bignumbers can be represented in hex.

I looked into all the `BigNumber` comparisons in the `contracts` tests and didn't find any other affected cases.

However... lesson time!

We have a lot of examples of this kind of thing in our tests:

```ts
expect(BigNumber.from(123)).to.equal(BigNumber.from(123));
```

This is *not* supposed to work. There is no operator overloading in JavaScript. `.equal` is supposed to use `===` to check for equality:

![Screen Shot 2023-02-14 at 2 47 28 pm](https://user-images.githubusercontent.com/9291586/218634308-072a43c6-58fb-4380-81f3-b2db42766771.png)
https://devdocs.io/chai/api/bdd/index#method_equal

`BigNumber(123) === BigNumber(123)` is `false` because they are two different objects (that model the same underlying concept, but different objects containing that concept nonetheless).

Indeed, if you try this program in isolation:

```ts
import { expect } from "chai";
import { BigNumber } from "ethers";

expect(BigNumber.from(123)).to.equal(BigNumber.from(123));
```

Output:

```
expect(BigNumber.from(123)).to.equal(BigNumber.from(123));
                               ^
AssertionError: expected BigNumber{ _hex: '0x7b', …(1) } to equal BigNumber{ _hex: '0x7b', …(1) }
```

The reason this doesn't happen in our tests is because we also import hardhat. Even just a bare import like this fixes the problem:

```diff
 import { expect } from "chai";
 import { BigNumber } from "ethers";
+import "hardhat";

 expect(BigNumber.from(123)).to.equal(BigNumber.from(123));
```

So... `hardhat` is monkeypatching `expect`. Not super-happy about that, but I guess someone thought that testing with hardhat would involve a lot of `BigNumber` comparisons, and users would like to be able to use it this way. I suppose they're right about that, but I wish they could have done `import { expectBigNumber } from "hardhat"` instead to avoid the bad practice and help out folks who wouldn't expect this thing to work.

Interestingly, `.deep.equal` is affected too:

```ts
expect([BigNumber.from(123)]).to.deep.equal([BigNumber.from(123)]); // ✅
```

and you can use `.equal` against a value that *converts* to a `BigNumber`:

```ts
expect(BigNumber.from(123)).to.equal(123); // ✅
```

**BUT** you can't use the above two things at the same time:

```ts
expect([BigNumber.from(123)]).to.deep.equal([123]); // ❌
```

May the footguns be ever in your favor 🤷‍♂️.

## How can these changes be manually tested?

Make this substitution in `Fixture.ts` to trigger the issue:

```diff
-          `0x${secretNumber.toString(16)}`,
+          i === 2 ? "0xbd97465e" : `0x${secretNumber.toString(16)}`,
```

This private key for `fx.lazyBlsWallets[2]` has the following public key:

```
[
  '0x154fcdf3c750850e806df59620e29b750cc7047818d775cd0611b3cddad89d39',
  '0x27e66e9559590e4732c8e1b2357488dde3c1b999971cf03305aaf1006b4eb9ba',
  '0x0041574c0b85b551f44344ed0086aa6a0530cb8c8994fc069b675d46fac549ad',
  '0x1e03d3faa20fa620784ee01cf2ca97f67f98557611cb98888d953c3fff0c55fa'
]
```

Crucially, the third element begins with `0x00`.

On `main`, run `should recover before bls key update`, verify that it fails.

On this branch, run it again and verify that it succeeds.

## Does this PR resolve or contribute to any issues?

Resolves #434.

## Checklist
- [x] I have manually tested these changes
- [x] Post a link to the PR in the group chat

## Guidelines
- If your PR is not ready, mark it as a draft
- The `resolve conversation` button is for reviewers, not authors
  - (But add a 'done' comment or similar)
