### PR TITLE
Improve private key management in BlsWalletWrapper

### DIFF
--- a/aggregator-proxy/package.json
+++ b/aggregator-proxy/package.json
@@ -21,7 +21,7 @@
     "@types/koa__cors": "^3.3.0",
     "@types/koa__router": "^8.0.11",
     "@types/node-fetch": "^2.6.1",
-    "bls-wallet-clients": "0.8.2-77f1638",
+    "bls-wallet-clients": "0.8.2-1452ef5",
     "fp-ts": "^2.12.1",
     "io-ts": "^2.2.16",
     "io-ts-reporters": "^2.0.1",

--- a/aggregator-proxy/yarn.lock
+++ b/aggregator-proxy/yarn.lock
@@ -887,10 +887,10 @@ bech32@1.1.4:
   resolved "https://registry.yarnpkg.com/bech32/-/bech32-1.1.4.tgz#e38c9f37bf179b8eb16ae3a772b40c356d4832e9"
   integrity sha512-s0IrSOzLlbvX7yp4WBfPITzpAU8sqQcpsmwXDiKwrG4r491vwCO/XpejasRNl0piBMe/DvP4Tz0mIS/X1DPJBQ==
 
-bls-wallet-clients@0.8.2-77f1638:
-  version "0.8.2-77f1638"
-  resolved "https://registry.yarnpkg.com/bls-wallet-clients/-/bls-wallet-clients-0.8.2-77f1638.tgz#61212aac502aed821bc6036cb95a2cdaa9c0b67e"
-  integrity sha512-2gTVHUvs4+/fBwgtcZCO+DsKTnJAiebYrpCUdygIqZaFeHdEyp6xU2F8ZT+XOcNoMeN1B9TT5EupV1RTvISFkQ==
+bls-wallet-clients@0.8.2-1452ef5:
+  version "0.8.2-1452ef5"
+  resolved "https://registry.yarnpkg.com/bls-wallet-clients/-/bls-wallet-clients-0.8.2-1452ef5.tgz#d76e938ca45ec5da44c8e59699d1bd5f6c69dcd2"
+  integrity sha512-bg7WLr9NRbvDzj+zgkLNfaPzr1m0m13Cc8RJoZ2s6s+ic7WxSiwxTkZGc2SChFgmG8ZGi1O9DnR6//lrTsMVUA==
   dependencies:
     "@thehubbleproject/bls" "^0.5.1"
     ethers "^5.7.2"

--- a/aggregator/deps.ts
+++ b/aggregator/deps.ts
@@ -53,7 +53,7 @@ export type {
   PublicKey,
   Signature,
   VerificationGateway,
-} from "https://esm.sh/bls-wallet-clients@0.8.2-77f1638";
+} from "https://esm.sh/bls-wallet-clients@0.8.2-1452ef5";
 
 export {
   Aggregator as AggregatorClient,
@@ -64,10 +64,10 @@ export {
   getConfig,
   MockERC20__factory,
   VerificationGateway__factory,
-} from "https://esm.sh/bls-wallet-clients@0.8.2-77f1638";
+} from "https://esm.sh/bls-wallet-clients@0.8.2-1452ef5";
 
 // Workaround for esbuild's export-star bug
-import blsWalletClients from "https://esm.sh/bls-wallet-clients@0.8.2-77f1638";
+import blsWalletClients from "https://esm.sh/bls-wallet-clients@0.8.2-1452ef5";
 const { bundleFromDto, bundleToDto, initBlsWalletSigner } = blsWalletClients;
 export { bundleFromDto, bundleToDto, initBlsWalletSigner };
 

--- a/aggregator/manualTests/createTestWallet.ts
+++ b/aggregator/manualTests/createTestWallet.ts
@@ -10,6 +10,6 @@ const wallet = await TestBlsWallet(
 );
 
 console.log({
-  privateKey: wallet.privateKey,
+  privateKey: wallet.blsWalletSigner.privateKey,
   address: wallet.walletContract.address,
 });

