### PR TITLE
Registry wrapper classes

### DIFF
--- a/contracts/clients/src/AddressRegistryWrapper.ts
+++ b/contracts/clients/src/AddressRegistryWrapper.ts
@@ -1,0 +1,89 @@
+/* eslint-disable camelcase */
+
+import { BigNumber, BigNumberish, ethers, Signer } from "ethers";
+import { AddressRegistry } from "../typechain-types/contracts/AddressRegistry";
+import { AddressRegistry__factory } from "../typechain-types/factories/contracts/AddressRegistry__factory";
+import SignerOrProvider from "./helpers/SignerOrProvider";
+import SafeSingletonFactory, {
+  SafeSingletonFactoryViewer,
+} from "./SafeSingletonFactory";
+
+export default class AddressRegistryWrapper {
+  constructor(public registry: AddressRegistry) {}
+
+  static async deployNew(signer: Signer): Promise<AddressRegistryWrapper> {
+    const factory = new AddressRegistry__factory(signer);
+
+    return new AddressRegistryWrapper(await factory.deploy());
+  }
+
+  static async connectOrDeploy(
+    signerOrFactory: Signer | SafeSingletonFactory,
+    salt: ethers.utils.BytesLike = ethers.utils.solidityPack(["uint256"], [0]),
+  ): Promise<AddressRegistryWrapper> {
+    const factory = await SafeSingletonFactory.from(signerOrFactory);
+
+    const registry = await factory.connectOrDeploy(
+      AddressRegistry__factory,
+      [],
+      salt,
+    );
+
+    return new AddressRegistryWrapper(registry);
+  }
+
+  static async connectIfDeployed(
+    signerOrProvider: SignerOrProvider,
+    salt: ethers.utils.BytesLike = ethers.utils.solidityPack(["uint256"], [0]),
+  ): Promise<AddressRegistryWrapper | undefined> {
+    const factoryViewer = await SafeSingletonFactoryViewer.from(
+      signerOrProvider,
+    );
+
+    const registry = await factoryViewer.connectIfDeployed(
+      AddressRegistry__factory,
+      [],
+      salt,
+    );
+
+    return registry ? new AddressRegistryWrapper(registry) : undefined;
+  }
+
+  async lookup(id: BigNumberish): Promise<string | undefined> {
+    const address = await this.registry.addresses(id);
+
+    return address === ethers.constants.AddressZero ? undefined : address;
+  }
+
+  async reverseLookup(address: string): Promise<BigNumber | undefined> {
+    const events = await this.registry.queryFilter(
+      this.registry.filters.AddressRegistered(null, address),
+    );
+
+    const id = events.at(-1)?.args?.id;
+
+    return id;
+  }
+
+  async register(address: string): Promise<BigNumber> {
+    await (await this.registry.register(address)).wait();
+
+    const id = await this.reverseLookup(address);
+
+    if (id === undefined) {
+      throw new Error("Registration completed but couldn't find id");
+    }
+
+    return id;
+  }
+
+  async registerIfNeeded(address: string): Promise<BigNumber> {
+    let id = await this.reverseLookup(address);
+
+    if (id === undefined) {
+      id = await this.register(address);
+    }
+
+    return id;
+  }
+}

