### PR TITLE
201 implement erc 1271 signature validation

### DIFF
--- a/contracts/contracts/BLSWallet.sol
+++ b/contracts/contracts/BLSWallet.sol
@@ -7,6 +7,9 @@ pragma abicoder v2;
 import "@openzeppelin/contracts/proxy/utils/Initializable.sol";
 import "./interfaces/IWallet.sol";
 
+interface IVerificationGateway {
+    function validateSignature(bytes32 _hash, bytes memory _signature) external view returns (bool);
+}
 
 /** Minimal upgradable smart contract wallet.
     Generic calls can only be requested by its trusted gateway.
@@ -191,6 +194,21 @@ contract BLSWallet is Initializable, IWallet
             }
 
             results[i] = result;
+        }
+    }
+
+    /**
+    * @dev ERC-1271 signature validation
+    */
+    function isValidSignature(
+        bytes32 _hash,
+        bytes memory _signature
+    ) public view returns (bytes4 magicValue) {
+
+        bool verified = IVerificationGateway(trustedBLSGateway).validateSignature(_hash, _signature);
+
+        if (verified) {
+            magicValue = 0x1626ba7e;
         }
     }
 

--- a/contracts/contracts/BLSWallet.sol
+++ b/contracts/contracts/BLSWallet.sol
@@ -208,6 +208,8 @@ contract BLSWallet is Initializable, IWallet
 
         if (verified) {
             magicValue = 0x1626ba7e;
+        } else {
+            magicValue = 0xffffffff;
         }
     }
 

