### PR TITLE
Audit issue 7

### DIFF
--- a/.github/workflows/aggregator.yml
+++ b/.github/workflows/aggregator.yml
@@ -68,8 +68,6 @@ jobs:
         deno-version: ${{ env.DENO_VERSION }}
     - uses: ./.github/actions/setup-contracts-clients
 
-    - uses: mxschmitt/action-tmate@v3
-
     # Setup node & contracts
     - working-directory: ./contracts
       run: yarn start &
@@ -78,4 +76,5 @@ jobs:
 
     - run: cp .env.local.example .env
     - run: deno test --allow-net --allow-env --allow-read
+    - uses: mxschmitt/action-tmate@v3
     - run: sleep 3600

--- a/.github/workflows/aggregator.yml
+++ b/.github/workflows/aggregator.yml
@@ -68,6 +68,8 @@ jobs:
         deno-version: ${{ env.DENO_VERSION }}
     - uses: ./.github/actions/setup-contracts-clients
 
+    - uses: mxschmitt/action-tmate@v3
+
     # Setup node & contracts
     - working-directory: ./contracts
       run: yarn start &
@@ -76,3 +78,4 @@ jobs:
 
     - run: cp .env.local.example .env
     - run: deno test --allow-net --allow-env --allow-read
+    - run: sleep 3600

--- a/aggregator-proxy/package.json
+++ b/aggregator-proxy/package.json
@@ -21,7 +21,7 @@
     "@types/koa__cors": "^3.3.0",
     "@types/koa__router": "^8.0.11",
     "@types/node-fetch": "^2.6.1",
-    "bls-wallet-clients": "0.8.2-1452ef5",
+    "bls-wallet-clients": "0.8.2-1fb4a55",
     "fp-ts": "^2.12.1",
     "io-ts": "^2.2.16",
     "io-ts-reporters": "^2.0.1",

--- a/aggregator-proxy/yarn.lock
+++ b/aggregator-proxy/yarn.lock
@@ -887,10 +887,10 @@ bech32@1.1.4:
   resolved "https://registry.yarnpkg.com/bech32/-/bech32-1.1.4.tgz#e38c9f37bf179b8eb16ae3a772b40c356d4832e9"
   integrity sha512-s0IrSOzLlbvX7yp4WBfPITzpAU8sqQcpsmwXDiKwrG4r491vwCO/XpejasRNl0piBMe/DvP4Tz0mIS/X1DPJBQ==
 
-bls-wallet-clients@0.8.2-1452ef5:
-  version "0.8.2-1452ef5"
-  resolved "https://registry.yarnpkg.com/bls-wallet-clients/-/bls-wallet-clients-0.8.2-1452ef5.tgz#d76e938ca45ec5da44c8e59699d1bd5f6c69dcd2"
-  integrity sha512-bg7WLr9NRbvDzj+zgkLNfaPzr1m0m13Cc8RJoZ2s6s+ic7WxSiwxTkZGc2SChFgmG8ZGi1O9DnR6//lrTsMVUA==
+bls-wallet-clients@0.8.2-1fb4a55:
+  version "0.8.2-1fb4a55"
+  resolved "https://registry.yarnpkg.com/bls-wallet-clients/-/bls-wallet-clients-0.8.2-1fb4a55.tgz#bab40801ee1e60ffbc9c0bc924943c6f90605e7c"
+  integrity sha512-2tlwOSUGzsOiam0G7GBmsN3W5cHjUwTmHR/DvGRH584zLkCC/8TFdAn2/laSF2baTYvegtIHwQNl1zX5DWivEQ==
   dependencies:
     "@thehubbleproject/bls" "^0.5.1"
     ethers "^5.7.2"

--- a/aggregator/deps.ts
+++ b/aggregator/deps.ts
@@ -53,7 +53,7 @@ export type {
   PublicKey,
   Signature,
   VerificationGateway,
-} from "https://esm.sh/bls-wallet-clients@0.8.2-1452ef5";
+} from "https://esm.sh/bls-wallet-clients@0.8.2-1fb4a55";
 
 export {
   Aggregator as AggregatorClient,
@@ -64,10 +64,10 @@ export {
   getConfig,
   MockERC20__factory,
   VerificationGateway__factory,
-} from "https://esm.sh/bls-wallet-clients@0.8.2-1452ef5";
+} from "https://esm.sh/bls-wallet-clients@0.8.2-1fb4a55";
 
 // Workaround for esbuild's export-star bug
-import blsWalletClients from "https://esm.sh/bls-wallet-clients@0.8.2-1452ef5";
+import blsWalletClients from "https://esm.sh/bls-wallet-clients@0.8.2-1fb4a55";
 const { bundleFromDto, bundleToDto, initBlsWalletSigner } = blsWalletClients;
 export { bundleFromDto, bundleToDto, initBlsWalletSigner };
 