--- a/contracts/clients/src/BlsPublicKeyRegistryWrapper.ts
+++ b/contracts/clients/src/BlsPublicKeyRegistryWrapper.ts
@@ -1,0 +1,104 @@
+/* eslint-disable camelcase */
+
+import { BigNumber, BigNumberish, ethers, Signer } from "ethers";
+import { solidityKeccak256 } from "ethers/lib/utils";
+import {
+  BLSPublicKeyRegistry,
+  BLSPublicKeyRegistry__factory,
+} from "../typechain-types";
+import SignerOrProvider from "./helpers/SignerOrProvider";
+import SafeSingletonFactory, {
+  SafeSingletonFactoryViewer,
+} from "./SafeSingletonFactory";
+import { PublicKey } from "./signer";
+
+export default class BlsPublicKeyRegistryWrapper {
+  constructor(public registry: BLSPublicKeyRegistry) {}
+
+  static async deployNew(signer: Signer): Promise<BlsPublicKeyRegistryWrapper> {
+    const factory = new BLSPublicKeyRegistry__factory(signer);
+
+    return new BlsPublicKeyRegistryWrapper(await factory.deploy());
+  }
+
+  static async connectOrDeploy(
+    signerOrFactory: Signer | SafeSingletonFactory,
+    salt: ethers.utils.BytesLike = ethers.utils.solidityPack(["uint256"], [0]),
+  ): Promise<BlsPublicKeyRegistryWrapper> {
+    const factory = await SafeSingletonFactory.from(signerOrFactory);
+
+    const registry = await factory.connectOrDeploy(
+      BLSPublicKeyRegistry__factory,
+      [],
+      salt,
+    );
+
+    return new BlsPublicKeyRegistryWrapper(registry);
+  }
+
+  static async connectIfDeployed(
+    signerOrProvider: SignerOrProvider,
+    salt: ethers.utils.BytesLike = ethers.utils.solidityPack(["uint256"], [0]),
+  ): Promise<BlsPublicKeyRegistryWrapper | undefined> {
+    const factoryViewer = await SafeSingletonFactoryViewer.from(
+      signerOrProvider,
+    );
+
+    const registry = await factoryViewer.connectIfDeployed(
+      BLSPublicKeyRegistry__factory,
+      [],
+      salt,
+    );
+
+    return registry ? new BlsPublicKeyRegistryWrapper(registry) : undefined;
+  }
+
+  async lookup(id: BigNumberish): Promise<PublicKey | undefined> {
+    const blsPublicKey = await Promise.all([
+      this.registry.blsPublicKeys(id, 0),
+      this.registry.blsPublicKeys(id, 1),
+      this.registry.blsPublicKeys(id, 2),
+      this.registry.blsPublicKeys(id, 3),
+    ]);
+
+    if (blsPublicKey.every((x) => x.eq(0))) {
+      return undefined;
+    }
+
+    return blsPublicKey;
+  }
+
+  async reverseLookup(blsPublicKey: PublicKey): Promise<BigNumber | undefined> {
+    const blsPublicKeyHash = solidityKeccak256(["uint256[4]"], [blsPublicKey]);
+
+    const events = await this.registry.queryFilter(
+      this.registry.filters.BLSPublicKeyRegistered(null, blsPublicKeyHash),
+    );
+
+    const id = events.at(-1)?.args?.id;
+
+    return id;
+  }
+
+  async register(blsPublicKey: PublicKey): Promise<BigNumber> {
+    await (await this.registry.register(blsPublicKey)).wait();
+
+    const id = await this.reverseLookup(blsPublicKey);
+
+    if (id === undefined) {
+      throw new Error("Registration completed but couldn't find id");
+    }
+
+    return id;
+  }
+
+  async registerIfNeeded(blsPublicKey: PublicKey): Promise<BigNumber> {
+    let id = await this.reverseLookup(blsPublicKey);
+
+    if (id === undefined) {
+      id = await this.register(blsPublicKey);
+    }
+
+    return id;
+  }
+}

--- a/contracts/clients/src/helpers/SignerOrProvider.ts
+++ b/contracts/clients/src/helpers/SignerOrProvider.ts
@@ -1,0 +1,5 @@
+import { ethers } from "ethers";
+
+type SignerOrProvider = ethers.Signer | ethers.providers.Provider;
+
+export default SignerOrProvider;

--- a/contracts/clients/src/index.ts
+++ b/contracts/clients/src/index.ts
@@ -36,6 +36,14 @@ import { BlsWalletContracts, connectToContracts } from "./BlsWalletContracts";
 
 export * from "./signer";
 