--- a/aggregator/src/app/EthereumService.ts
+++ b/aggregator/src/app/EthereumService.ts
@@ -133,7 +133,10 @@ export default class EthereumService {
 
     const nextNonce = BigNumber.from(await wallet.getTransactionCount());
     const chainId = await wallet.getChainId();
-    const blsWalletSigner = await initBlsWalletSigner({ chainId });
+    const blsWalletSigner = await initBlsWalletSigner({
+      chainId,
+      privateKey: aggPrivateKey,
+    });
 
     return new EthereumService(
       emit,

--- a/contracts/clients/README.md
+++ b/contracts/clients/README.md
@@ -365,9 +365,9 @@ import ethers from "ethers";
 import { initBlsWalletSigner } from "bls-wallet-clients";
 
 (async () => {
-  const signer = await initBlsWalletSigner({ chainId: 10 });
-
   const privateKey = "0x...256 bits of private hex data here";
+
+  const signer = await initBlsWalletSigner({ chainId: 10, privateKey });
 
   const someToken = new ethers.Contract(
     ...
@@ -387,7 +387,6 @@ import { initBlsWalletSigner } from "bls-wallet-clients";
         ethers.BigNumber.from(10).pow(18),
       ]),
     },
-    privateKey,
   );
 
   // Send bundle to an aggregator or use it with VerificationGateway directly.

--- a/contracts/clients/package.json
+++ b/contracts/clients/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bls-wallet-clients",
-  "version": "0.8.2-77f1638",
+  "version": "0.8.2-1452ef5",
   "description": "Client libraries for interacting with BLS Wallet components",
   "main": "dist/src/index.js",
   "types": "dist/src/index.d.ts",

--- a/contracts/clients/src/BlsSigner.ts
+++ b/contracts/clients/src/BlsSigner.ts
@@ -22,7 +22,7 @@ export default class BlsSigner extends Signer {
   constructor(
     constructorGuard: Record<string, unknown>,
     provider: BlsProvider,
-    privateKey: string | Promise<string>, // remove?
+    privateKey: string,
     readonly addressOrIndex?: string | number,
   ) {
     super();
@@ -53,10 +53,9 @@ export default class BlsSigner extends Signer {
     }
   }
 
-  private async initializeWallet(privateKey: string | Promise<string>) {
-    const resolvedPrivateKey = await privateKey;
+  private async initializeWallet(privateKey: string) {
     this.wallet = await BlsWalletWrapper.connect(
-      resolvedPrivateKey,
+      privateKey,
       this.verificationGatewayAddress,
       this.provider,
     );

--- a/contracts/clients/src/BlsSigner.ts
+++ b/contracts/clients/src/BlsSigner.ts
@@ -22,7 +22,7 @@ export default class BlsSigner extends Signer {
   constructor(
     constructorGuard: Record<string, unknown>,
     provider: BlsProvider,
-    privateKey: string | Promise<string>,
+    privateKey: string | Promise<string>, // remove?
     readonly addressOrIndex?: string | number,
   ) {
     super();
@@ -253,10 +253,10 @@ export default class BlsSigner extends Signer {
     return new UncheckedBlsSigner(
       _constructorGuard,
       this.provider,
-      this.wallet?.privateKey ??
+      this.wallet?.blsWalletSigner.privateKey ??
         (async (): Promise<string> => {
           await this.initPromise;
-          return this.wallet.privateKey;
+          return this.wallet.blsWalletSigner.privateKey;
         })(),
       this._address || this._index,
     );

--- a/contracts/clients/src/BlsWalletWrapper.ts
+++ b/contracts/clients/src/BlsWalletWrapper.ts
@@ -64,16 +64,14 @@ export default class BlsWalletWrapper {
    * @param privateKey private key associated with the wallet
    * @param verificationGatewayAddress address of the VerficationGateway contract
    * @param signerOrProvider ethers.js Signer or Provider
-   * @param blsWalletSigner (optional) a BLS Wallet signer
    * @returns The wallet's address
    */
   static async Address(
     privateKey: string,
     verificationGatewayAddress: string,
     signerOrProvider: SignerOrProvider,
-    blsWalletSigner?: BlsWalletSigner,
   ): Promise<string> {
-    blsWalletSigner ??= await this.#BlsWalletSigner(
+    const blsWalletSigner = await this.#BlsWalletSigner(
       signerOrProvider,
       privateKey,
     );

--- a/contracts/clients/src/BlsWalletWrapper.ts
+++ b/contracts/clients/src/BlsWalletWrapper.ts
@@ -330,6 +330,11 @@ export default class BlsWalletWrapper {
     return await initBlsWalletSigner({ chainId, privateKey });
   }
 
+  /**
+   * Binds the BlsWalletSigner instance to a new private key and chainId
+   *
+   * @returns The updated BlsWalletSigner object
+   */
   async setBlsWalletSigner(
     signerOrProvider: SignerOrProvider,
     privateKey: string,

--- a/contracts/clients/src/BlsWalletWrapper.ts
+++ b/contracts/clients/src/BlsWalletWrapper.ts
@@ -157,12 +157,9 @@ export default class BlsWalletWrapper {
     return blsWalletWrapper;
   }
 
-  async syncWallet(
-    verificationGateway: VerificationGateway,
-    privateKey: string,
-  ) {
+  async syncWallet(verificationGateway: VerificationGateway) {
     this.address = await BlsWalletWrapper.Address(
-      privateKey,
+      this.blsWalletSigner.privateKey,
       verificationGateway.address,
       verificationGateway.provider,
     );

--- a/contracts/clients/src/signer/getPublicKey.ts
+++ b/contracts/clients/src/signer/getPublicKey.ts
@@ -1,8 +1,12 @@
 import { signer } from "@thehubbleproject/bls";
 import { PublicKey } from "./types";
 
-export default (signerFactory: signer.BlsSignerFactory, domain: Uint8Array) =>
-  (privateKey: string): PublicKey => {
+export default (
+    signerFactory: signer.BlsSignerFactory,
+    domain: Uint8Array,
+    privateKey: string,
+  ) =>
+  (): PublicKey => {
     const signer = signerFactory.getSigner(domain, privateKey);
     return signer.pubkey;
   };

--- a/contracts/clients/src/signer/getPublicKeyHash.ts
+++ b/contracts/clients/src/signer/getPublicKeyHash.ts
@@ -3,11 +3,15 @@ import { signer } from "@thehubbleproject/bls";
 
 import getPublicKey from "./getPublicKey";
 
-export default (signerFactory: signer.BlsSignerFactory, domain: Uint8Array) =>
-  (privateKey: string): string => {
-    const publicKey = getPublicKey(signerFactory, domain)(privateKey);
+export default (
+    signerFactory: signer.BlsSignerFactory,
+    domain: Uint8Array,
+    privateKey: string,
+  ) =>
+  (): string => {
+    const publicKey = getPublicKey(signerFactory, domain, privateKey);
     return solidityKeccak256(
       ["uint256", "uint256", "uint256", "uint256"],
-      publicKey,
+      publicKey(),
     );
   };

--- a/contracts/clients/src/signer/getPublicKeyStr.ts
+++ b/contracts/clients/src/signer/getPublicKeyStr.ts
@@ -1,7 +1,11 @@
 import { signer, mcl } from "@thehubbleproject/bls";
 
-export default (signerFactory: signer.BlsSignerFactory, domain: Uint8Array) =>
-  (privateKey: string): string => {
+export default (
+    signerFactory: signer.BlsSignerFactory,
+    domain: Uint8Array,
+    privateKey: string,
+  ) =>
+  (): string => {
     const signer = signerFactory.getSigner(domain, privateKey);
     return mcl.dumpG2(signer.pubkey);
   };

--- a/contracts/clients/src/signer/index.ts
+++ b/contracts/clients/src/signer/index.ts
@@ -18,9 +18,11 @@ export type BlsWalletSigner = AsyncReturnType<typeof initBlsWalletSigner>;
 export async function initBlsWalletSigner({
   domain = defaultDomain,
   chainId,
+  privateKey,
 }: {
   domain?: Uint8Array;
   chainId: number;
+  privateKey: string;
 }) {
   // Note: Getting signers via this factory ensures that mcl-wasm's underlying
   // init() has been called when signing. However, other operations such as
@@ -32,11 +34,12 @@ export async function initBlsWalletSigner({
 
   return {
     aggregate,
-    getPublicKey: getPublicKey(signerFactory, domain),
-    getPublicKeyHash: getPublicKeyHash(signerFactory, domain),
-    getPublicKeyStr: getPublicKeyStr(signerFactory, domain),
-    sign: sign(signerFactory, domain, chainId),
-    signMessage: signMessage(signerFactory, domain),
+    getPublicKey: getPublicKey(signerFactory, domain, privateKey),
+    getPublicKeyHash: getPublicKeyHash(signerFactory, domain, privateKey),
+    getPublicKeyStr: getPublicKeyStr(signerFactory, domain, privateKey),
+    sign: sign(signerFactory, domain, chainId, privateKey),
+    signMessage: signMessage(signerFactory, domain, privateKey),
     verify: verify(domain, chainId),
+    privateKey,
   };
 }

--- a/contracts/clients/src/signer/sign.ts
+++ b/contracts/clients/src/signer/sign.ts
@@ -7,8 +7,9 @@ export default (
     signerFactory: signer.BlsSignerFactory,
     domain: Uint8Array,
     chainId: number,
+    privateKey: string,
   ) =>
-  (operation: Operation, privateKey: string, walletAddress: string): Bundle => {
+  (operation: Operation, walletAddress: string): Bundle => {
     const signer = signerFactory.getSigner(domain, privateKey);
     const message = encodeMessageForSigning(chainId)(operation, walletAddress);
     const signature = signer.sign(message);

--- a/contracts/clients/src/signer/signMessage.ts
+++ b/contracts/clients/src/signer/signMessage.ts
@@ -1,7 +1,11 @@
 import { signer, mcl } from "@thehubbleproject/bls";
 
-export default (signerFactory: signer.BlsSignerFactory, domain: Uint8Array) =>
-  (message: string, privateKey: string): mcl.solG1 => {
+export default (
+    signerFactory: signer.BlsSignerFactory,
+    domain: Uint8Array,
+    privateKey: string,
+  ) =>
+  (message: string): mcl.solG1 => {
     const signer = signerFactory.getSigner(domain, privateKey);
     return signer.sign(message);
   };

--- a/contracts/clients/test/index.test.ts
+++ b/contracts/clients/test/index.test.ts
@@ -47,15 +47,16 @@ const samples = (() => {
 
 describe("index", () => {
   it("signs and verifies transaction", async () => {
-    const { sign, verify } = await initBlsWalletSigner({
-      chainId: 123,
-      domain,
-    });
-
     const { bundleTemplate, privateKey, otherPrivateKey, walletAddress } =
       samples;
 
-    const bundle = sign(bundleTemplate, privateKey, walletAddress);
+    const { sign, verify } = await initBlsWalletSigner({
+      chainId: 123,
+      domain,
+      privateKey,
+    });
+
+    const bundle = sign(bundleTemplate, walletAddress);
 
     expect(bundle.signature).to.deep.equal([
       "0x2c1b0dc6643375e05a6f2ba3d23b1ce941253010b13a127e22f5db647dc37952",
@@ -64,9 +65,16 @@ describe("index", () => {
 
     expect(verify(bundle, walletAddress)).to.equal(true);
 
+    const { sign: signWithOtherPrivateKey } = await initBlsWalletSigner({
+      chainId: 123,
+      domain,
+      privateKey: otherPrivateKey,
+    });
+
     const bundleBadSig = {
       ...bundle,
-      signature: sign(bundleTemplate, otherPrivateKey, walletAddress).signature,
+      signature: signWithOtherPrivateKey(bundleTemplate, walletAddress)
+        .signature,
     };
 
     expect(verify(bundleBadSig, walletAddress)).to.equal(false);
@@ -88,16 +96,10 @@ describe("index", () => {
       ],
       signature: bundle.signature,
     };
-
     expect(verify(bundleBadMessage, walletAddress)).to.equal(false);
   });
 
   it("aggregates transactions", async () => {
-    const { sign, aggregate, verify } = await initBlsWalletSigner({
-      chainId: 123,
-      domain,
-    });
-
     const {
       bundleTemplate,
       privateKey,
@@ -106,8 +108,19 @@ describe("index", () => {
       otherWalletAddress,
     } = samples;
 
-    const bundle1 = sign(bundleTemplate, privateKey, walletAddress);
-    const bundle2 = sign(bundleTemplate, otherPrivateKey, otherWalletAddress);
+    const { sign, aggregate, verify } = await initBlsWalletSigner({
+      chainId: 123,
+      domain,
+      privateKey,
+    });
+    const { sign: signWithOtherPrivateKey } = await initBlsWalletSigner({
+      chainId: 123,
+      domain,
+      privateKey: otherPrivateKey,
+    });
+
+    const bundle1 = sign(bundleTemplate, walletAddress);
+    const bundle2 = signWithOtherPrivateKey(bundleTemplate, otherWalletAddress);
     const aggBundle = aggregate([bundle1, bundle2]);
 
     expect(aggBundle.signature).to.deep.equal([
@@ -145,12 +158,13 @@ describe("index", () => {
   });
 
   it("can aggregate transactions which already have multiple subTransactions", async () => {
+    const { bundleTemplate, privateKey, walletAddress } = samples;
+
     const { sign, aggregate, verify } = await initBlsWalletSigner({
       chainId: 123,
       domain,
+      privateKey,
     });
-
-    const { bundleTemplate, privateKey, walletAddress } = samples;
 
     const bundles = Range(4).map((i) =>
       sign(
@@ -163,7 +177,6 @@ describe("index", () => {
             },
           ],
         },
-        privateKey,
         walletAddress,
       ),
     );
@@ -177,12 +190,15 @@ describe("index", () => {
   });
 
   it("generates expected publicKeyStr", async () => {
+    const { privateKey } = samples;
+
     const { getPublicKeyStr } = await initBlsWalletSigner({
       chainId: 123,
       domain,
+      privateKey,
     });
 
-    expect(getPublicKeyStr(samples.privateKey)).to.equal(
+    expect(getPublicKeyStr()).to.equal(
       [
         "0x",
         "027c3c0483be2722a29a0229bef64b2d8c1f8d4e954b0203d01ce342608b6eb8",
@@ -194,9 +210,12 @@ describe("index", () => {
   });
 
   it("aggregates an empty bundle", async () => {
+    const { privateKey } = samples;
+
     const { aggregate } = await initBlsWalletSigner({
       chainId: 123,
       domain,
+      privateKey,
     });
 
     const emptyBundle = aggregate([]);
@@ -206,9 +225,12 @@ describe("index", () => {
   });
 
   it("verifies an empty bundle", async () => {
+    const { privateKey } = samples;
+
     const { aggregate, verify } = await initBlsWalletSigner({
       chainId: 123,
       domain,
+      privateKey,
     });
 
     const emptyBundle = aggregate([]);

--- a/contracts/clients/test/index.test.ts
+++ b/contracts/clients/test/index.test.ts
@@ -96,6 +96,7 @@ describe("index", () => {
       ],
       signature: bundle.signature,
     };
+
     expect(verify(bundleBadMessage, walletAddress)).to.equal(false);
   });
 

--- a/contracts/shared/helpers/Fixture.ts
+++ b/contracts/shared/helpers/Fixture.ts
@@ -133,6 +133,8 @@ export default class Fixture {
       };
     });
 
+    const privateKey = await BlsWalletWrapper.getRandomBlsPrivateKey();
+
     return new Fixture(
       chainId,
       ethers.provider,
@@ -144,7 +146,7 @@ export default class Fixture {
       blsExpander,
       utilities,
       BLSWallet,
-      await initBlsWalletSigner({ chainId }),
+      await initBlsWalletSigner({ chainId, privateKey }),
     );
   }
 

--- a/contracts/shared/helpers/Fixture.ts
+++ b/contracts/shared/helpers/Fixture.ts
@@ -87,18 +87,18 @@ export default class Fixture {
     ).wait();
 
     // deploy BLSExpander Gateway
-    const blsExpander = await create2Fixture.create2Contract(
+    const blsExpander = (await create2Fixture.create2Contract(
       "BLSExpander",
       ethers.utils.defaultAbiCoder.encode(
         ["address"],
         [verificationGateway.address],
       ),
-    );
+    )) as BLSExpander;
 
     // deploy utilities
-    const utilities = await create2Fixture.create2Contract(
+    const utilities = (await create2Fixture.create2Contract(
       "AggregatorUtilities",
-    );
+    )) as AggregatorUtilities;
 
     const BLSWallet = await ethers.getContractFactory("BLSWallet");
 

--- a/contracts/shared/helpers/callProxyAdmin.ts
+++ b/contracts/shared/helpers/callProxyAdmin.ts
@@ -33,7 +33,7 @@ export async function proxyAdminBundle(
   );
   const encodedWalletAdminCall =
     fx.verificationGateway.interface.encodeFunctionData("walletAdminCall", [
-      wallet.blsWalletSigner.getPublicKeyHash(wallet.privateKey),
+      wallet.blsWalletSigner.getPublicKeyHash(),
       encodedGetProxyAdmin,
     ]);
   const action: ActionData = {

--- a/contracts/test-integration/BlsSigner.test.ts
+++ b/contracts/test-integration/BlsSigner.test.ts
@@ -283,7 +283,6 @@ describe("BlsSigner", () => {
 
     const expectedBundle = wallet.blsWalletSigner.sign(
       operation,
-      privateKey,
       walletAddress,
     );
 
@@ -371,10 +370,7 @@ describe("BlsSigner", () => {
     // Arrange
     const address = ethers.Wallet.createRandom().address;
     const blsWalletSignerSignature =
-      blsSigner.wallet.blsWalletSigner.signMessage(
-        address,
-        blsSigner.wallet.privateKey,
-      );
+      blsSigner.wallet.blsWalletSigner.signMessage(address);
 
     const expectedSignature = RLP.encode(blsWalletSignerSignature);
 
@@ -391,10 +387,7 @@ describe("BlsSigner", () => {
     const bytes: number[] = [68, 219, 115, 219, 26, 248, 170, 165]; // random bytes
     const hexString = ethers.utils.hexlify(bytes);
     const blsWalletSignerSignature =
-      blsSigner.wallet.blsWalletSigner.signMessage(
-        hexString,
-        blsSigner.wallet.privateKey,
-      );
+      blsSigner.wallet.blsWalletSigner.signMessage(hexString);
 
     const expectedSignature = RLP.encode(blsWalletSignerSignature);
 

--- a/contracts/test/recovery-test.ts
+++ b/contracts/test/recovery-test.ts
@@ -246,7 +246,6 @@ describe("Recovery", async function () {
       fx,
       wallet1.address,
       walletAttacker.blsWalletSigner.privateKey,
-      // walletAttacker.privateKey,
     );
 
     // Attacker assumed to have compromised wallet1 bls key, and wishes to reset
@@ -330,8 +329,7 @@ describe("Recovery", async function () {
      *
      * For now cast to 'any'.
      */
-    await wallet2.syncWallet(vg as any, wallet2.blsWalletSigner.privateKey);
-    // await wallet2.syncWallet(vg as any);
+    await wallet2.syncWallet(vg as any);
     await fx.call(
       wallet2,
       vg,
@@ -350,7 +348,7 @@ describe("Recovery", async function () {
       blsWallet.address,
     );
 
-    // // verify recovered bls key can successfully call wallet-only function (eg setTrustedGateway)
+    // verify recovered bls key can successfully call wallet-only function (eg setTrustedGateway)
     const res = await fx.callStatic(
       wallet2,
       vg,

--- a/contracts/test/recovery-test.ts
+++ b/contracts/test/recovery-test.ts
@@ -51,7 +51,7 @@ describe("Recovery", async function () {
   let blsWallet: BLSWallet;
   let blsWallet3: BLSWallet;
   let recoverySigner;
-  let hash1, hash2, hashAttacker;
+  let wallet1PublicKeyHash, wallet2PublicKeyHash, walletAttackerPublicKeyHash;
   let salt;
   let recoveryHash;
   beforeEach(async function () {
@@ -66,18 +66,21 @@ describe("Recovery", async function () {
     blsWallet3 = await ethers.getContractAt("BLSWallet", wallet3.address);
     recoverySigner = (await ethers.getSigners())[1];
 
-    hash1 = wallet1.blsWalletSigner.getPublicKeyHash();
-    hash2 = wallet2.blsWalletSigner.getPublicKeyHash();
-    hashAttacker = walletAttacker.blsWalletSigner.getPublicKeyHash();
+    wallet1PublicKeyHash = wallet1.blsWalletSigner.getPublicKeyHash();
+    wallet2PublicKeyHash = wallet2.blsWalletSigner.getPublicKeyHash();
+    walletAttackerPublicKeyHash =
+      walletAttacker.blsWalletSigner.getPublicKeyHash();
     salt = "0x1234567812345678123456781234567812345678123456781234567812345678";
     recoveryHash = ethers.utils.solidityKeccak256(
       ["address", "bytes32", "bytes32"],
-      [recoverySigner.address, hash1, salt],
+      [recoverySigner.address, wallet1PublicKeyHash, salt],
     );
   });
 
   it("should update bls key", async function () {
-    expect(await vg.hashFromWallet(wallet1.address)).to.eql(hash1);
+    expect(await vg.hashFromWallet(wallet1.address)).to.eql(
+      wallet1PublicKeyHash,
+    );
 
     const addressSignature = await signWalletAddress(
       fx,
@@ -96,25 +99,27 @@ describe("Recovery", async function () {
     await fx.advanceTimeBy(safetyDelaySeconds + 1);
     await fx.call(wallet1, vg, "setPendingBLSKeyForWallet", [], 2);
 
-    expect(await vg.hashFromWallet(wallet1.address)).to.eql(hash2);
+    expect(await vg.hashFromWallet(wallet1.address)).to.eql(
+      wallet2PublicKeyHash,
+    );
   });
 
   it("should NOT override public key hash after creation", async function () {
-    let walletForHash = await vg.walletFromHash(hash1);
+    let walletForHash = await vg.walletFromHash(wallet1PublicKeyHash);
     expect(BigNumber.from(walletForHash)).to.not.equal(BigNumber.from(0));
     expect(walletForHash).to.equal(wallet1.address);
 
     let hashFromWallet = await vg.hashFromWallet(wallet1.address);
     expect(BigNumber.from(hashFromWallet)).to.not.equal(BigNumber.from(0));
-    expect(hashFromWallet).to.equal(hash1);
+    expect(hashFromWallet).to.equal(wallet1PublicKeyHash);
 
     await fx.call(wallet1, vg, "setPendingBLSKeyForWallet", [], 1);
 
-    walletForHash = await vg.walletFromHash(hash1);
+    walletForHash = await vg.walletFromHash(wallet1PublicKeyHash);
     expect(walletForHash).to.equal(wallet1.address);
 
     hashFromWallet = await vg.hashFromWallet(wallet1.address);
-    expect(hashFromWallet).to.equal(hash1);
+    expect(hashFromWallet).to.equal(wallet1PublicKeyHash);
   });
 
   it("should set recovery hash", async function () {
@@ -126,7 +131,7 @@ describe("Recovery", async function () {
     salt = "0x" + "AB".repeat(32);
     const newRecoveryHash = ethers.utils.solidityKeccak256(
       ["address", "bytes32", "bytes32"],
-      [recoverySigner.address, hash1, salt],
+      [recoverySigner.address, wallet1PublicKeyHash, salt],
     );
     await fx.call(wallet1, blsWallet, "setRecoveryHash", [newRecoveryHash], 2);
     expect(await blsWallet.recoveryHash()).to.equal(recoveryHash);
@@ -192,7 +197,7 @@ describe("Recovery", async function () {
     // wallet 2 address is recovery address of wallet 1
     recoveryHash = ethers.utils.solidityKeccak256(
       ["address", "bytes32", "bytes32"],
-      [wallet2.address, hash1, salt],
+      [wallet2.address, wallet1PublicKeyHash, salt],
     );
     let w1Nonce = 1;
     await fx.call(
@@ -217,7 +222,7 @@ describe("Recovery", async function () {
       wallet2,
       vg,
       "recoverWallet",
-      [addressSignature, hash1, salt, wallet3.PublicKey()],
+      [addressSignature, wallet1PublicKeyHash, salt, wallet3.PublicKey()],
       w2Nonce++,
     );
 
@@ -256,7 +261,9 @@ describe("Recovery", async function () {
 
     const pendingKey = await Promise.all(
       [0, 1, 2, 3].map(async (i) =>
-        (await vg.pendingBLSPublicKeyFromHash(hash1, i)).toHexString(),
+        (
+          await vg.pendingBLSPublicKeyFromHash(wallet1PublicKeyHash, i)
+        ).toHexString(),
       ),
     );
 
@@ -289,12 +296,16 @@ describe("Recovery", async function () {
     await (
       await fx.verificationGateway
         .connect(recoverySigner)
-        .recoverWallet(addressSignature, hash1, salt, safeKey)
+        .recoverWallet(addressSignature, wallet1PublicKeyHash, salt, safeKey)
     ).wait();
 
     // key reset via recovery
-    expect(await vg.hashFromWallet(wallet1.address)).to.eql(hash2);
-    expect(await vg.walletFromHash(hash2)).to.eql(wallet1.address);
+    expect(await vg.hashFromWallet(wallet1.address)).to.eql(
+      wallet2PublicKeyHash,
+    );
+    expect(await vg.walletFromHash(wallet2PublicKeyHash)).to.eql(
+      wallet1.address,
+    );
 
     await fx.advanceTimeBy(safetyDelaySeconds / 2 + 1); // wait remainder the time
     // NB: advancing the time makes an empty tx with lazywallet[1]
@@ -329,21 +340,22 @@ describe("Recovery", async function () {
       recoveredWalletNonce++, // await wallet2.Nonce(),
     );
 
-    console.log("here1");
-    expect(await vg.walletFromHash(hash1)).to.not.equal(blsWallet.address);
-    console.log("here2");
-    expect(await vg.walletFromHash(hashAttacker)).to.not.equal(
+    expect(await vg.walletFromHash(wallet1PublicKeyHash)).to.not.equal(
       blsWallet.address,
     );
-    console.log("here3");
-    expect(await vg.walletFromHash(hash2)).to.equal(blsWallet.address);
+    expect(await vg.walletFromHash(walletAttackerPublicKeyHash)).to.not.equal(
+      blsWallet.address,
+    );
+    expect(await vg.walletFromHash(wallet2PublicKeyHash)).to.equal(
+      blsWallet.address,
+    );
 
     // // verify recovered bls key can successfully call wallet-only function (eg setTrustedGateway)
     const res = await fx.callStatic(
       wallet2,
       vg,
       "setTrustedBLSGateway",
-      [hash2, vg.address],
+      [wallet2PublicKeyHash, vg.address],
       recoveredWalletNonce, // await wallet2.Nonce(),
     );
     expect(res.successes[0]).to.equal(true);
@@ -359,7 +371,7 @@ describe("Recovery", async function () {
     // Attacker users recovery signer to set their recovery hash
     const attackerRecoveryHash = ethers.utils.solidityKeccak256(
       ["address", "bytes32", "bytes32"],
-      [recoverySigner.address, hashAttacker, salt],
+      [recoverySigner.address, walletAttackerPublicKeyHash, salt],
     );
     await fx.call(
       walletAttacker,
@@ -387,7 +399,12 @@ describe("Recovery", async function () {
     await expect(
       fx.verificationGateway
         .connect(recoverySigner)
-        .recoverWallet(addressSignature, hashAttacker, salt, wallet1Key),
+        .recoverWallet(
+          addressSignature,
+          walletAttackerPublicKeyHash,
+          salt,
+          wallet1Key,
+        ),
     ).to.be.rejectedWith("VG: Signature not verified for wallet address");
   });
 
@@ -414,7 +431,12 @@ describe("Recovery", async function () {
 
     const recoveryTxn = await fx.verificationGateway
       .connect(recoverySigner)
-      .recoverWallet(addressSignature, hash1, salt, wallet2.PublicKey());
+      .recoverWallet(
+        addressSignature,
+        wallet1PublicKeyHash,
+        salt,
+        wallet2.PublicKey(),
+      );
     await recoveryTxn.wait();
 
     const [wallet1PubkeyHash, wallet2PubkeyHash, wallet1Nonce, wallet2Nonce] =
@@ -424,8 +446,8 @@ describe("Recovery", async function () {
         wallet1.Nonce(),
         wallet2.Nonce(),
       ]);
-    expect(wallet1PubkeyHash).to.eql(hash2);
-    expect(wallet2PubkeyHash).to.eql(hash2);
+    expect(wallet1PubkeyHash).to.eql(wallet2PublicKeyHash);
+    expect(wallet2PubkeyHash).to.eql(wallet2PublicKeyHash);
     expect(wallet1Nonce.toNumber()).to.eql(wallet2Nonce.toNumber());
 
     // Attempt to run a bundle from wallet 2 through wallet 1

--- a/contracts/test/upgrade-test.ts
+++ b/contracts/test/upgrade-test.ts
@@ -119,7 +119,7 @@ describe("Upgrade", async function () {
     // Recreate hubble bls signer
     const walletOldVg = await fx.lazyBlsWallets[0]();
     const walletAddress = walletOldVg.address;
-    const blsSecret = walletOldVg.privateKey;
+    const blsSecret = walletOldVg.blsWalletSigner.privateKey;
 
     const wallet = await BlsWalletWrapper.connect(
       blsSecret,
@@ -150,9 +150,7 @@ describe("Upgrade", async function () {
     // Advance time one week
     await fx.advanceTimeBy(safetyDelaySeconds + 1);
 
-    const hash = walletOldVg.blsWalletSigner.getPublicKeyHash(
-      walletOldVg.privateKey,
-    );
+    const hash = walletOldVg.blsWalletSigner.getPublicKeyHash();
 
     const setExternalWalletAction: ActionData = {
       ethValue: BigNumber.from(0),
@@ -310,18 +308,18 @@ describe("Upgrade", async function () {
     const lazyWallet2 = await fx.lazyBlsWallets[1]();
 
     const wallet1 = await BlsWalletWrapper.connect(
-      lazyWallet1.privateKey,
+      lazyWallet1.blsWalletSigner.privateKey,
       vg1.address,
       vg1.provider,
     );
 
     const wallet2 = await BlsWalletWrapper.connect(
-      lazyWallet2.privateKey,
+      lazyWallet2.blsWalletSigner.privateKey,
       vg1.address,
       vg1.provider,
     );
 
-    const hash1 = wallet1.blsWalletSigner.getPublicKeyHash(wallet1.privateKey);
+    const hash1 = wallet1.blsWalletSigner.getPublicKeyHash();
 
     expect(await vg1.walletFromHash(hash1)).to.equal(wallet1.address);
     expect(await vg1.hashFromWallet(wallet1.address)).to.equal(hash1);
@@ -364,7 +362,7 @@ describe("Upgrade", async function () {
 
     // wallet 1's hash is pointed to null address
     // wallet 2's hash is now pointed to wallet 1's address
-    const hash2 = wallet2.blsWalletSigner.getPublicKeyHash(wallet2.privateKey);
+    const hash2 = wallet2.blsWalletSigner.getPublicKeyHash();
 
     await fx.advanceTimeBy(safetyDelaySeconds + 1);
     await fx.call(wallet1, vg1, "setPendingBLSKeyForWallet", [], 2);

--- a/contracts/test/walletAction-test.ts
+++ b/contracts/test/walletAction-test.ts
@@ -61,7 +61,6 @@ describe("WalletActions", async function () {
     const calculatedAddress = ethers.utils.getCreate2Address(
       fx.verificationGateway.address,
       wallet.blsWalletSigner.getPublicKeyHash(),
-      // fx.blsWalletSigner.getPublicKeyHash(wallet.privateKey),
       ethers.utils.solidityKeccak256(
         ["bytes", "bytes"],
         [

--- a/contracts/test/walletAction-test.ts
+++ b/contracts/test/walletAction-test.ts
@@ -60,7 +60,8 @@ describe("WalletActions", async function () {
 
     const calculatedAddress = ethers.utils.getCreate2Address(
       fx.verificationGateway.address,
-      fx.blsWalletSigner.getPublicKeyHash(wallet.privateKey),
+      wallet.blsWalletSigner.getPublicKeyHash(),
+      // fx.blsWalletSigner.getPublicKeyHash(wallet.privateKey),
       ethers.utils.solidityKeccak256(
         ["bytes", "bytes"],
         [
@@ -187,7 +188,7 @@ describe("WalletActions", async function () {
           contractAddress: fx.verificationGateway.address,
           encodedFunction: fx.verificationGateway.interface.encodeFunctionData(
             "walletFromHash",
-            [fx.blsWalletSigner.getPublicKeyHash(wallet.privateKey)],
+            [fx.blsWalletSigner.getPublicKeyHash()],
           ),
         },
       ],

--- a/extension/package.json
+++ b/extension/package.json
@@ -36,7 +36,7 @@
     "advanced-css-reset": "^1.2.2",
     "async-mutex": "^0.3.2",
     "axios": "^0.27.2",
-    "bls-wallet-clients": "0.8.2-77f1638",
+    "bls-wallet-clients": "0.8.2-1452ef5",
     "browser-passworder": "^2.0.3",
     "bs58check": "^2.1.2",
     "crypto-browserify": "^3.12.0",

--- a/extension/source/background/KeyringController.ts
+++ b/extension/source/background/KeyringController.ts
@@ -124,7 +124,10 @@ export default class KeyringController {
         () => new Error('Wallet already exists'),
       );
 
-      const { address, privateKey } = await this.BlsWalletWrapper(pKey);
+      const {
+        address,
+        blsWalletSigner: { privateKey },
+      } = await this.BlsWalletWrapper(pKey);
       return { address, privateKey };
     },
 

--- a/extension/yarn.lock
+++ b/extension/yarn.lock
@@ -2907,10 +2907,10 @@ blakejs@^1.1.0:
   resolved "https://registry.yarnpkg.com/blakejs/-/blakejs-1.2.1.tgz#5057e4206eadb4a97f7c0b6e197a505042fc3814"
   integrity sha512-QXUSXI3QVc/gJME0dBpXrag1kbzOqCjCX8/b54ntNyW6sjtoqxqRk3LTmXzaJoh71zMsDCjM+47jS7XiwN/+fQ==
 
-bls-wallet-clients@0.8.2-77f1638:
-  version "0.8.2-77f1638"
-  resolved "https://registry.yarnpkg.com/bls-wallet-clients/-/bls-wallet-clients-0.8.2-77f1638.tgz#61212aac502aed821bc6036cb95a2cdaa9c0b67e"
-  integrity sha512-2gTVHUvs4+/fBwgtcZCO+DsKTnJAiebYrpCUdygIqZaFeHdEyp6xU2F8ZT+XOcNoMeN1B9TT5EupV1RTvISFkQ==
+bls-wallet-clients@0.8.2-1452ef5:
+  version "0.8.2-1452ef5"
+  resolved "https://registry.yarnpkg.com/bls-wallet-clients/-/bls-wallet-clients-0.8.2-1452ef5.tgz#d76e938ca45ec5da44c8e59699d1bd5f6c69dcd2"
+  integrity sha512-bg7WLr9NRbvDzj+zgkLNfaPzr1m0m13Cc8RJoZ2s6s+ic7WxSiwxTkZGc2SChFgmG8ZGi1O9DnR6//lrTsMVUA==
   dependencies:
     "@thehubbleproject/bls" "^0.5.1"
     ethers "^5.7.2"


### PR DESCRIPTION
## What is this PR doing?
This PR modifies private key management in the `BlsWalletWrapper` class to:
- improve data abstraction
- improve security
- create a more unified abstraction.

Places where private key is removed:
- Directly in the `BlsWalletWrapper ` constructor
- `getPublicKeyHash()`
- `sign()`
- `signMessage()`
- `PublicKey()`
- `PublicKeyStr()`
- `validateWalletNotRecovered`

Places where privateKey is introduced:
- `initBlsWalletSigner` the private that would have been part of the BlsWalletWrapper class, is now passed to the BlsWalletSigner. So init method now takes in a private key. 
- `#BlsWalletSigner` returns a `BlsWalletSigner`, which takes a private key, so this private method also does that now. The only place it is used is in the static `Address` method, which already takes a private key, so it doesn't actually change how an end user would call the method.

Also added a `setBlsWalletSigner` helper method. This was to ensure the `should recover blswallet via blswallet to new bls key using bls client module` recovery test still passed as a new public key needed generating.

## How can these changes be manually tested?
1. Running all test suites that use the client module (contracts, clients, aggregator, integration)
2. Sending a transaction with the browser wallet
3. Recovering an account from the browser wallet to quill

## Does this PR resolve or contribute to any issues?
#499 

## Checklist
- [x] I have manually tested these changes
- [x] Post a link to the PR in the group chat

## Guidelines
- If your PR is not ready, mark it as a draft
- The `resolve conversation` button is for reviewers, not authors
  - (But add a 'done' comment or similar)