--- a/aggregator/src/app/BundleTable.ts
+++ b/aggregator/src/app/BundleTable.ts
@@ -60,14 +60,14 @@ export type BundleRow = Row;
 function fromRawRow(rawRow: RawRow | sqlite.Row): Row {
   if (Array.isArray(rawRow)) {
     rawRow = {
-      id: rawRow[0],
-      status: rawRow[1],
-      hash: rawRow[2],
-      bundle: rawRow[3],
-      eligibleAfter: rawRow[4],
-      nextEligibilityDelay: rawRow[5],
-      submitError: rawRow[6],
-      receipt: rawRow[7],
+      id: rawRow[0] as number,
+      status: rawRow[1] as string,
+      hash: rawRow[2] as string,
+      bundle: rawRow[3] as string,
+      eligibleAfter: rawRow[4] as string,
+      nextEligibilityDelay: rawRow[5] as string,
+      submitError: rawRow[6] as string | null,
+      receipt: rawRow[7] as string | null,
     };
   }
 

--- a/aggregator/src/app/EthereumService.ts
+++ b/aggregator/src/app/EthereumService.ts
@@ -136,6 +136,7 @@ export default class EthereumService {
     const blsWalletSigner = await initBlsWalletSigner({
       chainId,
       privateKey: aggPrivateKey,
+      verificationGatewayAddress,
     });
 
     return new EthereumService(

--- a/contracts/clients/README.md
+++ b/contracts/clients/README.md
@@ -332,8 +332,13 @@ import { initBlsWalletSigner } from "bls-wallet-clients";
 
 (async () => {
   const privateKey = "0x...256 bits of private hex data here";
+  const verificationGatewayAddress = "0x123...456";
 
-  const signer = await initBlsWalletSigner({ chainId: 10, privateKey });
+  const signer = await initBlsWalletSigner({
+    chainId: 10,
+    privateKey,
+    verificationGatewayAddress
+  });
 
   const someToken = new ethers.Contract(
     ...

--- a/contracts/clients/src/BlsWalletWrapper.ts
+++ b/contracts/clients/src/BlsWalletWrapper.ts
@@ -148,7 +148,7 @@ export default class BlsWalletWrapper {
     const blsWalletSigner = await initBlsWalletSigner({
       chainId: (await verificationGateway.provider.getNetwork()).chainId,
       privateKey,
-      verificationGateway: verificationGatewayAddress,
+      verificationGatewayAddress,
     });
 
     const blsWalletWrapper = new BlsWalletWrapper(
@@ -333,7 +333,7 @@ export default class BlsWalletWrapper {
     return await initBlsWalletSigner({
       chainId,
       privateKey,
-      verificationGateway: verificationGatewayAddress,
+      verificationGatewayAddress,
     });
   }
 
@@ -354,7 +354,7 @@ export default class BlsWalletWrapper {
     const newBlsWalletSigner = await initBlsWalletSigner({
       chainId,
       privateKey,
-      verificationGateway: this.walletContract.address,
+      verificationGatewayAddress: this.walletContract.address,
     });
 
     this.blsWalletSigner = newBlsWalletSigner;

--- a/contracts/clients/src/BlsWalletWrapper.ts
+++ b/contracts/clients/src/BlsWalletWrapper.ts
@@ -74,6 +74,7 @@ export default class BlsWalletWrapper {
     const blsWalletSigner = await this.#BlsWalletSigner(
       signerOrProvider,
       privateKey,
+      verificationGatewayAddress,
     );
 
     const verificationGateway = VerificationGateway__factory.connect(
@@ -147,6 +148,7 @@ export default class BlsWalletWrapper {
     const blsWalletSigner = await initBlsWalletSigner({
       chainId: (await verificationGateway.provider.getNetwork()).chainId,
       privateKey,
+      verificationGateway: verificationGatewayAddress,
     });
 
     const blsWalletWrapper = new BlsWalletWrapper(
@@ -321,13 +323,14 @@ export default class BlsWalletWrapper {
   static async #BlsWalletSigner(
     signerOrProvider: SignerOrProvider,
     privateKey: string,
+    verificationGatewayAddress: string,
   ): Promise<BlsWalletSigner> {
     const chainId =
       "getChainId" in signerOrProvider
         ? await signerOrProvider.getChainId()
         : (await signerOrProvider.getNetwork()).chainId;
 
-    return await initBlsWalletSigner({ chainId, privateKey });
+    return await initBlsWalletSigner({ chainId, privateKey, verificationGateway: verificationGatewayAddress });
   }
 
   /**
@@ -347,6 +350,7 @@ export default class BlsWalletWrapper {
     const newBlsWalletSigner = await initBlsWalletSigner({
       chainId,
       privateKey,
+      verificationGateway: this.walletContract.address,
     });
 
     this.blsWalletSigner = newBlsWalletSigner;

--- a/contracts/clients/src/BlsWalletWrapper.ts
+++ b/contracts/clients/src/BlsWalletWrapper.ts
@@ -330,7 +330,11 @@ export default class BlsWalletWrapper {
         ? await signerOrProvider.getChainId()
         : (await signerOrProvider.getNetwork()).chainId;
 
-    return await initBlsWalletSigner({ chainId, privateKey, verificationGateway: verificationGatewayAddress });
+    return await initBlsWalletSigner({
+      chainId,
+      privateKey,
+      verificationGateway: verificationGatewayAddress,
+    });
   }
 
   /**

--- a/contracts/clients/src/signer/defaultDomain.ts
+++ b/contracts/clients/src/signer/defaultDomain.ts
@@ -1,3 +1,0 @@
-import { arrayify, keccak256 } from "ethers/lib/utils";
-
-export default arrayify(keccak256("0xfeedbee5"));

--- a/contracts/clients/src/signer/encodeMessageForSigning.ts
+++ b/contracts/clients/src/signer/encodeMessageForSigning.ts
@@ -1,7 +1,7 @@
 import { keccak256, solidityPack } from "ethers/lib/utils";
 import { Operation } from "./types";
 
-export default (chainId: number) =>
+export default () =>
   (operation: Operation, walletAddress: string): string => {
     let encodedActionData = "0x";
 
@@ -18,7 +18,7 @@ export default (chainId: number) =>
     }
 
     return solidityPack(
-      ["uint256", "address", "uint256", "bytes32"],
-      [chainId, walletAddress, operation.nonce, keccak256(encodedActionData)],
+      ["address", "uint256", "bytes32"],
+      [walletAddress, operation.nonce, keccak256(encodedActionData)],
     );
   };

--- a/contracts/clients/src/signer/getDomain.ts
+++ b/contracts/clients/src/signer/getDomain.ts
@@ -1,0 +1,15 @@
+import { arrayify, solidityPack } from "ethers/lib/utils";
+import { utils } from "ethers";
+
+export default (
+  chainId: number,
+  verificationGatewayAddress: string,
+  type: string,
+): Uint8Array => {
+  const encoded = solidityPack(
+    ["uint256", "address", "string"],
+    [chainId, verificationGatewayAddress, type],
+  );
+
+  return arrayify(utils.keccak256(encoded));
+};

--- a/contracts/clients/src/signer/index.ts
+++ b/contracts/clients/src/signer/index.ts
@@ -18,9 +18,9 @@ export type BlsWalletSigner = AsyncReturnType<typeof initBlsWalletSigner>;
 export async function initBlsWalletSigner({
   chainId,
   privateKey,
-  verificationGateway,
+  verificationGatewayAddress,
 }: {
-  verificationGateway: string;
+  verificationGatewayAddress: string;
   chainId: number;
   privateKey: string;
 }) {
@@ -32,8 +32,8 @@ export async function initBlsWalletSigner({
   // properly initialized for all use cases, not just signing.
   const signerFactory = await signer.BlsSignerFactory.new();
 
-  const bundleDomain = getDomain(chainId, verificationGateway, "Bundle");
-  const walletDomain = getDomain(chainId, verificationGateway, "Wallet");
+  const bundleDomain = getDomain(chainId, verificationGatewayAddress, "Bundle");
+  const walletDomain = getDomain(chainId, verificationGatewayAddress, "Wallet");
 
   return {
     aggregate,

--- a/contracts/clients/src/signer/index.ts
+++ b/contracts/clients/src/signer/index.ts
@@ -20,7 +20,6 @@ export async function initBlsWalletSigner({
   privateKey,
   verificationGateway,
 }: {
-  domain?: Uint8Array;
   verificationGateway: string;
   chainId: number;
   privateKey: string;
@@ -33,21 +32,17 @@ export async function initBlsWalletSigner({
   // properly initialized for all use cases, not just signing.
   const signerFactory = await signer.BlsSignerFactory.new();
 
-  const budleDomain = getDomain(chainId, verificationGateway, "Bundle");
-  const popDomain = getDomain(
-    chainId,
-    verificationGateway,
-    "ProofOfPossession",
-  );
+  const bundleDomain = getDomain(chainId, verificationGateway, "Bundle");
+  const walletDomain = getDomain(chainId, verificationGateway, "Wallet");
 
   return {
     aggregate,
-    getPublicKey: getPublicKey(signerFactory, budleDomain, privateKey),
-    getPublicKeyHash: getPublicKeyHash(signerFactory, budleDomain, privateKey),
-    getPublicKeyStr: getPublicKeyStr(signerFactory, budleDomain, privateKey),
-    sign: sign(signerFactory, budleDomain, chainId, privateKey),
-    signMessage: signMessage(signerFactory, popDomain, privateKey),
-    verify: verify(budleDomain, chainId),
+    getPublicKey: getPublicKey(signerFactory, bundleDomain, privateKey),
+    getPublicKeyHash: getPublicKeyHash(signerFactory, bundleDomain, privateKey),
+    getPublicKeyStr: getPublicKeyStr(signerFactory, bundleDomain, privateKey),
+    sign: sign(signerFactory, bundleDomain, chainId, privateKey),
+    signMessage: signMessage(signerFactory, walletDomain, privateKey),
+    verify: verify(bundleDomain, chainId),
     privateKey,
   };
 }

--- a/contracts/clients/src/signer/index.ts
+++ b/contracts/clients/src/signer/index.ts
@@ -2,6 +2,7 @@ import { signer } from "@thehubbleproject/bls";
 
 import aggregate from "./aggregate";
 import defaultDomain from "./defaultDomain";
+import getDomain from "./getDomain";
 import getPublicKey from "./getPublicKey";
 import getPublicKeyHash from "./getPublicKeyHash";
 import getPublicKeyStr from "./getPublicKeyStr";
@@ -16,11 +17,12 @@ export * from "./conversions";
 export type BlsWalletSigner = AsyncReturnType<typeof initBlsWalletSigner>;
 
 export async function initBlsWalletSigner({
-  domain = defaultDomain,
   chainId,
   privateKey,
+  verificationGateway,
 }: {
   domain?: Uint8Array;
+  verificationGateway: string;
   chainId: number;
   privateKey: string;
 }) {
@@ -31,6 +33,8 @@ export async function initBlsWalletSigner({
   // the creation of the signer factory, we're ensuring that mcl-wasm is
   // properly initialized for all use cases, not just signing.
   const signerFactory = await signer.BlsSignerFactory.new();
+
+  const domain = getDomain(chainId, verificationGateway);
 
   return {
     aggregate,

--- a/contracts/clients/src/signer/index.ts
+++ b/contracts/clients/src/signer/index.ts
@@ -1,7 +1,6 @@
 import { signer } from "@thehubbleproject/bls";
 
 import aggregate from "./aggregate";
-import defaultDomain from "./defaultDomain";
 import getDomain from "./getDomain";
 import getPublicKey from "./getPublicKey";
 import getPublicKeyHash from "./getPublicKeyHash";
@@ -34,16 +33,21 @@ export async function initBlsWalletSigner({
   // properly initialized for all use cases, not just signing.
   const signerFactory = await signer.BlsSignerFactory.new();
 
-  const domain = getDomain(chainId, verificationGateway);
+  const budleDomain = getDomain(chainId, verificationGateway, "Bundle");
+  const popDomain = getDomain(
+    chainId,
+    verificationGateway,
+    "ProofOfPossession",
+  );
 
   return {
     aggregate,
-    getPublicKey: getPublicKey(signerFactory, domain, privateKey),
-    getPublicKeyHash: getPublicKeyHash(signerFactory, domain, privateKey),
-    getPublicKeyStr: getPublicKeyStr(signerFactory, domain, privateKey),
-    sign: sign(signerFactory, domain, chainId, privateKey),
-    signMessage: signMessage(signerFactory, domain, privateKey),
-    verify: verify(domain, chainId),
+    getPublicKey: getPublicKey(signerFactory, budleDomain, privateKey),
+    getPublicKeyHash: getPublicKeyHash(signerFactory, budleDomain, privateKey),
+    getPublicKeyStr: getPublicKeyStr(signerFactory, budleDomain, privateKey),
+    sign: sign(signerFactory, budleDomain, chainId, privateKey),
+    signMessage: signMessage(signerFactory, popDomain, privateKey),
+    verify: verify(budleDomain, chainId),
     privateKey,
   };
 }

--- a/contracts/clients/src/signer/sign.ts
+++ b/contracts/clients/src/signer/sign.ts
@@ -11,7 +11,7 @@ export default (
   ) =>
   (operation: Operation, walletAddress: string): Bundle => {
     const signer = signerFactory.getSigner(domain, privateKey);
-    const message = encodeMessageForSigning(chainId)(operation, walletAddress);
+    const message = encodeMessageForSigning()(operation, walletAddress);
     const signature = signer.sign(message);
 
     return {

--- a/contracts/clients/src/signer/verify.ts
+++ b/contracts/clients/src/signer/verify.ts
@@ -26,7 +26,7 @@ export default (domain: Uint8Array, chainId: number) =>
         BigNumber.from(n3).toHexString(),
       ]),
       bundle.operations.map((op) =>
-        encodeMessageForSigning(chainId)(op, walletAddress),
+        encodeMessageForSigning()(op, walletAddress),
       ),
     );
   };

--- a/contracts/clients/test/index.test.ts
+++ b/contracts/clients/test/index.test.ts
@@ -52,6 +52,7 @@ describe("index", () => {
 
     const { sign, verify } = await initBlsWalletSigner({
       chainId: 123,
+      verificationGateway: "0xC8CD2BE653759aed7B0996315821AAe71e1FEAdF",
       domain,
       privateKey,
     });
@@ -59,14 +60,15 @@ describe("index", () => {
     const bundle = sign(bundleTemplate, walletAddress);
 
     expect(bundle.signature).to.deep.equal([
-      "0x2c1b0dc6643375e05a6f2ba3d23b1ce941253010b13a127e22f5db647dc37952",
-      "0x0338f96fc67ce194a74a459791865ac2eb304fc214fd0962775078d12aea5b7e",
+      "0x21135f40b38f55236ceb637ad8f2d6d4e8081bc1c37ea08273838f839008b9cd",
+      "0x16515fb0821c039e127dd8e4a70c7004aec1baf698802fc16e7cf8d2ae0bb14a",
     ]);
 
     expect(verify(bundle, walletAddress)).to.equal(true);
 
     const { sign: signWithOtherPrivateKey } = await initBlsWalletSigner({
       chainId: 123,
+      verificationGateway: "0xC8CD2BE653759aed7B0996315821AAe71e1FEAdF",
       domain,
       privateKey: otherPrivateKey,
     });
@@ -111,11 +113,13 @@ describe("index", () => {
 
     const { sign, aggregate, verify } = await initBlsWalletSigner({
       chainId: 123,
+      verificationGateway: "0xC8CD2BE653759aed7B0996315821AAe71e1FEAdF",
       domain,
       privateKey,
     });
     const { sign: signWithOtherPrivateKey } = await initBlsWalletSigner({
       chainId: 123,
+      verificationGateway: "0xC8CD2BE653759aed7B0996315821AAe71e1FEAdF",
       domain,
       privateKey: otherPrivateKey,
     });
@@ -125,8 +129,8 @@ describe("index", () => {
     const aggBundle = aggregate([bundle1, bundle2]);
 
     expect(aggBundle.signature).to.deep.equal([
-      "0x2319fc81d339dce4678c73429dfd2f11766742ed1e41df5a2ba2bf4863d877b5",
-      "0x1bb25c15ad1f2f967a80a7a65c7593fcd66b59bf092669707baf2db726e8e714",
+      "0x20c3afd45d2c7cd72003752377cf6853569bccd23abf962967a9245091b69c3b",
+      "0x1ff4a18f1e920206f849e50df41e7bab6377d3908a8198d9c9268ca01ae70552",
     ]);
 
     expect(verify(bundle1, walletAddress)).to.equal(true);
@@ -163,6 +167,7 @@ describe("index", () => {
 
     const { sign, aggregate, verify } = await initBlsWalletSigner({
       chainId: 123,
+      verificationGateway: "0xC8CD2BE653759aed7B0996315821AAe71e1FEAdF",
       domain,
       privateKey,
     });
@@ -195,6 +200,7 @@ describe("index", () => {
 
     const { getPublicKeyStr } = await initBlsWalletSigner({
       chainId: 123,
+      verificationGateway: "0xC8CD2BE653759aed7B0996315821AAe71e1FEAdF",
       domain,
       privateKey,
     });
@@ -215,6 +221,7 @@ describe("index", () => {
 
     const { aggregate } = await initBlsWalletSigner({
       chainId: 123,
+      verificationGateway: "0xC8CD2BE653759aed7B0996315821AAe71e1FEAdF",
       domain,
       privateKey,
     });
@@ -230,6 +237,7 @@ describe("index", () => {
 
     const { aggregate, verify } = await initBlsWalletSigner({
       chainId: 123,
+      verificationGateway: "0xC8CD2BE653759aed7B0996315821AAe71e1FEAdF",
       domain,
       privateKey,
     });

--- a/contracts/clients/test/index.test.ts
+++ b/contracts/clients/test/index.test.ts
@@ -50,7 +50,7 @@ describe("index", () => {
 
     const { sign, verify } = await initBlsWalletSigner({
       chainId: 123,
-      verificationGateway: "0xC8CD2BE653759aed7B0996315821AAe71e1FEAdF",
+      verificationGatewayAddress: "0xC8CD2BE653759aed7B0996315821AAe71e1FEAdF",
       privateKey,
     });
 
@@ -65,7 +65,7 @@ describe("index", () => {
 
     const { sign: signWithOtherPrivateKey } = await initBlsWalletSigner({
       chainId: 123,
-      verificationGateway: "0xC8CD2BE653759aed7B0996315821AAe71e1FEAdF",
+      verificationGatewayAddress: "0xC8CD2BE653759aed7B0996315821AAe71e1FEAdF",
       privateKey: otherPrivateKey,
     });
 
@@ -109,12 +109,12 @@ describe("index", () => {
 
     const { sign, aggregate, verify } = await initBlsWalletSigner({
       chainId: 123,
-      verificationGateway: "0xC8CD2BE653759aed7B0996315821AAe71e1FEAdF",
+      verificationGatewayAddress: "0xC8CD2BE653759aed7B0996315821AAe71e1FEAdF",
       privateKey,
     });
     const { sign: signWithOtherPrivateKey } = await initBlsWalletSigner({
       chainId: 123,
-      verificationGateway: "0xC8CD2BE653759aed7B0996315821AAe71e1FEAdF",
+      verificationGatewayAddress: "0xC8CD2BE653759aed7B0996315821AAe71e1FEAdF",
       privateKey: otherPrivateKey,
     });
 
@@ -161,7 +161,7 @@ describe("index", () => {
 
     const { sign, aggregate, verify } = await initBlsWalletSigner({
       chainId: 123,
-      verificationGateway: "0xC8CD2BE653759aed7B0996315821AAe71e1FEAdF",
+      verificationGatewayAddress: "0xC8CD2BE653759aed7B0996315821AAe71e1FEAdF",
       privateKey,
     });
 
@@ -193,7 +193,7 @@ describe("index", () => {
 
     const { getPublicKeyStr } = await initBlsWalletSigner({
       chainId: 123,
-      verificationGateway: "0xC8CD2BE653759aed7B0996315821AAe71e1FEAdF",
+      verificationGatewayAddress: "0xC8CD2BE653759aed7B0996315821AAe71e1FEAdF",
       privateKey,
     });
 
@@ -213,7 +213,7 @@ describe("index", () => {
 
     const { aggregate } = await initBlsWalletSigner({
       chainId: 123,
-      verificationGateway: "0xC8CD2BE653759aed7B0996315821AAe71e1FEAdF",
+      verificationGatewayAddress: "0xC8CD2BE653759aed7B0996315821AAe71e1FEAdF",
       privateKey,
     });
 
@@ -228,7 +228,7 @@ describe("index", () => {
 
     const { aggregate, verify } = await initBlsWalletSigner({
       chainId: 123,
-      verificationGateway: "0xC8CD2BE653759aed7B0996315821AAe71e1FEAdF",
+      verificationGatewayAddress: "0xC8CD2BE653759aed7B0996315821AAe71e1FEAdF",
       privateKey,
     });
 

--- a/contracts/clients/test/index.test.ts
+++ b/contracts/clients/test/index.test.ts
@@ -1,12 +1,10 @@
 import { BigNumber } from "ethers";
-import { keccak256, arrayify } from "ethers/lib/utils";
 import { expect } from "chai";
 
 import { initBlsWalletSigner, Bundle, Operation } from "../src/signer";
 
 import Range from "./helpers/Range";
 
-const domain = arrayify(keccak256("0xfeedbee5"));
 const weiPerToken = BigNumber.from(10).pow(18);
 
 const samples = (() => {
@@ -53,7 +51,6 @@ describe("index", () => {
     const { sign, verify } = await initBlsWalletSigner({
       chainId: 123,
       verificationGateway: "0xC8CD2BE653759aed7B0996315821AAe71e1FEAdF",
-      domain,
       privateKey,
     });
 
@@ -69,7 +66,6 @@ describe("index", () => {
     const { sign: signWithOtherPrivateKey } = await initBlsWalletSigner({
       chainId: 123,
       verificationGateway: "0xC8CD2BE653759aed7B0996315821AAe71e1FEAdF",
-      domain,
       privateKey: otherPrivateKey,
     });
 
@@ -114,13 +110,11 @@ describe("index", () => {
     const { sign, aggregate, verify } = await initBlsWalletSigner({
       chainId: 123,
       verificationGateway: "0xC8CD2BE653759aed7B0996315821AAe71e1FEAdF",
-      domain,
       privateKey,
     });
     const { sign: signWithOtherPrivateKey } = await initBlsWalletSigner({
       chainId: 123,
       verificationGateway: "0xC8CD2BE653759aed7B0996315821AAe71e1FEAdF",
-      domain,
       privateKey: otherPrivateKey,
     });
 
@@ -168,7 +162,6 @@ describe("index", () => {
     const { sign, aggregate, verify } = await initBlsWalletSigner({
       chainId: 123,
       verificationGateway: "0xC8CD2BE653759aed7B0996315821AAe71e1FEAdF",
-      domain,
       privateKey,
     });
 
@@ -201,7 +194,6 @@ describe("index", () => {
     const { getPublicKeyStr } = await initBlsWalletSigner({
       chainId: 123,
       verificationGateway: "0xC8CD2BE653759aed7B0996315821AAe71e1FEAdF",
-      domain,
       privateKey,
     });
 
@@ -222,7 +214,6 @@ describe("index", () => {
     const { aggregate } = await initBlsWalletSigner({
       chainId: 123,
       verificationGateway: "0xC8CD2BE653759aed7B0996315821AAe71e1FEAdF",
-      domain,
       privateKey,
     });
 
@@ -238,7 +229,6 @@ describe("index", () => {
     const { aggregate, verify } = await initBlsWalletSigner({
       chainId: 123,
       verificationGateway: "0xC8CD2BE653759aed7B0996315821AAe71e1FEAdF",
-      domain,
       privateKey,
     });
 

--- a/contracts/contracts/VerificationGateway.sol
+++ b/contracts/contracts/VerificationGateway.sol
@@ -9,6 +9,8 @@ import "@openzeppelin/contracts/proxy/transparent/TransparentUpgradeableProxy.so
 
 import "./interfaces/IWallet.sol";
 
+import "hardhat/console.sol";
+
 /**
 A non-upgradable gateway used to create BLSWallets and call them with
 verified Operations that have been respectively signed.
@@ -19,7 +21,7 @@ is the calling wallet's address.
 contract VerificationGateway
 {
     /** Domain chosen arbitrarily */
-    bytes32 BLS_DOMAIN = keccak256(abi.encodePacked(uint32(0xfeedbee5)));
+    bytes32 BLS_DOMAIN;
     uint8 constant BLS_KEY_LEN = 4;
 
     IBLS public immutable blsLib;
@@ -73,6 +75,7 @@ contract VerificationGateway
         blsLib = bls;
         blsWalletLogic = blsWalletImpl;
         walletProxyAdmin = ProxyAdmin(proxyAdmin);
+        BLS_DOMAIN = keccak256(abi.encode(block.chainid, address(this)));
     }
 
     /** Throw if bundle not valid or signature verification fails */
@@ -353,7 +356,7 @@ contract VerificationGateway
     ) private {
         // verify the given wallet was signed for by the bls key
         uint256[2] memory addressMsg = blsLib.hashToPoint(
-            BLS_DOMAIN,
+            BLS_DOMAIN, // second domain here
             abi.encodePacked(wallet)
         );
         require(

--- a/contracts/contracts/VerificationGateway.sol
+++ b/contracts/contracts/VerificationGateway.sol
@@ -20,7 +20,7 @@ is the calling wallet's address.
  */
 contract VerificationGateway
 {
-    bytes32 PoP_DOMAIN;
+    bytes32 WALLET_DOMAIN;
     bytes32 BUNDLE_DOMAIN;
     uint8 constant BLS_KEY_LEN = 4;
 
@@ -75,10 +75,10 @@ contract VerificationGateway
         blsLib = bls;
         blsWalletLogic = blsWalletImpl;
         walletProxyAdmin = ProxyAdmin(proxyAdmin);
-        PoP_DOMAIN = keccak256(abi.encodePacked(
+        WALLET_DOMAIN = keccak256(abi.encodePacked(
             block.chainid,
             address(this),
-            "ProofOfPossession"
+            "Wallet"
         ));
         BUNDLE_DOMAIN = keccak256(abi.encodePacked(
             block.chainid,
@@ -365,7 +365,7 @@ contract VerificationGateway
     ) private {
         // verify the given wallet was signed for by the bls key
         uint256[2] memory addressMsg = blsLib.hashToPoint(
-            PoP_DOMAIN,
+            WALLET_DOMAIN,
             abi.encodePacked(wallet)
         );
         require(

--- a/contracts/shared/helpers/Fixture.ts
+++ b/contracts/shared/helpers/Fixture.ts
@@ -149,7 +149,7 @@ export default class Fixture {
       await initBlsWalletSigner({
         chainId,
         privateKey,
-        verificationGateway: verificationGateway.address,
+        verificationGatewayAddress: verificationGateway.address,
       }),
     );
   }

--- a/contracts/shared/helpers/Fixture.ts
+++ b/contracts/shared/helpers/Fixture.ts
@@ -146,7 +146,11 @@ export default class Fixture {
       blsExpander,
       utilities,
       BLSWallet,
-      await initBlsWalletSigner({ chainId, privateKey }),
+      await initBlsWalletSigner({
+        chainId,
+        privateKey,
+        verificationGateway: verificationGateway.address,
+      }),
     );
   }
 

--- a/contracts/test-integration/BlsProvider.test.ts
+++ b/contracts/test-integration/BlsProvider.test.ts
@@ -441,7 +441,7 @@ describe("BlsProvider", () => {
       value: parseEther("1"),
     });
 
-    const expectedToAddress = "0x689A095B4507Bfa302eef8551F90fB322B3451c6"; // Verification Gateway address
+    const expectedToAddress = "0x14EE47429DEf3462142AE5f8d1E263E0B137bA63"; // Verification Gateway address
     const expectedFromAddress = "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266"; // Aggregator address (Hardhat account 0)
 
     // Act
@@ -502,7 +502,7 @@ describe("BlsProvider", () => {
       value: parseEther("1"),
     });
 
-    const expectedToAddress = "0x689A095B4507Bfa302eef8551F90fB322B3451c6"; // Verification Gateway address
+    const expectedToAddress = "0x14EE47429DEf3462142AE5f8d1E263E0B137bA63"; // Verification Gateway address
     const expectedFromAddress = "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266"; // Aggregator address (Hardhat account 0)
 
     // Act

--- a/contracts/test/upgrade-test.ts
+++ b/contracts/test/upgrade-test.ts
@@ -228,7 +228,7 @@ describe("Upgrade", async function () {
           }),
         );
 
-      expect(successes).to.deep.equal([true]); // blake fails here
+      expect(successes).to.deep.equal([true]);
     }
 
     expect(await vg2.walletFromHash(hash)).not.to.equal(walletAddress);
@@ -277,7 +277,7 @@ describe("Upgrade", async function () {
 
     await walletNewVg.syncWallet(vg2);
     // Check new gateway has wallet via static call through new gateway
-    const bundleResult = await vg2.callStatic.processBundle(  // blake now failing here
+    const bundleResult = await vg2.callStatic.processBundle(
       fx.blsWalletSigner.aggregate([
         walletNewVg.sign({
           nonce: BigNumber.from(3),

--- a/contracts/test/upgrade-test.ts
+++ b/contracts/test/upgrade-test.ts
@@ -182,15 +182,15 @@ describe("Upgrade", async function () {
       // Fail if setExternalWalletAction is skipped
 
       const result = await fx.verificationGateway.callStatic.processBundle(
-          walletOldVg.sign({
-            nonce: BigNumber.from(2),
-            actions: [
-              // skip: setExternalWalletAction,
-              changeProxyAction,
-              setTrustedBLSGatewayAction,
-            ],
-          }),
-        );
+        walletOldVg.sign({
+          nonce: BigNumber.from(2),
+          actions: [
+            // skip: setExternalWalletAction,
+            changeProxyAction,
+            setTrustedBLSGatewayAction,
+          ],
+        }),
+      );
 
       expect(result.successes).to.deep.equal([false]);
     }

--- a/contracts/test/upgrade-test.ts
+++ b/contracts/test/upgrade-test.ts
@@ -181,8 +181,7 @@ describe("Upgrade", async function () {
     {
       // Fail if setExternalWalletAction is skipped
 
-      const { successes } =
-        await fx.verificationGateway.callStatic.processBundle(
+      const result = await fx.verificationGateway.callStatic.processBundle(
           walletOldVg.sign({
             nonce: BigNumber.from(2),
             actions: [
@@ -193,7 +192,7 @@ describe("Upgrade", async function () {
           }),
         );
 
-      expect(successes).to.deep.equal([false]);
+      expect(result.successes).to.deep.equal([false]);
     }
 
     {
@@ -229,7 +228,7 @@ describe("Upgrade", async function () {
           }),
         );
 
-      expect(successes).to.deep.equal([true]);
+      expect(successes).to.deep.equal([true]); // blake fails here
     }
 
     expect(await vg2.walletFromHash(hash)).not.to.equal(walletAddress);

--- a/contracts/test/upgrade-test.ts
+++ b/contracts/test/upgrade-test.ts
@@ -121,14 +121,14 @@ describe("Upgrade", async function () {
     const walletAddress = walletOldVg.address;
     const blsSecret = walletOldVg.blsWalletSigner.privateKey;
 
-    const wallet = await BlsWalletWrapper.connect(
-      blsSecret,
-      fx.verificationGateway.address,
-      fx.verificationGateway.provider,
-    );
     // Sign simple address message
     const addressMessage = solidityPack(["address"], [walletAddress]);
-    const addressSignature = wallet.signMessage(addressMessage);
+    const walletNewVg = await BlsWalletWrapper.connect(
+      blsSecret,
+      vg2.address,
+      vg2.provider,
+    );
+    const addressSignature = walletNewVg.signMessage(addressMessage);
 
     const proxyAdmin2Address = await vg2.walletProxyAdmin();
     // Get admin action to change proxy
@@ -275,10 +275,11 @@ describe("Upgrade", async function () {
     // Check new verification gateway was set
     expect(await blsWallet.trustedBLSGateway()).to.equal(vg2.address);
 
+    await walletNewVg.syncWallet(vg2);
     // Check new gateway has wallet via static call through new gateway
-    const bundleResult = await vg2.callStatic.processBundle(
+    const bundleResult = await vg2.callStatic.processBundle(  // blake now failing here
       fx.blsWalletSigner.aggregate([
-        walletOldVg.sign({
+        walletNewVg.sign({
           nonce: BigNumber.from(3),
           actions: [
             {

--- a/extension/package.json
+++ b/extension/package.json
@@ -36,7 +36,7 @@
     "advanced-css-reset": "^1.2.2",
     "async-mutex": "^0.3.2",
     "axios": "^0.27.2",
-    "bls-wallet-clients": "0.8.2-1452ef5",
+    "bls-wallet-clients": "0.8.2-1fb4a55",
     "browser-passworder": "^2.0.3",
     "bs58check": "^2.1.2",
     "crypto-browserify": "^3.12.0",

--- a/extension/yarn.lock
+++ b/extension/yarn.lock
@@ -2907,10 +2907,10 @@ blakejs@^1.1.0:
   resolved "https://registry.yarnpkg.com/blakejs/-/blakejs-1.2.1.tgz#5057e4206eadb4a97f7c0b6e197a505042fc3814"
   integrity sha512-QXUSXI3QVc/gJME0dBpXrag1kbzOqCjCX8/b54ntNyW6sjtoqxqRk3LTmXzaJoh71zMsDCjM+47jS7XiwN/+fQ==
 
-bls-wallet-clients@0.8.2-1452ef5:
-  version "0.8.2-1452ef5"
-  resolved "https://registry.yarnpkg.com/bls-wallet-clients/-/bls-wallet-clients-0.8.2-1452ef5.tgz#d76e938ca45ec5da44c8e59699d1bd5f6c69dcd2"
-  integrity sha512-bg7WLr9NRbvDzj+zgkLNfaPzr1m0m13Cc8RJoZ2s6s+ic7WxSiwxTkZGc2SChFgmG8ZGi1O9DnR6//lrTsMVUA==
+bls-wallet-clients@0.8.2-1fb4a55:
+  version "0.8.2-1fb4a55"
+  resolved "https://registry.yarnpkg.com/bls-wallet-clients/-/bls-wallet-clients-0.8.2-1fb4a55.tgz#bab40801ee1e60ffbc9c0bc924943c6f90605e7c"
+  integrity sha512-2tlwOSUGzsOiam0G7GBmsN3W5cHjUwTmHR/DvGRH584zLkCC/8TFdAn2/laSF2baTYvegtIHwQNl1zX5DWivEQ==
   dependencies:
     "@thehubbleproject/bls" "^0.5.1"
     ethers "^5.7.2"


### PR DESCRIPTION
## What is this PR doing?

Issues:
- `BLS_DOMAIN` is just an arbitrary string so it doesn't protect against replay across contracts or chains.
- Ex: The message in `safeSetWallet()` is only signed with the wallet address.  
- Ex: In the `verify()` function, the `chainId` is appended to messages but not the verification gateway address.

Solution:
- Include the chainId and the verification gateway address in the domain.
- Create a seperate domain for `safeSetWallet` and `verify` so that it's not possible for overlap between a bundle message and a proof of possession message.

## How can these changes be manually tested?
- Running all tests and checking Quil/example dapps still work

## Does this PR resolve or contribute to any issues?
https://github.com/web3well/bls-wallet/issues/459

## Checklist
- [ ] I have manually tested these changes
- [ ] Post a link to the PR in the group chat

## Guidelines
- If your PR is not ready, mark it as a draft
- The `resolve conversation` button is for reviewers, not authors
  - (But add a 'done' comment or similar)