+export {
+  default as SafeSingletonFactory,
+  SafeSingletonFactoryViewer,
+} from "./SafeSingletonFactory";
+
+export { default as AddressRegistryWrapper } from "./AddressRegistryWrapper";
+export { default as BlsPublicKeyRegistryWrapper } from "./BlsPublicKeyRegistryWrapper";
+
 const Experimental_ = {
   BlsProvider,
   BlsSigner,

--- a/contracts/contracts/AddressRegistry.sol
+++ b/contracts/contracts/AddressRegistry.sol
@@ -15,4 +15,11 @@ contract AddressRegistry {
 
         emit AddressRegistered(id, addr);
     }
+
+    function lookup(uint256 id) external view returns (address) {
+        address addr = addresses[id];
+        require(addr != address(0), "AddressRegistry: Address not found");
+
+        return addr;
+    }
 }

--- a/contracts/contracts/AddressRegistry.sol
+++ b/contracts/contracts/AddressRegistry.sol
@@ -1,0 +1,18 @@
+//SPDX-License-Identifier: MIT
+pragma solidity >=0.7.0 <0.9.0;
+pragma abicoder v2;
+
+contract AddressRegistry {
+    mapping(uint256 => address) public addresses;
+    uint public nextId = 0;
+
+    event AddressRegistered(uint256 id, address indexed addr);
+
+    function register(address addr) external {
+        uint256 id = nextId;
+        nextId += 1;
+        addresses[id] = addr;
+
+        emit AddressRegistered(id, addr);
+    }
+}

--- a/contracts/contracts/AddressRegistry.sol
+++ b/contracts/contracts/AddressRegistry.sol
@@ -4,7 +4,7 @@ pragma abicoder v2;
 
 contract AddressRegistry {
     mapping(uint256 => address) public addresses;
-    uint public nextId = 0;
+    uint256 public nextId = 0;
 
     event AddressRegistered(uint256 id, address indexed addr);
 

--- a/contracts/contracts/BLSPublicKeyRegistry.sol
+++ b/contracts/contracts/BLSPublicKeyRegistry.sol
@@ -1,0 +1,18 @@
+//SPDX-License-Identifier: MIT
+pragma solidity >=0.7.0 <0.9.0;
+pragma abicoder v2;
+
+contract BLSPublicKeyRegistry {
+    mapping(uint256 => uint256[4]) public blsPublicKeys;
+    uint public nextId = 0;
+
+    event BLSPublicKeyRegistered(uint256 id, uint256[4] indexed blsPublicKey);
+
+    function register(uint256[4] memory blsPublicKey) external {
+        uint256 id = nextId;
+        nextId += 1;
+        blsPublicKeys[id] = blsPublicKey;
+
+        emit BLSPublicKeyRegistered(id, blsPublicKey);
+    }
+}

--- a/contracts/contracts/BLSPublicKeyRegistry.sol
+++ b/contracts/contracts/BLSPublicKeyRegistry.sol
@@ -15,4 +15,21 @@ contract BLSPublicKeyRegistry {
 
         emit BLSPublicKeyRegistered(id, blsPublicKey);
     }
+
+    function lookup(uint256 id) external view returns (uint256[4] memory) {
+        uint256[4] memory blsPublicKey = blsPublicKeys[id];
+        require(!isZeroBLSPublicKey(blsPublicKey), "BLSPublicKeyRegistry: BLS public key not found");
+
+        return blsPublicKey;
+    }
+
+    function isZeroBLSPublicKey(uint256[4] memory blsPublicKey) internal pure returns (bool) {
+        for (uint i = 0; i < 4; i++) {
+            if (blsPublicKey[i] != 0) {
+                return false;
+            }
+        }
+
+        return true;
+    }
 }