--- a/contracts/contracts/BLSWallet.sol
+++ b/contracts/contracts/BLSWallet.sol
@@ -201,11 +201,11 @@ contract BLSWallet is Initializable, IWallet
     * @dev ERC-1271 signature validation
     */
     function isValidSignature(
-        bytes32 _hash,
-        bytes memory _signature
+        bytes32 hash,
+        bytes memory signature
     ) public view returns (bytes4 magicValue) {
 
-        bool verified = IVerificationGateway(trustedBLSGateway).validateSignature(_hash, _signature);
+        bool verified = IVerificationGateway(trustedBLSGateway).validateSignature(hash, signature);
 
         if (verified) {
             magicValue = 0x1626ba7e;

--- a/contracts/contracts/BLSWallet.sol
+++ b/contracts/contracts/BLSWallet.sol
@@ -8,7 +8,7 @@ import "@openzeppelin/contracts/proxy/utils/Initializable.sol";
 import "./interfaces/IWallet.sol";
 
 interface IVerificationGateway {
-    function validateSignature(bytes32 _hash, bytes memory _signature) external view returns (bool);
+    function isValidSignature(bytes32 _hash, bytes memory _signature) external view returns (bool);
 }
 
 /** Minimal upgradable smart contract wallet.
@@ -204,8 +204,7 @@ contract BLSWallet is Initializable, IWallet
         bytes32 hash,
         bytes memory signature
     ) public view returns (bytes4 magicValue) {
-
-        bool verified = IVerificationGateway(trustedBLSGateway).validateSignature(hash, signature);
+        bool verified = IVerificationGateway(trustedBLSGateway).isValidSignature(hash, signature);
 
         if (verified) {
             magicValue = 0x1626ba7e;

--- a/contracts/contracts/VerificationGateway.sol
+++ b/contracts/contracts/VerificationGateway.sol
@@ -116,17 +116,18 @@ contract VerificationGateway
     function isValidSignature(
         bytes32 hash,
         bytes memory signature
-    ) public view onlyWallet(hashFromWallet[IWallet(msg.sender)]) returns (bool verified) {
+    ) public view returns (bool verified) {
         IWallet wallet = IWallet(msg.sender);
         bytes32 existingHash = hashFromWallet[wallet];
+        require(existingHash != 0, "VG: not called from wallet");
 
         uint256[BLS_KEY_LEN] memory publicKey = BLSPublicKeyFromHash[existingHash];
 
-        bytes memory concatenatedHash = abi.encode(hash);
+        bytes memory hashBytes = abi.encode(hash);
 
         uint256[2] memory message = blsLib.hashToPoint(
             BLS_DOMAIN,
-            concatenatedHash
+            hashBytes
         );
 
         require(signature.length == 64, "VG: Sig bytes length must be 64");

--- a/contracts/contracts/VerificationGateway.sol
+++ b/contracts/contracts/VerificationGateway.sol
@@ -113,20 +113,16 @@ contract VerificationGateway
         require(verified, "VG: Sig not verified");
     }
 
-    function validateSignature(
+    function isValidSignature(
         bytes32 hash,
         bytes memory signature
-    ) public view returns (bool verified) {
+    ) public view onlyWallet(hashFromWallet[IWallet(msg.sender)]) returns (bool verified) {
         IWallet wallet = IWallet(msg.sender);
         bytes32 existingHash = hashFromWallet[wallet];
-        require(
-            (IWallet(msg.sender) == walletFromHash[existingHash]),
-            "VG: not called from wallet"
-        );
 
         uint256[BLS_KEY_LEN] memory publicKey = BLSPublicKeyFromHash[existingHash];
 
-        bytes memory concatenatedHash = bytes.concat(hash);
+        bytes memory concatenatedHash = abi.encode(hash);
 
         uint256[2] memory message = blsLib.hashToPoint(
             BLS_DOMAIN,

--- a/contracts/contracts/VerificationGateway.sol
+++ b/contracts/contracts/VerificationGateway.sol
@@ -133,7 +133,6 @@ contract VerificationGateway
         uint256[2] memory decodedSignature = abi.decode(signature, (uint256[2]));
 
         verified = blsLib.verifySingle(decodedSignature, publicKey, message);
-        require(verified, "VG: Sig not verified");
     }
 
     /**

--- a/contracts/contracts/VerificationGateway.sol
+++ b/contracts/contracts/VerificationGateway.sol
@@ -114,8 +114,8 @@ contract VerificationGateway
     }
 
     function validateSignature(
-        bytes32 _hash,
-        bytes memory _signature
+        bytes32 hash,
+        bytes memory signature
     ) public view returns (bool verified) {
         IWallet wallet = IWallet(msg.sender);
         bytes32 existingHash = hashFromWallet[wallet];
@@ -126,17 +126,17 @@ contract VerificationGateway
 
         uint256[BLS_KEY_LEN] memory publicKey = BLSPublicKeyFromHash[existingHash];
 
-        bytes memory concatenatedHash = bytes.concat(_hash);
+        bytes memory concatenatedHash = bytes.concat(hash);
 
         uint256[2] memory message = blsLib.hashToPoint(
             BLS_DOMAIN,
             concatenatedHash
         );
 
-        require(_signature.length == 64, "Input bytes length must be 64.");
-        uint256[2] memory signature = abi.decode(_signature, (uint256[2]));
+        require(signature.length == 64, "VG: Sig bytes length must be 64");
+        uint256[2] memory decodedSignature = abi.decode(signature, (uint256[2]));
 
-        verified = blsLib.verifySingle(signature, publicKey, message);
+        verified = blsLib.verifySingle(decodedSignature, publicKey, message);
         require(verified, "VG: Sig not verified");
     }
 

--- a/contracts/shared/helpers/getPublicKeyFromHash.ts
+++ b/contracts/shared/helpers/getPublicKeyFromHash.ts
@@ -1,0 +1,12 @@
+import { VerificationGateway } from "../../typechain-types";
+
+export default async function getPublicKeyFromHash(
+  verificationGateway: VerificationGateway,
+  hash: string,
+) {
+  return await Promise.all(
+    [0, 1, 2, 3].map(async (i) =>
+      (await verificationGateway.BLSPublicKeyFromHash(hash, i)).toHexString(),
+    ),
+  );
+}

--- a/contracts/test/upgrade-test.ts
+++ b/contracts/test/upgrade-test.ts
@@ -13,6 +13,7 @@ import {
   proxyAdminBundle,
   proxyAdminCall,
 } from "../shared/helpers/callProxyAdmin";
+import getPublicKeyFromHash from "../shared/helpers/getPublicKeyFromHash";
 import deploy from "../shared/deploy";
 
 const expectOperationsToSucceed = (txnReceipt: ContractReceipt) => {
@@ -240,6 +241,9 @@ describe("Upgrade", async function () {
     await expect(proxyAdmin.getProxyAdmin(walletAddress)).to.eventually.equal(
       proxyAdmin.address,
     );
+    await expect(getPublicKeyFromHash(vg2, hash)).to.eventually.deep.equal(
+      walletOldVg.PublicKey(),
+    );
 
     const blsWallet = await ethers.getContractAt("BLSWallet", walletAddress);
     // New verification gateway pending
@@ -307,6 +311,9 @@ describe("Upgrade", async function () {
     await expect(vg1.hashFromWallet(wallet1.address)).to.eventually.equal(
       hash1,
     );
+    await expect(getPublicKeyFromHash(vg1, hash1)).to.eventually.deep.equal(
+      wallet1.PublicKey(),
+    );
 
     // wallet 2 bls key signs message containing address of wallet 1
     const addressMessage = solidityPack(["address"], [wallet1.address]);
@@ -369,11 +376,20 @@ describe("Upgrade", async function () {
     await expect(vg1.walletFromHash(hash1)).to.eventually.equal(
       ethers.constants.AddressZero,
     );
+    await expect(getPublicKeyFromHash(vg1, hash1)).to.eventually.deep.equal([
+      "0x00",
+      "0x00",
+      "0x00",
+      "0x00",
+    ]);
     await expect(vg1.walletFromHash(hash2)).to.eventually.equal(
       wallet1.address,
     );
     await expect(vg1.hashFromWallet(wallet1.address)).to.eventually.equal(
       hash2,
+    );
+    await expect(getPublicKeyFromHash(vg1, hash2)).to.eventually.deep.equal(
+      wallet2.PublicKey(),
     );
   });
 

--- a/contracts/test/walletAction-test.ts
+++ b/contracts/test/walletAction-test.ts
@@ -385,10 +385,10 @@ describe("WalletActions", async function () {
 
     await expect(
       blsWallet.isValidSignature(hashedMessage, shortSignature),
-    ).to.be.rejectedWith("Input bytes length must be 64.");
+    ).to.be.rejectedWith("VG: Sig bytes length must be 64");
     await expect(
       blsWallet.isValidSignature(hashedMessage, longSignature),
-    ).to.be.rejectedWith("Input bytes length must be 64.");
+    ).to.be.rejectedWith("VG: Sig bytes length must be 64");
   });
 
   it("(ERC-1271) should fail to verify message when not called from BLS Wallet", async function () {

--- a/contracts/test/walletAction-test.ts
+++ b/contracts/test/walletAction-test.ts
@@ -331,12 +331,17 @@ describe("WalletActions", async function () {
       ethers.utils.hexlify(signatureWithWrongMessage[1]).substring(2);
     const signatureBytes = ethers.utils.arrayify(concatenatedSignature);
 
+    const expectedMagicValue = "0xffffffff";
+
     // initial call needed to ensure isValidSignature is successful
     await fx.call(wallet, blsWallet, "nonce", [], 0, 30_000_000);
 
-    await expect(
-      blsWallet.isValidSignature(hashedMessage, signatureBytes),
-    ).to.be.rejectedWith("VG: Sig not verified");
+    const magicValue = await blsWallet.isValidSignature(
+      hashedMessage,
+      signatureBytes,
+    );
+
+    expect(magicValue).to.equal(expectedMagicValue);
   });
 
   it("(ERC-1271) should fail to verify message signed by another wallet", async function () {
@@ -355,12 +360,17 @@ describe("WalletActions", async function () {
       ethers.utils.hexlify(signature[1]).substring(2);
     const signatureBytes = ethers.utils.arrayify(concatenatedSignature);
 
+    const expectedMagicValue = "0xffffffff";
+
     // initial call needed to ensure isValidSignature is successful
     await fx.call(wallet, blsWallet, "nonce", [], 0, 30_000_000);
 
-    await expect(
-      blsWallet.isValidSignature(hashedMessage, signatureBytes),
-    ).to.be.rejectedWith("VG: Sig not verified");
+    const magicValue = await blsWallet.isValidSignature(
+      hashedMessage,
+      signatureBytes,
+    );
+
+    expect(magicValue).to.equal(expectedMagicValue);
   });
 
   it("(ERC-1271) should fail to verify message when signature is not 64 bytes long", async function () {

--- a/contracts/test/walletAction-test.ts
+++ b/contracts/test/walletAction-test.ts
@@ -398,10 +398,7 @@ describe("WalletActions", async function () {
     const mockSignature = ethers.utils.arrayify("0x00");
 
     await expect(
-      fx.verificationGateway.validateSignature(
-        mockHashedMessage,
-        mockSignature,
-      ),
+      fx.verificationGateway.isValidSignature(mockHashedMessage, mockSignature),
     ).to.be.rejectedWith("VG: not called from wallet");
   });
 

--- a/contracts/test/walletAction-test.ts
+++ b/contracts/test/walletAction-test.ts
@@ -288,6 +288,123 @@ describe("WalletActions", async function () {
     await expect(fx.verificationGateway.callStatic.verify(tx)).to.be.rejected;
   });
 
+  it("(ERC-1271) should verify message", async function () {
+    const wallet = await fx.createBLSWallet();
+    const blsWallet = await ethers.getContractAt("BLSWallet", wallet.address);
+
+    const hashedMessage = ethers.utils.keccak256(
+      ethers.utils.toUtf8Bytes("I'm a message"),
+    );
+
+    const signature = wallet.signMessage(hashedMessage);
+    const concatenatedSignature =
+      ethers.utils.hexlify(signature[0]) +
+      ethers.utils.hexlify(signature[1]).substring(2);
+    const signatureBytes = ethers.utils.arrayify(concatenatedSignature);
+
+    const expectedBytes4MagicValue = ethers.utils
+      .solidityKeccak256(["string"], ["isValidSignature(bytes32,bytes)"])
+      .substring(0, 10);
+
+    // initial call needed to ensure isValidSignature is successful
+    await fx.call(wallet, blsWallet, "nonce", [], 0, 30_000_000);
+
+    const magicValue = await blsWallet.isValidSignature(
+      hashedMessage,
+      signatureBytes,
+    );
+
+    expect(magicValue).to.equal(expectedBytes4MagicValue);
+  });
+
+  it("(ERC-1271) should fail to verify message when the wrong message is signed", async function () {
+    const wallet = await fx.createBLSWallet();
+    const blsWallet = await ethers.getContractAt("BLSWallet", wallet.address);
+
+    const hashedMessage = ethers.utils.keccak256(
+      ethers.utils.toUtf8Bytes("I'm a message"),
+    );
+
+    const signatureWithWrongMessage = wallet.signMessage("0x1234");
+    const concatenatedSignature =
+      ethers.utils.hexlify(signatureWithWrongMessage[0]) +
+      ethers.utils.hexlify(signatureWithWrongMessage[1]).substring(2);
+    const signatureBytes = ethers.utils.arrayify(concatenatedSignature);
+
+    // initial call needed to ensure isValidSignature is successful
+    await fx.call(wallet, blsWallet, "nonce", [], 0, 30_000_000);
+
+    await expect(
+      blsWallet.isValidSignature(hashedMessage, signatureBytes),
+    ).to.be.rejectedWith("VG: Sig not verified");
+  });
+
+  it("(ERC-1271) should fail to verify message signed by another wallet", async function () {
+    const wallet = await fx.createBLSWallet();
+    const blsWallet = await ethers.getContractAt("BLSWallet", wallet.address);
+
+    const imposterWallet = await fx.createBLSWallet();
+
+    const hashedMessage = ethers.utils.keccak256(
+      ethers.utils.toUtf8Bytes("I'm a message"),
+    );
+
+    const signature = imposterWallet.signMessage(hashedMessage);
+    const concatenatedSignature =
+      ethers.utils.hexlify(signature[0]) +
+      ethers.utils.hexlify(signature[1]).substring(2);
+    const signatureBytes = ethers.utils.arrayify(concatenatedSignature);
+
+    // initial call needed to ensure isValidSignature is successful
+    await fx.call(wallet, blsWallet, "nonce", [], 0, 30_000_000);
+
+    await expect(
+      blsWallet.isValidSignature(hashedMessage, signatureBytes),
+    ).to.be.rejectedWith("VG: Sig not verified");
+  });
+
+  it("(ERC-1271) should fail to verify message when signature is not 64 bytes long", async function () {
+    const wallet = await fx.createBLSWallet();
+    const blsWallet = await ethers.getContractAt("BLSWallet", wallet.address);
+
+    const hashedMessage = ethers.utils.keccak256(
+      ethers.utils.toUtf8Bytes("I'm a message"),
+    );
+
+    const signature = wallet.signMessage(hashedMessage);
+    const longConcatenatedSignature =
+      ethers.utils.hexlify(signature[0]) +
+      ethers.utils.hexlify(signature[1]).substring(2) +
+      ethers.utils.hexlify("0x12").substring(2);
+
+    const shortSignature = ethers.utils.arrayify("0x00");
+    const longSignature = ethers.utils.arrayify(longConcatenatedSignature);
+
+    // initial call needed to ensure isValidSignature is successful
+    await fx.call(wallet, blsWallet, "nonce", [], 0, 30_000_000);
+
+    await expect(
+      blsWallet.isValidSignature(hashedMessage, shortSignature),
+    ).to.be.rejectedWith("Input bytes length must be 64.");
+    await expect(
+      blsWallet.isValidSignature(hashedMessage, longSignature),
+    ).to.be.rejectedWith("Input bytes length must be 64.");
+  });
+
+  it("(ERC-1271) should fail to verify message when not called from BLS Wallet", async function () {
+    const mockHashedMessage = ethers.utils.keccak256(
+      ethers.utils.toUtf8Bytes("I'm a message"),
+    );
+    const mockSignature = ethers.utils.arrayify("0x00");
+
+    await expect(
+      fx.verificationGateway.validateSignature(
+        mockHashedMessage,
+        mockSignature,
+      ),
+    ).to.be.rejectedWith("VG: not called from wallet");
+  });
+
   it("should process individual calls", async function () {
     const th = new TokenHelper(fx, Fixture.DEFAULT_BLS_ACCOUNTS_LENGTH);
     const wallets = await th.walletTokenSetup();


### PR DESCRIPTION
## What is this PR doing?
This PR does two things:
1. Adds a new mapping to the verification gateway:
`mapping(bytes32 => uint256[BLS_KEY_LEN]) public BLSPublicKeyFromHash;`

2. Adds support for [ERC-1271](https://eips.ethereum.org/EIPS/eip-1271) signature validation

### Why do we need a new mapping?
After speaking with James, we decided to go with the solution Jake outlined in #201 of adding the 1271 spec (`isValidSignature` function) to the `BLSWallet` and have that call the `VerificationGateway` to run the actual validation. This creates tighter coupling between `BLSWallet` and the `VerificationGateway`, but this solution was deemed the most appropriate for the purpose of ERC-1271.

In order for that solution to work, the `VerificationGateway` needs to have reference to a wallets `PublicKey`, in order to run `blsLib.verifySingle` to verify the signature. The new mapping was added in order to meet this requirement. The lowest level function call that updates the hash mappings is `updateWalletHashMappings`, so that function was chosen to update the new `BLSPublicKeyFromHash` mapping. This additional change increases the complexity of the PR beyond the initial scope.

## How can these changes be manually tested?
`yarn hardhat test`
- ERC-1271 tests have been added to `walletAction-test.ts`
- Existing tests in `recovery-test.ts` & `upgrade-test.ts` were updated to test the new mapping

## Does this PR resolve or contribute to any issues?
resolves #201 

## Checklist
- [x] I have manually tested these changes
- [x] Post a link to the PR in the group chat

## Guidelines
- If your PR is not ready, mark it as a draft
- The `resolve conversation` button is for reviewers, not authors
  - (But add a 'done' comment or similar)
