### PR TITLE
Add static get random private key method to bls signer

### DIFF
--- a/contracts/clients/src/BlsSigner.ts
+++ b/contracts/clients/src/BlsSigner.ts
@@ -115,6 +115,13 @@ export default class BlsSigner extends Signer {
   }
 
   /**
+   * @returns a random BLS private key
+   */
+  static async getRandomBlsPrivateKey(): Promise<string> {
+    return await BlsWalletWrapper.getRandomBlsPrivateKey();
+  }
+
+  /**
    * Sends transactions to be executed. Converts the TransactionRequest
    * to a bundle and adds it to the aggregator
    *

--- a/contracts/clients/test/BlsProvider.test.ts
+++ b/contracts/clients/test/BlsProvider.test.ts
@@ -2,7 +2,7 @@ import { expect } from "chai";
 import { ethers } from "ethers";
 import { parseEther } from "ethers/lib/utils";
 
-import { Experimental, BlsWalletWrapper } from "../src";
+import { Experimental } from "../src";
 import BlsSigner, { UncheckedBlsSigner } from "../src/BlsSigner";
 
 let aggregatorUrl: string;
@@ -28,7 +28,7 @@ describe("BlsProvider", () => {
       chainId: 0x539, // 1337
     };
 
-    privateKey = await BlsWalletWrapper.getRandomBlsPrivateKey();
+    privateKey = await Experimental.BlsSigner.getRandomBlsPrivateKey();
 
     blsProvider = new Experimental.BlsProvider(
       aggregatorUrl,
@@ -72,7 +72,7 @@ describe("BlsProvider", () => {
     );
 
     // Act
-    const newPrivateKey = await BlsWalletWrapper.getRandomBlsPrivateKey();
+    const newPrivateKey = await Experimental.BlsSigner.getRandomBlsPrivateKey();
 
     const newBlsSigner = newBlsProvider.getSigner(newPrivateKey);
 

--- a/contracts/clients/test/BlsSigner.test.ts
+++ b/contracts/clients/test/BlsSigner.test.ts
@@ -1,7 +1,7 @@
 import { expect } from "chai";
 import { ethers } from "ethers";
 
-import { Experimental, BlsWalletWrapper } from "../src";
+import { Experimental } from "../src";
 import { UncheckedBlsSigner } from "../src/BlsSigner";
 
 let aggregatorUrl: string;
@@ -25,7 +25,7 @@ describe("BlsSigner", () => {
       chainId: 0x7a69,
     };
 
-    privateKey = await BlsWalletWrapper.getRandomBlsPrivateKey();
+    privateKey = await Experimental.BlsSigner.getRandomBlsPrivateKey();
 
     blsProvider = new Experimental.BlsProvider(
       aggregatorUrl,

--- a/contracts/test-integration/BlsProvider.test.ts
+++ b/contracts/test-integration/BlsProvider.test.ts
@@ -39,7 +39,7 @@ describe("BlsProvider", () => {
       chainId: 0x539, // 1337
     };
 
-    privateKey = await BlsWalletWrapper.getRandomBlsPrivateKey();
+    privateKey = await Experimental.BlsSigner.getRandomBlsPrivateKey();
 
     blsProvider = new Experimental.BlsProvider(
       aggregatorUrl,

--- a/contracts/test-integration/BlsProviderContractInteraction.test.ts
+++ b/contracts/test-integration/BlsProviderContractInteraction.test.ts
@@ -2,7 +2,7 @@ import { expect } from "chai";
 import { ethers } from "hardhat";
 import { BigNumber, utils, Wallet } from "ethers";
 
-import { Experimental, BlsWalletWrapper } from "../clients/src";
+import { Experimental } from "../clients/src";
 import getNetworkConfig from "../shared/helpers/getNetworkConfig";
 
 describe("Provider tests", function () {
@@ -12,7 +12,7 @@ describe("Provider tests", function () {
 
   this.beforeAll(async () => {
     const networkConfig = await getNetworkConfig("local");
-    const privateKey = await BlsWalletWrapper.getRandomBlsPrivateKey();
+    const privateKey = await Experimental.BlsSigner.getRandomBlsPrivateKey();
     const aggregatorUrl = "http://localhost:3000";
     const verificationGateway = networkConfig.addresses.verificationGateway;
     const aggregatorUtilities = networkConfig.addresses.utilities;

--- a/contracts/test-integration/BlsSigner.test.ts
+++ b/contracts/test-integration/BlsSigner.test.ts
@@ -48,7 +48,7 @@ describe("BlsSigner", () => {
       chainId: 0x539, // 1337
     };
 
-    privateKey = await BlsWalletWrapper.getRandomBlsPrivateKey();
+    privateKey = await Experimental.BlsSigner.getRandomBlsPrivateKey();
 
     blsProvider = new Experimental.BlsProvider(
       aggregatorUrl,
@@ -799,7 +799,7 @@ describe("BlsSigner", () => {
 
   it("should await the init promise when connecting to an unchecked bls signer", async () => {
     // Arrange
-    const newPrivateKey = await BlsWalletWrapper.getRandomBlsPrivateKey();
+    const newPrivateKey = await Experimental.BlsSigner.getRandomBlsPrivateKey();
     const newBlsSigner = blsProvider.getSigner(newPrivateKey);
     const uncheckedBlsSigner = newBlsSigner.connectUnchecked();
 
@@ -834,7 +834,7 @@ describe("BlsSigner", () => {
       rpcUrl,
       network,
     );
-    const newPrivateKey = await BlsWalletWrapper.getRandomBlsPrivateKey();
+    const newPrivateKey = await Experimental.BlsSigner.getRandomBlsPrivateKey();
     const newBlsSigner = newBlsProvider.getSigner(newPrivateKey);
     const uncheckedBlsSigner = newBlsSigner.connectUnchecked();
 

--- a/contracts/test-integration/BlsSignerContractInteraction.test.ts
+++ b/contracts/test-integration/BlsSignerContractInteraction.test.ts
@@ -22,7 +22,7 @@ async function getRandomSigners(
 
   const signers = [];
   for (let i = 0; i < numSigners; i++) {
-    const privateKey = await BlsWalletWrapper.getRandomBlsPrivateKey();
+    const privateKey = await Experimental.BlsSigner.getRandomBlsPrivateKey();
     const blsProvider = new Experimental.BlsProvider(
       aggregatorUrl,
       verificationGateway,

--- a/docs/use_bls_provider.md
+++ b/docs/use_bls_provider.md
@@ -40,9 +40,9 @@ const provider = new Experimental.BlsProvider(
 **Important:** Ensure that the BLS wallet you are linking the `BlsSigner` to via the private key is funded. Alternatively, if a wallet doesn't yet exist, it will be lazily created on the first transaction. In this scenario, you can create a random BLS private key with the following helper method and fund that account. It will need to be funded in order to send its first transaction.
 
 ```ts
-import { BlsWalletWrapper } from "bls-wallet-clients";
+import { Experimental } from "bls-wallet-clients";
 
-const privateKey = await BlsWalletWrapper.getRandomBlsPrivateKey();
+const privateKey = await Experimental.BlsSigner.getRandomBlsPrivateKey();
 
 const signer = provider.getSigner(privateKey);
 


### PR DESCRIPTION
## What is this PR doing?
Adds static helper method to BlsSigner to generate a random private key. Follow up from https://github.com/web3well/bls-wallet/pull/562#discussion_r1149969154

## How can these changes be manually tested?
Run tests

## Does this PR resolve or contribute to any issues?
resolves #565 

## Checklist
- [x] I have manually tested these changes
- [x] Post a link to the PR in the group chat

## Guidelines
- If your PR is not ready, mark it as a draft
- The `resolve conversation` button is for reviewers, not authors
  - (But add a 'done' comment or similar)