--- a/contracts/contracts/BLSPublicKeyRegistry.sol
+++ b/contracts/contracts/BLSPublicKeyRegistry.sol
@@ -4,7 +4,7 @@ pragma abicoder v2;
 
 contract BLSPublicKeyRegistry {
     mapping(uint256 => uint256[4]) public blsPublicKeys;
-    uint public nextId = 0;
+    uint256 public nextId = 0;
 
     event BLSPublicKeyRegistered(uint256 id, bytes32 indexed blsPublicKeyHash);
 

--- a/contracts/contracts/BLSPublicKeyRegistry.sol
+++ b/contracts/contracts/BLSPublicKeyRegistry.sol
@@ -6,14 +6,14 @@ contract BLSPublicKeyRegistry {
     mapping(uint256 => uint256[4]) public blsPublicKeys;
     uint public nextId = 0;
 
-    event BLSPublicKeyRegistered(uint256 id, uint256[4] indexed blsPublicKey);
+    event BLSPublicKeyRegistered(uint256 id, bytes32 indexed blsPublicKeyHash);
 
     function register(uint256[4] memory blsPublicKey) external {
         uint256 id = nextId;
         nextId += 1;
         blsPublicKeys[id] = blsPublicKey;
 
-        emit BLSPublicKeyRegistered(id, blsPublicKey);
+        emit BLSPublicKeyRegistered(id, keccak256(abi.encode(blsPublicKey)));
     }
 
     function lookup(uint256 id) external view returns (uint256[4] memory) {

--- a/contracts/shared/deploy.ts
+++ b/contracts/shared/deploy.ts
@@ -17,7 +17,7 @@ import {
   VerificationGateway__factory,
 } from "../typechain-types";
 
-import SafeSingletonFactory from "./SafeSingletonFactory";
+import { SafeSingletonFactory } from "../clients/src";
 
 export type Deployment = {
   singletonFactory: SafeSingletonFactory;
@@ -35,7 +35,7 @@ export default async function deploy(
 ): Promise<Deployment> {
   const singletonFactory = await SafeSingletonFactory.init(signer);
 
-  const precompileCostEstimator = await singletonFactory.deploy(
+  const precompileCostEstimator = await singletonFactory.connectOrDeploy(
     BNPairingPrecompileCostEstimator__factory,
     [],
     salt,
@@ -43,27 +43,31 @@ export default async function deploy(
 
   await (await precompileCostEstimator.run()).wait();
 
-  const blsLibrary = await singletonFactory.deploy(BLSOpen__factory, [], salt);
+  const blsLibrary = await singletonFactory.connectOrDeploy(
+    BLSOpen__factory,
+    [],
+    salt,
+  );
 
-  const verificationGateway = await singletonFactory.deploy(
+  const verificationGateway = await singletonFactory.connectOrDeploy(
     VerificationGateway__factory,
     [blsLibrary.address],
     salt,
   );
 
-  const blsExpander = await singletonFactory.deploy(
+  const blsExpander = await singletonFactory.connectOrDeploy(
     BLSExpander__factory,
     [verificationGateway.address],
     salt,
   );
 
-  const blsExpanderDelegator = await singletonFactory.deploy(
+  const blsExpanderDelegator = await singletonFactory.connectOrDeploy(
     BLSExpanderDelegator__factory,
     [verificationGateway.address],
     salt,
   );
 
-  const fallbackExpander = await singletonFactory.deploy(
+  const fallbackExpander = await singletonFactory.connectOrDeploy(
     FallbackExpander__factory,
     [],
     salt,
@@ -79,7 +83,7 @@ export default async function deploy(
     throw new Error("Existing expander at index 0 is not fallbackExpander");
   }
 
-  const aggregatorUtilities = await singletonFactory.deploy(
+  const aggregatorUtilities = await singletonFactory.connectOrDeploy(
     AggregatorUtilities__factory,
     [],
     salt,

--- a/contracts/test/addressRegistry-test.ts
+++ b/contracts/test/addressRegistry-test.ts
@@ -1,0 +1,53 @@
+/* eslint-disable camelcase */
+
+import { expect } from "chai";
+import { ethers } from "hardhat";
+import { AddressRegistry, AddressRegistry__factory } from "../typechain-types";
+
+describe("AddressRegistry", async () => {
+  let addressRegistry: AddressRegistry;
+
+  beforeEach(async () => {
+    const [signer] = await ethers.getSigners();
+    const addressRegistryFactory = new AddressRegistry__factory(signer);
+    addressRegistry = await addressRegistryFactory.deploy();
+  });
+
+  it("should register address", async () => {
+    const [signer] = await ethers.getSigners();
+    const address = await signer.getAddress();
+
+    await expect(addressRegistry.lookup(0)).to.be.revertedWith(
+      "AddressRegistry: Address not found",
+    );
+
+    await addressRegistry.register(address);
+
+    const address0 = await addressRegistry.lookup(0);
+    expect(address0).to.equal(address);
+  });
+
+  it("should enable finding the id of an address", async () => {
+    const [signer] = await ethers.getSigners();
+    const address = await signer.getAddress();
+
+    expect(await findAddressId(addressRegistry, address)).to.eq(undefined);
+
+    await addressRegistry.register(address);
+
+    expect(await findAddressId(addressRegistry, address)).to.eq(0);
+  });
+});
+
+async function findAddressId(
+  addressRegistry: AddressRegistry,
+  address: string,
+) {
+  const events = await addressRegistry.queryFilter(
+    addressRegistry.filters.AddressRegistered(null, address),
+  );
+
+  const id = events.at(0)?.args?.id;
+
+  return id;
+}

--- a/contracts/test/blsPublicKeyRegistry-test.ts
+++ b/contracts/test/blsPublicKeyRegistry-test.ts
@@ -1,0 +1,72 @@
+/* eslint-disable camelcase */
+
+import { expect } from "chai";
+import { BigNumber } from "ethers";
+import { solidityKeccak256 } from "ethers/lib/utils";
+import { ethers } from "hardhat";
+import type { PublicKey } from "../clients/src";
+import {
+  BLSPublicKeyRegistry,
+  BLSPublicKeyRegistry__factory,
+} from "../typechain-types";
+
+const blsPublicKey = [
+  "0x2fa5eae26e850147f76823375b9ee060fdb3838c8ec31e89c44aadf1cb3360b8",
+  "0x09be12ff0323692301d9cdd7e6740cd8ab3fc17e3eadf2edb1d32d3d98c76939",
+  "0x1d69e92b863636811081c60132f18a6c41281f75f6c2816ac255a9af13f2b416",
+  "0x099f53b1005b1f53be13a30c71fa32e785bc516508fda055cf22f7ab33580412",
+].map((x) => BigNumber.from(x)) as PublicKey;
+
+describe("BLSPublicKeyRegistry", async () => {
+  let blsPublicKeyRegistry: BLSPublicKeyRegistry;
+
+  beforeEach(async () => {
+    const [signer] = await ethers.getSigners();
+    const blsPublicKeyRegistryFactory = new BLSPublicKeyRegistry__factory(
+      signer,
+    );
+    blsPublicKeyRegistry = await blsPublicKeyRegistryFactory.deploy();
+  });
+
+  it("should register BLS public key", async () => {
+    await expect(blsPublicKeyRegistry.lookup(0)).to.be.revertedWith(
+      "BLSPublicKeyRegistry: BLS public key not found",
+    );
+
+    await blsPublicKeyRegistry.register(blsPublicKey);
+
+    const blsPublicKey0 = await blsPublicKeyRegistry.lookup(0);
+
+    expect(blsPublicKey0).to.deep.equal(blsPublicKey);
+  });
+
+  it("should enable finding the id of an BLS public key", async () => {
+    expect(await findBLSPublicKeyId(blsPublicKeyRegistry, blsPublicKey)).to.eq(
+      undefined,
+    );
+
+    await blsPublicKeyRegistry.register(blsPublicKey);
+
+    // Doesn't seem like much to find id 0, but without the indexed event we'd
+    // need to store the reverse mapping on-chain (in expensive regular storage)
+    // or in a centralized off-chain database.
+    expect(await findBLSPublicKeyId(blsPublicKeyRegistry, blsPublicKey)).to.eq(
+      0,
+    );
+  });
+});
+
+async function findBLSPublicKeyId(
+  blsPublicKeyRegistry: BLSPublicKeyRegistry,
+  blsPublicKey: PublicKey,
+) {
+  const blsPublicKeyHash = solidityKeccak256(["uint256[4]"], [blsPublicKey]);
+
+  const events = await blsPublicKeyRegistry.queryFilter(
+    blsPublicKeyRegistry.filters.BLSPublicKeyRegistered(null, blsPublicKeyHash),
+  );
+
+  const id = events.at(0)?.args?.id;
+
+  return id;
+}

--- a/contracts/test/deploy-test.ts
+++ b/contracts/test/deploy-test.ts
@@ -3,7 +3,7 @@
 import { expect } from "chai";
 
 import { ethers } from "hardhat";
-import SafeSingletonFactory from "../shared/SafeSingletonFactory";
+import { SafeSingletonFactory } from "../clients/src";
 import { MockERC20__factory } from "../typechain-types";
 
 describe("SafeSingletonFactory", async () => {
@@ -26,7 +26,7 @@ describe("SafeSingletonFactory", async () => {
 
     expect(await ethers.provider.getCode(expectedAddress)).to.equal("0x");
 
-    await singletonFactory.deploy(MockERC20__factory, [
+    await singletonFactory.connectOrDeploy(MockERC20__factory, [
       "TestToken123",
       "TOK",
       0,
@@ -39,7 +39,7 @@ describe("SafeSingletonFactory", async () => {
     const [signer] = await ethers.getSigners();
     const singletonFactory = await SafeSingletonFactory.init(signer);
 
-    await singletonFactory.deploy(MockERC20__factory, [
+    await singletonFactory.connectOrDeploy(MockERC20__factory, [
       "TestToken123",
       "TOK",
       0,
@@ -48,7 +48,7 @@ describe("SafeSingletonFactory", async () => {
     const txCount = await signer.getTransactionCount();
 
     // Deploy the same contract (with the same salt (defaults to 0))
-    await singletonFactory.deploy(MockERC20__factory, [
+    await singletonFactory.connectOrDeploy(MockERC20__factory, [
       "TestToken123",
       "TOK",
       0,


### PR DESCRIPTION
# *Dependent PR*

This PR depends on:
- #546

The diff will include the changes from that PR until it is merged. Merging that PR first is recommended.

## What is this PR doing?

- Moves `SafeSingletonFactory` into `clients`
- Adds `BlsPublicKeyRegistryWrapper` and `AddressRegistryWrapper`

The wrapper classes have these methods for deployment:
- `deployNew` - deploy a new instance of the contract the old fashioned way
- `connectOrDeploy` - connect to *the* instance of the contract using `SafeSingletonFactory`, deploying if needed
- `connectIfDeployed` - connect to *the* instance of the contract using `SafeSingletonFactory`, if it has been deployed

Additionally, registries expose these methods:
- `lookup` - given an id, if it has associated data, return the associated data
- `reverseLookup` - given associated data, if it has an associated id, return the most recent associated id
- `register` - register some data, returning the allocated id
- `registerIfNeeded` - do a `reverseLookup` on some data, registering it if it's not already registered

## How can these changes be manually tested?

`yarn hardhat test`
(See `addressRegistry-test.ts`, `blsPublicKeyRegistry-test.ts`)

## Does this PR resolve or contribute to any issues?

Contributes to #523.

## Checklist
- [x] I have manually tested these changes
- [x] Post a link to the PR in the group chat

## Guidelines
- If your PR is not ready, mark it as a draft
- The `resolve conversation` button is for reviewers, not authors
  - (But add a 'done' comment or similar)
