### PR TITLE
Add multi-action send transaction method to bls signer

### DIFF
--- a/contracts/clients/src/BlsProvider.ts
+++ b/contracts/clients/src/BlsProvider.ts
@@ -62,13 +62,13 @@ export default class BlsProvider extends ethers.providers.JsonRpcProvider {
       this,
     );
 
-    const actionsWithFeePaymentAction =
+    const actionWithFeePaymentAction =
       this._addFeePaymentActionForFeeEstimation([action]);
 
     const feeEstimate = await this.aggregator.estimateFee(
       this.signer.wallet.sign({
         nonce,
-        actions: [...actionsWithFeePaymentAction],
+        actions: [...actionWithFeePaymentAction],
       }),
     );
 

--- a/contracts/clients/src/BlsSigner.ts
+++ b/contracts/clients/src/BlsSigner.ts
@@ -2,7 +2,6 @@
 import { ethers, BigNumber, Signer, Bytes, BigNumberish } from "ethers";
 import {
   AccessListish,
-  BytesLike,
   Deferrable,
   hexlify,
   isBytes,
@@ -15,29 +14,6 @@ import addSafetyPremiumToFee from "./helpers/addSafetyDivisorToFee";
 import { ActionData, bundleToDto } from "./signer";
 
 export const _constructorGuard = {};
-
-/**
- * @param to - 20 Bytes The address the transaction is directed to. Undefined for creation transactions
- * @param value - the value sent with this transaction
- * @param gas - transaction gas limit
- * @param maxPriorityFeePerGas - miner tip aka priority fee
- * @param maxFeePerGas - the maximum total fee per gas the sender is willing to pay (includes the network/base fee and miner/priority fee) in wei
- * @param data - the hash of the invoked method signature and encoded parameters
- * @param nonce - integer of a nonce. This allows overwriting your own pending transactions that use the same nonce
- * @param chainId - chain ID that this transaction is valid on
- * @param accessList - EIP-2930 access list
- */
-export type Transaction = {
-  to?: string;
-  value?: BigNumberish;
-  gas?: BigNumberish;
-  maxPriorityFeePerGas?: BigNumberish;
-  maxFeePerGas?: BigNumberish;
-  data?: BytesLike;
-  nonce?: BigNumberish;
-  chainId?: number;
-  accessList?: Array<AccessListish>;
-};
 
 /**
  * @param gas - transaction gas limit
@@ -61,7 +37,7 @@ export type BatchOptions = {
  * @param batchOptions - optional batch options taken into account by SC wallets
  */
 export type TransactionBatch = {
-  transactions: Array<Transaction>;
+  transactions: Array<ethers.providers.TransactionRequest>;
   batchOptions?: BatchOptions;
 };
 
@@ -175,11 +151,9 @@ export default class BlsSigner extends Signer {
     await this.initPromise;
 
     const actions: Array<ActionData> = transactionBatch.transactions.map(
-      (transaction) => {
+      (transaction, i) => {
         if (!transaction.to) {
-          throw new TypeError(
-            "Transaction.to should be defined for all transactions",
-          );
+          throw new TypeError(`Transaction.to is missing on transaction ${i}`);
         }
 
         return {
@@ -378,11 +352,9 @@ export default class BlsSigner extends Signer {
     await this.initPromise;
 
     const actions: Array<ActionData> = transactionBatch.transactions.map(
-      (transaction) => {
+      (transaction, i) => {
         if (!transaction.to) {
-          throw new TypeError(
-            "Transaction.to should be defined for all transactions",
-          );
+          throw new TypeError(`Transaction.to is missing on transaction ${i}`);
         }
 
         return {

--- a/contracts/clients/src/helpers/addSafetyDivisorToFee.ts
+++ b/contracts/clients/src/helpers/addSafetyDivisorToFee.ts
@@ -1,0 +1,18 @@
+import { BigNumber } from "ethers";
+
+/**
+ * Used to add a small safety premium to estimated fees. This protects
+ * against small fluctuations is gas estimation, and thus increases
+ * the chance that bundles get accepted during aggregation.
+ *
+ * @param feeEstimate fee required for bundle
+ * @param safetyDivisor optional safety divisor. Default is 5
+ * @returns fee estimate with added safety premium
+ */
+export default function addSafetyPremiumToFee(
+  feeEstimate: BigNumber,
+  safetyDivisor: number = 5,
+): BigNumber {
+  const safetyPremium = feeEstimate.div(safetyDivisor);
+  return feeEstimate.add(safetyPremium);
+}

--- a/contracts/clients/test/BlsProvider.test.ts
+++ b/contracts/clients/test/BlsProvider.test.ts
@@ -149,35 +149,6 @@ describe("BlsProvider", () => {
     );
   });
 
-  it("should throw an error sending a transaction batch when this.signer is not defined", async () => {
-    // Arrange
-    const newBlsProvider = new Experimental.BlsProvider(
-      aggregatorUrl,
-      verificationGateway,
-      aggregatorUtilities,
-      rpcUrl,
-      network,
-    );
-    const signedTransaction = await blsSigner.signTransactionBatch({
-      transactions: [
-        {
-          value: parseEther("1"),
-          to: ethers.Wallet.createRandom().address,
-        },
-      ],
-    });
-
-    // Act
-    const result = async () =>
-      await newBlsProvider.sendTransactionBatch(signedTransaction);
-
-    // Assert
-    await expect(result()).to.be.rejectedWith(
-      Error,
-      "Call provider.getSigner first",
-    );
-  });
-
   it("should return the connection info for the provider", () => {
     // Arrange
     const expectedConnection = regularProvider.connection;

--- a/contracts/clients/test/BlsProvider.test.ts
+++ b/contracts/clients/test/BlsProvider.test.ts
@@ -149,6 +149,35 @@ describe("BlsProvider", () => {
     );
   });
 
+  it("should throw an error sending a transaction batch when this.signer is not defined", async () => {
+    // Arrange
+    const newBlsProvider = new Experimental.BlsProvider(
+      aggregatorUrl,
+      verificationGateway,
+      aggregatorUtilities,
+      rpcUrl,
+      network,
+    );
+    const signedTransaction = await blsSigner.signTransactionBatch({
+      transactions: [
+        {
+          value: parseEther("1"),
+          to: ethers.Wallet.createRandom().address,
+        },
+      ],
+    });
+
+    // Act
+    const result = async () =>
+      await newBlsProvider.sendTransactionBatch(signedTransaction);
+
+    // Assert
+    await expect(result()).to.be.rejectedWith(
+      Error,
+      "Call provider.getSigner first",
+    );
+  });
+
   it("should return the connection info for the provider", () => {
     // Arrange
     const expectedConnection = regularProvider.connection;

--- a/contracts/contracts/mock/MockERC20Spender.sol
+++ b/contracts/contracts/mock/MockERC20Spender.sol
@@ -1,0 +1,15 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import "@openzeppelin/contracts/token/ERC721/IERC721.sol";
+
+contract MockTokenSpender {
+    function TransferERC20ToSelf(address _token, uint256 _amount) public {
+        IERC20(_token).transferFrom(msg.sender, address(this), _amount);
+    }
+
+    function TransferERC721ToSelf(address _token, uint256 _tokenId) public {
+        IERC721(_token).transferFrom(msg.sender, address(this), _tokenId);
+    }
+}

--- a/contracts/test-integration/BlsProvider.test.ts
+++ b/contracts/test-integration/BlsProvider.test.ts
@@ -4,7 +4,9 @@ import { BigNumber, ethers } from "ethers";
 import { formatEther, parseEther } from "ethers/lib/utils";
 
 import {
+  AggregatorUtilities__factory,
   BlsWalletWrapper,
+  bundleToDto,
   Experimental,
   MockERC20__factory,
   NetworkConfig,
@@ -99,7 +101,7 @@ describe("BlsProvider", () => {
     await expect(gasEstimate()).to.not.be.rejected;
   });
 
-  it("should send ETH (empty call) given a valid bundle successfully", async () => {
+  it("should send ETH (empty call) given a valid bundle", async () => {
     // Arrange
     const recipient = ethers.Wallet.createRandom().address;
     const expectedBalance = parseEther("1");
@@ -125,6 +127,77 @@ describe("BlsProvider", () => {
     ).to.equal(expectedBalance);
   });
 
+  it("should throw an error when sending multiple signed operations to sendTransaction", async () => {
+    // Arrange
+    const expectedAmount = parseEther("1");
+    const verySafeFee = parseEther("0.1");
+    const firstRecipient = ethers.Wallet.createRandom().address;
+    const secondRecipient = ethers.Wallet.createRandom().address;
+
+    const aggregatorUtilitiesContract = AggregatorUtilities__factory.connect(
+      aggregatorUtilities,
+      blsProvider,
+    );
+
+    const firstOperation = {
+      nonce: await blsSigner.wallet.Nonce(),
+      actions: [
+        {
+          ethValue: expectedAmount,
+          contractAddress: firstRecipient,
+          encodedFunction: "0x",
+        },
+        {
+          ethValue: verySafeFee,
+          contractAddress: blsProvider.aggregatorUtilitiesAddress,
+          encodedFunction:
+            aggregatorUtilitiesContract.interface.encodeFunctionData(
+              "sendEthToTxOrigin",
+            ),
+        },
+      ],
+    };
+
+    const secondOperation = {
+      nonce: (await blsSigner.wallet.Nonce()).add(1),
+      actions: [
+        {
+          ethValue: expectedAmount,
+          contractAddress: secondRecipient,
+          encodedFunction: "0x",
+        },
+        {
+          ethValue: verySafeFee,
+          contractAddress: blsProvider.aggregatorUtilitiesAddress,
+          encodedFunction:
+            aggregatorUtilitiesContract.interface.encodeFunctionData(
+              "sendEthToTxOrigin",
+            ),
+        },
+      ],
+    };
+
+    const firstBundle = blsSigner.wallet.sign(firstOperation);
+    const secondBundle = blsSigner.wallet.sign(secondOperation);
+
+    const aggregatedBundle = blsSigner.wallet.blsWalletSigner.aggregate([
+      firstBundle,
+      secondBundle,
+    ]);
+
+    // Act
+    const result = async () =>
+      await blsProvider.sendTransaction(
+        JSON.stringify(bundleToDto(aggregatedBundle)),
+      );
+
+    // Assert
+    await expect(result()).to.rejectedWith(
+      Error,
+      "Can only operate on single operations. Call provider.sendTransactionBatch instead",
+    );
+  });
+
   it("should get the account nonce when the signer constructs the transaction response", async () => {
     // Arrange
     const spy = chai.spy.on(BlsWalletWrapper, "Nonce");
@@ -147,6 +220,7 @@ describe("BlsProvider", () => {
     // Once when calling "signer.signTransaction", once when calling "blsProvider.estimateGas", and once when calling "blsSigner.constructTransactionResponse".
     // This unit test is concerned with the latter being called.
     expect(spy).to.have.been.called.exactly(3);
+    chai.spy.restore(spy);
   });
 
   it("should throw an error when sending a modified signed transaction", async () => {
@@ -173,18 +247,187 @@ describe("BlsProvider", () => {
     );
   });
 
-  it("should throw an error when sending an invalid signed transaction", async () => {
+  it("should throw an error when sending invalid signed transactions", async () => {
     // Arrange
     const invalidTransaction = "Invalid signed transaction";
 
     // Act
     const result = async () =>
       await blsProvider.sendTransaction(invalidTransaction);
+    const batchResult = async () =>
+      await blsProvider.sendTransaction(invalidTransaction);
 
     // Assert
     await expect(result()).to.be.rejectedWith(
       Error,
       "Unexpected token I in JSON at position 0",
+    );
+    await expect(batchResult()).to.be.rejectedWith(
+      Error,
+      "Unexpected token I in JSON at position 0",
+    );
+  });
+
+  it("should send a batch of ETH transfers (empty calls) given a valid bundle", async () => {
+    // Arrange
+    const expectedAmount = parseEther("1");
+    const recipients = [];
+    const unsignedTransactionBatch = [];
+
+    for (let i = 0; i < 3; i++) {
+      recipients.push(ethers.Wallet.createRandom().address);
+      unsignedTransactionBatch.push({
+        to: recipients[i],
+        value: expectedAmount,
+      });
+    }
+
+    const signedTransactionBatch = await blsSigner.signTransactionBatch({
+      transactions: unsignedTransactionBatch,
+    });
+
+    // Act
+    const result = await blsProvider.sendTransactionBatch(
+      signedTransactionBatch,
+    );
+    await result.awaitBatch();
+
+    // Assert
+    expect(await blsProvider.getBalance(recipients[0])).to.equal(
+      expectedAmount,
+    );
+    expect(await blsProvider.getBalance(recipients[1])).to.equal(
+      expectedAmount,
+    );
+    expect(await blsProvider.getBalance(recipients[2])).to.equal(
+      expectedAmount,
+    );
+  });
+
+  it("should send a batch of ETH transfers (empty calls) given two aggregated bundles", async () => {
+    // Arrange
+    const expectedAmount = parseEther("1");
+    const verySafeFee = parseEther("0.1");
+    const firstRecipient = ethers.Wallet.createRandom().address;
+    const secondRecipient = ethers.Wallet.createRandom().address;
+
+    const aggregatorUtilitiesContract = AggregatorUtilities__factory.connect(
+      aggregatorUtilities,
+      blsProvider,
+    );
+
+    const firstOperation = {
+      nonce: await blsSigner.wallet.Nonce(),
+      actions: [
+        {
+          ethValue: expectedAmount,
+          contractAddress: firstRecipient,
+          encodedFunction: "0x",
+        },
+        {
+          ethValue: verySafeFee,
+          contractAddress: blsProvider.aggregatorUtilitiesAddress,
+          encodedFunction:
+            aggregatorUtilitiesContract.interface.encodeFunctionData(
+              "sendEthToTxOrigin",
+            ),
+        },
+      ],
+    };
+
+    const secondOperation = {
+      nonce: (await blsSigner.wallet.Nonce()).add(1),
+      actions: [
+        {
+          ethValue: expectedAmount,
+          contractAddress: secondRecipient,
+          encodedFunction: "0x",
+        },
+        {
+          ethValue: verySafeFee,
+          contractAddress: blsProvider.aggregatorUtilitiesAddress,
+          encodedFunction:
+            aggregatorUtilitiesContract.interface.encodeFunctionData(
+              "sendEthToTxOrigin",
+            ),
+        },
+      ],
+    };
+
+    const firstBundle = blsSigner.wallet.sign(firstOperation);
+    const secondBundle = blsSigner.wallet.sign(secondOperation);
+
+    const aggregatedBundle = blsSigner.wallet.blsWalletSigner.aggregate([
+      firstBundle,
+      secondBundle,
+    ]);
+
+    // Act
+    const result = await blsProvider.sendTransactionBatch(
+      JSON.stringify(bundleToDto(aggregatedBundle)),
+    );
+    await result.awaitBatch();
+
+    // Assert
+    expect(await blsProvider.getBalance(firstRecipient)).to.equal(
+      expectedAmount,
+    );
+    expect(await blsProvider.getBalance(secondRecipient)).to.equal(
+      expectedAmount,
+    );
+  });
+
+  it("should get the account nonce when the signer constructs the transaction batch response", async () => {
+    // Arrange
+    const spy = chai.spy.on(BlsWalletWrapper, "Nonce");
+    const recipient = ethers.Wallet.createRandom().address;
+    const expectedBalance = parseEther("1");
+
+    const unsignedTransaction = {
+      value: expectedBalance.toString(),
+      to: recipient,
+      data: "0x",
+    };
+    const signedTransaction = await blsSigner.signTransactionBatch({
+      transactions: [unsignedTransaction],
+    });
+
+    // Act
+    await blsProvider.sendTransactionBatch(signedTransaction);
+
+    // Assert
+    // Once when calling "signer.signTransaction", and once when calling "blsSigner.constructTransactionResponse".
+    // This unit test is concerned with the latter being called.
+    expect(spy).to.have.been.called.exactly(2);
+    chai.spy.restore(spy);
+  });
+
+  it("should throw an error when sending a modified signed transaction", async () => {
+    // Arrange
+    const address = await blsSigner.getAddress();
+
+    const signedTransaction = await blsSigner.signTransactionBatch({
+      transactions: [
+        {
+          value: parseEther("1"),
+          to: ethers.Wallet.createRandom().address,
+          data: "0x",
+        },
+      ],
+    });
+
+    const userBundle = JSON.parse(signedTransaction);
+    userBundle.operations[0].actions[0].ethValue = parseEther("2");
+    const invalidBundle = JSON.stringify(userBundle);
+
+    // Act
+    const result = async () =>
+      await blsProvider.sendTransactionBatch(invalidBundle);
+
+    // Assert
+    await expect(result()).to.be.rejectedWith(
+      Error,
+      `[{"type":"invalid-signature","description":"invalid signature for wallet address ${address}"}]`,
     );
   });
 

--- a/contracts/test-integration/BlsProvider.test.ts
+++ b/contracts/test-integration/BlsProvider.test.ts
@@ -4,7 +4,6 @@ import { BigNumber, ethers } from "ethers";
 import { formatEther, parseEther } from "ethers/lib/utils";
 
 import {
-  AggregatorUtilities__factory,
   BlsWalletWrapper,
   bundleToDto,
   Experimental,
@@ -134,47 +133,34 @@ describe("BlsProvider", () => {
     const firstRecipient = ethers.Wallet.createRandom().address;
     const secondRecipient = ethers.Wallet.createRandom().address;
 
-    const aggregatorUtilitiesContract = AggregatorUtilities__factory.connect(
-      aggregatorUtilities,
-      blsProvider,
-    );
-
-    const firstOperation = {
-      nonce: await blsSigner.wallet.Nonce(),
-      actions: [
+    const firstActionWithSafeFee = blsProvider._addFeePaymentActionWithSafeFee(
+      [
         {
           ethValue: expectedAmount,
           contractAddress: firstRecipient,
           encodedFunction: "0x",
         },
-        {
-          ethValue: verySafeFee,
-          contractAddress: blsProvider.aggregatorUtilitiesAddress,
-          encodedFunction:
-            aggregatorUtilitiesContract.interface.encodeFunctionData(
-              "sendEthToTxOrigin",
-            ),
-        },
       ],
-    };
-
-    const secondOperation = {
-      nonce: (await blsSigner.wallet.Nonce()).add(1),
-      actions: [
+      verySafeFee,
+    );
+    const secondActionWithSafeFee = blsProvider._addFeePaymentActionWithSafeFee(
+      [
         {
           ethValue: expectedAmount,
           contractAddress: secondRecipient,
           encodedFunction: "0x",
         },
-        {
-          ethValue: verySafeFee,
-          contractAddress: blsProvider.aggregatorUtilitiesAddress,
-          encodedFunction:
-            aggregatorUtilitiesContract.interface.encodeFunctionData(
-              "sendEthToTxOrigin",
-            ),
-        },
       ],
+      verySafeFee,
+    );
+
+    const firstOperation = {
+      nonce: await blsSigner.wallet.Nonce(),
+      actions: [...firstActionWithSafeFee],
+    };
+    const secondOperation = {
+      nonce: (await blsSigner.wallet.Nonce()).add(1),
+      actions: [...secondActionWithSafeFee],
     };
 
     const firstBundle = blsSigner.wallet.sign(firstOperation);
@@ -311,47 +297,34 @@ describe("BlsProvider", () => {
     const firstRecipient = ethers.Wallet.createRandom().address;
     const secondRecipient = ethers.Wallet.createRandom().address;
 
-    const aggregatorUtilitiesContract = AggregatorUtilities__factory.connect(
-      aggregatorUtilities,
-      blsProvider,
-    );
-
-    const firstOperation = {
-      nonce: await blsSigner.wallet.Nonce(),
-      actions: [
+    const firstActionWithSafeFee = blsProvider._addFeePaymentActionWithSafeFee(
+      [
         {
           ethValue: expectedAmount,
           contractAddress: firstRecipient,
           encodedFunction: "0x",
         },
-        {
-          ethValue: verySafeFee,
-          contractAddress: blsProvider.aggregatorUtilitiesAddress,
-          encodedFunction:
-            aggregatorUtilitiesContract.interface.encodeFunctionData(
-              "sendEthToTxOrigin",
-            ),
-        },
       ],
-    };
-
-    const secondOperation = {
-      nonce: (await blsSigner.wallet.Nonce()).add(1),
-      actions: [
+      verySafeFee,
+    );
+    const secondActionWithSafeFee = blsProvider._addFeePaymentActionWithSafeFee(
+      [
         {
           ethValue: expectedAmount,
           contractAddress: secondRecipient,
           encodedFunction: "0x",
         },
-        {
-          ethValue: verySafeFee,
-          contractAddress: blsProvider.aggregatorUtilitiesAddress,
-          encodedFunction:
-            aggregatorUtilitiesContract.interface.encodeFunctionData(
-              "sendEthToTxOrigin",
-            ),
-        },
       ],
+      verySafeFee,
+    );
+
+    const firstOperation = {
+      nonce: await blsSigner.wallet.Nonce(),
+      actions: [...firstActionWithSafeFee],
+    };
+    const secondOperation = {
+      nonce: (await blsSigner.wallet.Nonce()).add(1),
+      actions: [...secondActionWithSafeFee],
     };
 
     const firstBundle = blsSigner.wallet.sign(firstOperation);

--- a/contracts/test-integration/BlsProvider.test.ts
+++ b/contracts/test-integration/BlsProvider.test.ts
@@ -276,7 +276,7 @@ describe("BlsProvider", () => {
     const result = await blsProvider.sendTransactionBatch(
       signedTransactionBatch,
     );
-    await result.awaitBatch();
+    await result.awaitBatchReceipt();
 
     // Assert
     expect(await blsProvider.getBalance(recipients[0])).to.equal(
@@ -339,7 +339,7 @@ describe("BlsProvider", () => {
     const result = await blsProvider.sendTransactionBatch(
       JSON.stringify(bundleToDto(aggregatedBundle)),
     );
-    await result.awaitBatch();
+    await result.awaitBatchReceipt();
 
     // Assert
     expect(await blsProvider.getBalance(firstRecipient)).to.equal(

--- a/contracts/test-integration/BlsProviderContractInteraction.test.ts
+++ b/contracts/test-integration/BlsProviderContractInteraction.test.ts
@@ -161,6 +161,9 @@ describe("Provider tests", function () {
         .transfer(recipient, amountToTransfer);
       await tx.wait();
 
+      // wait 1 second to ensure listener count updates
+      await new Promise((resolve) => setTimeout(resolve, 1000));
+
       // Assert
       expect((await erc20.balanceOf(recipient)).sub(balanceBefore)).to.equal(
         amountToTransfer,

--- a/contracts/test-integration/BlsSigner.test.ts
+++ b/contracts/test-integration/BlsSigner.test.ts
@@ -510,7 +510,8 @@ describe("BlsSigner", () => {
     );
   });
 
-  it("should sign a transaction batch to create a bundleDto and serialize the result", async () => {
+  // TODO: passing in isolation but failing when run with whole file
+  it.skip("should sign a transaction batch to create a bundleDto and serialize the result", async () => {
     // Arrange
     const expectedAmount = parseEther("1");
 

--- a/contracts/test-integration/BlsSigner.test.ts
+++ b/contracts/test-integration/BlsSigner.test.ts
@@ -479,12 +479,18 @@ describe("BlsSigner", () => {
       walletAddress,
     );
 
+    const expectedBundleSignatureHexStrings = expectedBundle.signature.map(
+      (keyElement) => BigNumber.from(keyElement).toHexString(),
+    );
+
     // Act
     const signedTransaction = await blsSigner.signTransaction(transaction);
 
     // Assert
     const bundleDto = JSON.parse(signedTransaction);
-    expect(bundleDto.signature).to.deep.equal(expectedBundle.signature);
+    expect(bundleDto.signature).to.deep.equal(
+      expectedBundleSignatureHexStrings,
+    );
   });
 
   it("should throw an error when signing an invalid transaction", async () => {
@@ -507,7 +513,7 @@ describe("BlsSigner", () => {
     );
   });
 
-  it("should sign a transaction batch to create a bundleDto and serialize the result", async () => {
+  it.only("should sign a transaction batch to create a bundleDto and serialize the result", async () => {
     // Arrange
     const expectedAmount = parseEther("1");
 

--- a/contracts/test-integration/BlsSigner.test.ts
+++ b/contracts/test-integration/BlsSigner.test.ts
@@ -499,8 +499,7 @@ describe("BlsSigner", () => {
     );
   });
 
-  // TODO: passing in isolation but failing when run with whole file
-  it.skip("should sign a transaction batch to create a bundleDto and serialize the result", async () => {
+  it("should sign a transaction batch to create a bundleDto and serialize the result", async () => {
     // Arrange
     const expectedAmount = parseEther("1");
 

--- a/contracts/test-integration/BlsSigner.test.ts
+++ b/contracts/test-integration/BlsSigner.test.ts
@@ -211,11 +211,11 @@ describe("BlsSigner", () => {
     // Assert
     await expect(sendResult()).to.be.rejectedWith(
       TypeError,
-      "Transaction.to should be defined for all transactions",
+      "Transaction.to is missing on transaction 0",
     );
     await expect(signResult()).to.be.rejectedWith(
       TypeError,
-      "Transaction.to should be defined for all transactions",
+      "Transaction.to is missing on transaction 0",
     );
   });
 

--- a/contracts/test-integration/BlsSigner.test.ts
+++ b/contracts/test-integration/BlsSigner.test.ts
@@ -326,6 +326,35 @@ describe("BlsSigner", () => {
     );
   });
 
+  it("should throw an error sending a transaction batch when this.signer is not defined", async () => {
+    // Arrange
+    const newBlsProvider = new Experimental.BlsProvider(
+      aggregatorUrl,
+      verificationGateway,
+      aggregatorUtilities,
+      rpcUrl,
+      network,
+    );
+    const signedTransaction = await blsSigner.signTransactionBatch({
+      transactions: [
+        {
+          value: parseEther("1"),
+          to: ethers.Wallet.createRandom().address,
+        },
+      ],
+    });
+
+    // Act
+    const result = async () =>
+      await newBlsProvider.sendTransactionBatch(signedTransaction);
+
+    // Assert
+    await expect(result()).to.be.rejectedWith(
+      Error,
+      "Call provider.getSigner first",
+    );
+  });
+
   it("should throw an error when invalid private key is supplied", async () => {
     // Arrange
     const newBlsProvider = new Experimental.BlsProvider(

--- a/contracts/test-integration/BlsSigner.test.ts
+++ b/contracts/test-integration/BlsSigner.test.ts
@@ -192,22 +192,30 @@ describe("BlsSigner", () => {
     );
   });
 
-  it("should throw an error sending a transaction when 'transaction.to' has not been defined", async () => {
+  it("should throw an error sending & signing a transaction batch when 'transaction.to' has not been defined", async () => {
     // Arrange
     const transactionBatch = new Array(3).fill({
       ...{ value: parseEther("1") },
     });
 
     // Act
-    const result = async () =>
+    const sendResult = async () =>
       await blsSigner.sendTransactionBatch({
+        transactions: transactionBatch,
+      });
+    const signResult = async () =>
+      await blsSigner.signTransactionBatch({
         transactions: transactionBatch,
       });
 
     // Assert
-    await expect(result()).to.be.rejectedWith(
+    await expect(sendResult()).to.be.rejectedWith(
       TypeError,
-      "Transaction.to should be defined",
+      "Transaction.to should be defined for all transactions",
+    );
+    await expect(signResult()).to.be.rejectedWith(
+      TypeError,
+      "Transaction.to should be defined for all transactions",
     );
   });
 

--- a/contracts/test-integration/BlsSignerContractInteraction.test.ts
+++ b/contracts/test-integration/BlsSignerContractInteraction.test.ts
@@ -419,9 +419,7 @@ describe("Signer contract interaction tests", function () {
       const spender = mockTokenSpender.address;
       const tokenId = 7;
 
-      const mint = await mockERC721
-        .connect(blsSigners[0])
-        .safeMint(owner, tokenId);
+      const mint = await mockERC721.connect(blsSigners[0]).mint(owner, tokenId);
       await mint.wait();
 
       const transactionBatch = {

--- a/contracts/test-integration/BlsSignerContractInteraction.test.ts
+++ b/contracts/test-integration/BlsSignerContractInteraction.test.ts
@@ -221,7 +221,7 @@ describe("Signer contract interaction tests", function () {
 
       // Act
       const result = await blsSigners[0].sendTransactionBatch(transactionBatch);
-      await result.awaitBatch();
+      await result.awaitBatchReceipt();
 
       // Assert
       const newBalance = await mockERC20.balanceOf(spender);
@@ -445,7 +445,7 @@ describe("Signer contract interaction tests", function () {
 
       // Act
       const result = await blsSigners[3].sendTransactionBatch(transactionBatch);
-      await result.awaitBatch();
+      await result.awaitBatchReceipt();
 
       // Assert
       expect(await mockERC721.ownerOf(tokenId)).to.equal(spender);

--- a/contracts/test-integration/BlsSignerContractInteraction.test.ts
+++ b/contracts/test-integration/BlsSignerContractInteraction.test.ts
@@ -184,6 +184,50 @@ describe("Signer contract interaction tests", function () {
       expect(newBalance.sub(initialBalance)).to.equal(erc20ToTransfer);
     });
 
+    it("approve() and transferFrom() calls batched together", async () => {
+      // Arrange
+      const MockTokenSpender = await ethers.getContractFactory(
+        "MockTokenSpender",
+      );
+      const mockTokenSpender = await MockTokenSpender.connect(
+        fundedWallet,
+      ).deploy();
+      await mockTokenSpender.deployed();
+
+      const spender = mockTokenSpender.address;
+      const initialBalance = await mockERC20.balanceOf(spender);
+      const erc20ToTransfer = utils.parseUnits("33.6");
+
+      const transactionBatch = {
+        transactions: [
+          {
+            to: mockERC20.address,
+            value: 0,
+            data: mockERC20.interface.encodeFunctionData("approve", [
+              spender,
+              erc20ToTransfer,
+            ]),
+          },
+          {
+            to: spender,
+            value: 0,
+            data: mockTokenSpender.interface.encodeFunctionData(
+              "TransferERC20ToSelf",
+              [mockERC20.address, erc20ToTransfer],
+            ),
+          },
+        ],
+      };
+
+      // Act
+      const result = await blsSigners[0].sendTransactionBatch(transactionBatch);
+      await result.awaitBatch();
+
+      // Assert
+      const newBalance = await mockERC20.balanceOf(spender);
+      expect(newBalance.sub(initialBalance)).to.equal(erc20ToTransfer);
+    });
+
     it("contract factory connects and reconnects to new signer", async () => {
       // Truncated as not required for test
       const mockERC20Bytecode = "0x60806040523480";
@@ -359,6 +403,54 @@ describe("Signer contract interaction tests", function () {
 
       // Check signer[1]'s address is now an approved address for the token
       expect(await mockERC721.getApproved(tokenId)).to.equal(spender);
+    });
+
+    it("approve() and transferFrom() calls batched together", async () => {
+      // Arrange
+      const MockTokenSpender = await ethers.getContractFactory(
+        "MockTokenSpender",
+      );
+      const mockTokenSpender = await MockTokenSpender.connect(
+        fundedWallet,
+      ).deploy();
+      await mockTokenSpender.deployed();
+
+      const owner = await blsSigners[3].getAddress();
+      const spender = mockTokenSpender.address;
+      const tokenId = 7;
+
+      const mint = await mockERC721
+        .connect(blsSigners[0])
+        .safeMint(owner, tokenId);
+      await mint.wait();
+
+      const transactionBatch = {
+        transactions: [
+          {
+            to: mockERC721.address,
+            value: 0,
+            data: mockERC721.interface.encodeFunctionData("approve", [
+              spender,
+              tokenId,
+            ]),
+          },
+          {
+            to: mockTokenSpender.address,
+            value: 0,
+            data: mockTokenSpender.interface.encodeFunctionData(
+              "TransferERC721ToSelf",
+              [mockERC721.address, tokenId],
+            ),
+          },
+        ],
+      };
+
+      // Act
+      const result = await blsSigners[3].sendTransactionBatch(transactionBatch);
+      await result.awaitBatch();
+
+      // Assert
+      expect(await mockERC721.ownerOf(tokenId)).to.equal(spender);
     });
   });
 });


### PR DESCRIPTION
## What is this PR doing?
Adds multi-action transactions to bls provider and bls signer.

New methods were added as to not break the ethers provider base-class function signatures:
```ts
async sendTransactionBatch(transactionBatch: TransactionBatch): Promise<TransactionBatchResponse> {}

async constructTransactionBatchResponse(actions: Array<ActionData>, hash: string, from: string, nonce?: BigNumber): Promise<TransactionBatchResponse> {}

async signTransactionBatch(transactionBatch: TransactionBatch): Promise<string> {}

async sendTransactionBatch(signedTransactionBatch: string): Promise<TransactionBatchResponse> {}
```

### multi-action standards

TLDR ended up going for the [wallet_batchTransactions standard](https://gist.github.com/mikhailxyz/773ba5196b5a7046423592204e5bc5c4). It was the simplest option and we can easily build upon it as future requirements come up.
~**TLDR**: Gut feeling is EIP 5792 is the option to go for. But after reading the discussion on eth magicians, it feels like there is some pushback which makes me think it won't get adopted in it's current state. e.g. disagreements about standardisation of bundle identifiers and disagreement about level of 'atomicity'.~

New types:

```ts
export type TransactionBatch = {
  transactions: Array<Transaction>;
  batchOptions?: BatchOptions;
};
```

These were based on this [draft batch transaction standard](https://gist.github.com/mikhailxyz/773ba5196b5a7046423592204e5bc5c4) - `wallet_batchTransactions` JSON-RPC method. The idea was to ensure our code abides by a spec if one exists. There is no formal standard and it was a choice between the `wallet_batchTransactions` draft and [EIP 5792](https://eips.ethereum.org/EIPS/eip-5792) (draft). While the draft EIP is further along in it's journey towards becoming a standard (by this, I mean it's an actual draft EIP with discussion, as opposed to an informal draft), it's had some pushback in it's eth magicians thread. I've gone for the `wallet_batchTransactions` option for simplicity.

I've also created a new response type, this isn't based on any of the above standards, but it was easy to implement.
```ts
interface TransactionBatchResponse {
  transactions: Array<ethers.providers.TransactionResponse>;
  awaitBatchReceipt: (
    confirmations?: number,
  ) => Promise<ethers.providers.TransactionReceipt>;
}
```
___

## Further notes and other changes

1. Preliminary decision with `signer.sendTransactionBatch` was to only add transactions to a single operation. This means that all transactions in the batch will be atomic. Another option may be to give the developer a choice on whether to add transactions to different operations, and thus permit non-atomic transaction flows. Non-atomic tx flows are out of scope for this work.

2. provider.sendTransactionBatch operates on an already signed bundle, so could theoretically receive multiple operations. I've added some code to support this in case of that scenario:

```ts
    const actionData: Array<ActionData> = bundle.operations
      .map((operation) => operation.actions)
      .flat();
```

3. Abstracted common fee estimate code into helper functions:
    - Provider. _addFeePaymentActionForFeeEstimation
    - Provider. _addFeePaymentActionWithSafeFee
    - addSafetyDivisorToFee

## How can these changes be manually tested?
- run integration tests in workflow or locally

## Does this PR resolve or contribute to any issues?
Resolves https://github.com/web3well/bls-wallet/issues/375

## Checklist
- [x] I have manually tested these changes
- [x] Post a link to the PR in the group chat

## Guidelines
- If your PR is not ready, mark it as a draft
- The `resolve conversation` button is for reviewers, not authors
  - (But add a 'done' comment or similar)
