### PR TITLE
567 bls provider and bls signer release

### DIFF
--- a/aggregator-proxy/package.json
+++ b/aggregator-proxy/package.json
@@ -21,7 +21,7 @@
     "@types/koa__cors": "^3.3.0",
     "@types/koa__router": "^8.0.11",
     "@types/node-fetch": "^2.6.1",
-    "bls-wallet-clients": "0.8.2-1452ef5",
+    "bls-wallet-clients": "0.8.2-de12b3c",
     "fp-ts": "^2.12.1",
     "io-ts": "^2.2.16",
     "io-ts-reporters": "^2.0.1",

--- a/aggregator-proxy/package.json
+++ b/aggregator-proxy/package.json
@@ -21,7 +21,7 @@
     "@types/koa__cors": "^3.3.0",
     "@types/koa__router": "^8.0.11",
     "@types/node-fetch": "^2.6.1",
-    "bls-wallet-clients": "0.8.2-de12b3c",
+    "bls-wallet-clients": "0.8.3",
     "fp-ts": "^2.12.1",
     "io-ts": "^2.2.16",
     "io-ts-reporters": "^2.0.1",

--- a/aggregator-proxy/yarn.lock
+++ b/aggregator-proxy/yarn.lock
@@ -887,10 +887,10 @@ bech32@1.1.4:
   resolved "https://registry.yarnpkg.com/bech32/-/bech32-1.1.4.tgz#e38c9f37bf179b8eb16ae3a772b40c356d4832e9"
   integrity sha512-s0IrSOzLlbvX7yp4WBfPITzpAU8sqQcpsmwXDiKwrG4r491vwCO/XpejasRNl0piBMe/DvP4Tz0mIS/X1DPJBQ==
 
-bls-wallet-clients@0.8.2-1452ef5:
-  version "0.8.2-1452ef5"
-  resolved "https://registry.yarnpkg.com/bls-wallet-clients/-/bls-wallet-clients-0.8.2-1452ef5.tgz#d76e938ca45ec5da44c8e59699d1bd5f6c69dcd2"
-  integrity sha512-bg7WLr9NRbvDzj+zgkLNfaPzr1m0m13Cc8RJoZ2s6s+ic7WxSiwxTkZGc2SChFgmG8ZGi1O9DnR6//lrTsMVUA==
+bls-wallet-clients@0.8.2-de12b3c:
+  version "0.8.2-de12b3c"
+  resolved "https://registry.yarnpkg.com/bls-wallet-clients/-/bls-wallet-clients-0.8.2-de12b3c.tgz#819ac2d80533c728900616f35918353dd07eb2c2"
+  integrity sha512-quoDibpDL3Injw4b4/2FjhMhH/Rq9hjO4n7sVMMa5jRe5Ttd1gCzCvGMkvNpL856k7zDxV20PNPxJf7GQgziCw==
   dependencies:
     "@thehubbleproject/bls" "^0.5.1"
     ethers "^5.7.2"

--- a/aggregator-proxy/yarn.lock
+++ b/aggregator-proxy/yarn.lock
@@ -887,10 +887,10 @@ bech32@1.1.4:
   resolved "https://registry.yarnpkg.com/bech32/-/bech32-1.1.4.tgz#e38c9f37bf179b8eb16ae3a772b40c356d4832e9"
   integrity sha512-s0IrSOzLlbvX7yp4WBfPITzpAU8sqQcpsmwXDiKwrG4r491vwCO/XpejasRNl0piBMe/DvP4Tz0mIS/X1DPJBQ==
 
-bls-wallet-clients@0.8.2-de12b3c:
-  version "0.8.2-de12b3c"
-  resolved "https://registry.yarnpkg.com/bls-wallet-clients/-/bls-wallet-clients-0.8.2-de12b3c.tgz#819ac2d80533c728900616f35918353dd07eb2c2"
-  integrity sha512-quoDibpDL3Injw4b4/2FjhMhH/Rq9hjO4n7sVMMa5jRe5Ttd1gCzCvGMkvNpL856k7zDxV20PNPxJf7GQgziCw==
+bls-wallet-clients@0.8.3:
+  version "0.8.3"
+  resolved "https://registry.yarnpkg.com/bls-wallet-clients/-/bls-wallet-clients-0.8.3.tgz#7d3ee34ad3508ee730f3c4766980301bc3625d61"
+  integrity sha512-U5CQ7dZXIDmThu7spZyEhAgXyZ1FkamQk5jjV024L3egPr5zhenaeghdRqnjgp5YJ0PuxeFbe0c3SC5s42z7tQ==
   dependencies:
     "@thehubbleproject/bls" "^0.5.1"
     ethers "^5.7.2"

--- a/aggregator/deps.ts
+++ b/aggregator/deps.ts
@@ -53,7 +53,7 @@ export type {
   PublicKey,
   Signature,
   VerificationGateway,
-} from "https://esm.sh/bls-wallet-clients@0.8.2-de12b3c";
+} from "https://esm.sh/bls-wallet-clients@0.8.3";
 
 export {
   Aggregator as AggregatorClient,
@@ -64,10 +64,10 @@ export {
   getConfig,
   MockERC20__factory,
   VerificationGateway__factory,
-} from "https://esm.sh/bls-wallet-clients@0.8.2-de12b3c";
+} from "https://esm.sh/bls-wallet-clients@0.8.3";
 
 // Workaround for esbuild's export-star bug
-import blsWalletClients from "https://esm.sh/bls-wallet-clients@0.8.2-de12b3c";
+import blsWalletClients from "https://esm.sh/bls-wallet-clients@0.8.3";
 const { bundleFromDto, bundleToDto, initBlsWalletSigner } = blsWalletClients;
 export { bundleFromDto, bundleToDto, initBlsWalletSigner };
 

--- a/aggregator/deps.ts
+++ b/aggregator/deps.ts
@@ -53,7 +53,7 @@ export type {
   PublicKey,
   Signature,
   VerificationGateway,
-} from "https://esm.sh/bls-wallet-clients@0.8.2-1452ef5";
+} from "https://esm.sh/bls-wallet-clients@0.8.2-de12b3c";
 
 export {
   Aggregator as AggregatorClient,
@@ -64,10 +64,10 @@ export {
   getConfig,
   MockERC20__factory,
   VerificationGateway__factory,
-} from "https://esm.sh/bls-wallet-clients@0.8.2-1452ef5";
+} from "https://esm.sh/bls-wallet-clients@0.8.2-de12b3c";
 
 // Workaround for esbuild's export-star bug
-import blsWalletClients from "https://esm.sh/bls-wallet-clients@0.8.2-1452ef5";
+import blsWalletClients from "https://esm.sh/bls-wallet-clients@0.8.2-de12b3c";
 const { bundleFromDto, bundleToDto, initBlsWalletSigner } = blsWalletClients;
 export { bundleFromDto, bundleToDto, initBlsWalletSigner };
 

--- a/contracts/clients/package.json
+++ b/contracts/clients/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bls-wallet-clients",
-  "version": "0.8.2-de12b3c",
+  "version": "0.8.3",
   "description": "Client libraries for interacting with BLS Wallet components",
   "main": "dist/src/index.js",
   "types": "dist/src/index.d.ts",

--- a/contracts/clients/package.json
+++ b/contracts/clients/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bls-wallet-clients",
-  "version": "0.8.2-1452ef5",
+  "version": "0.8.2-de12b3c",
   "description": "Client libraries for interacting with BLS Wallet components",
   "main": "dist/src/index.js",
   "types": "dist/src/index.d.ts",

--- a/contracts/clients/src/index.ts
+++ b/contracts/clients/src/index.ts
@@ -36,20 +36,6 @@ import { BlsWalletContracts, connectToContracts } from "./BlsWalletContracts";
 
 export * from "./signer";
 
-const Experimental_ = {
-  BlsProvider,
-  BlsSigner,
-};
-
-/**
- * The Experimental namespace exposes APIs that are unstable.
- * Unstable in the sense that the APIs will be less functional, less well-tested, and/or are expected to change.
- */
-namespace Experimental {
-  export const BlsProvider = Experimental_.BlsProvider;
-  export const BlsSigner = Experimental_.BlsSigner;
-}
-
 export {
   Aggregator,
   BlsWalletWrapper,
@@ -77,5 +63,6 @@ export {
   MockERC20,
   BlsWalletContracts,
   connectToContracts,
-  Experimental,
+  BlsProvider,
+  BlsSigner,
 };

--- a/contracts/clients/test/BlsProvider.test.ts
+++ b/contracts/clients/test/BlsProvider.test.ts
@@ -2,8 +2,8 @@ import { expect } from "chai";
 import { ethers } from "ethers";
 import { parseEther } from "ethers/lib/utils";
 
-import { Experimental } from "../src";
-import BlsSigner, { UncheckedBlsSigner } from "../src/BlsSigner";
+import { BlsProvider, BlsSigner } from "../src";
+import { UncheckedBlsSigner } from "../src/BlsSigner";
 
 let aggregatorUrl: string;
 let verificationGateway: string;
@@ -12,8 +12,8 @@ let rpcUrl: string;
 let network: ethers.providers.Networkish;
 
 let privateKey: string;
-let blsProvider: InstanceType<typeof Experimental.BlsProvider>;
-let blsSigner: InstanceType<typeof Experimental.BlsSigner>;
+let blsProvider: BlsProvider;
+let blsSigner: BlsSigner;
 
 let regularProvider: ethers.providers.JsonRpcProvider;
 
@@ -28,9 +28,9 @@ describe("BlsProvider", () => {
       chainId: 0x539, // 1337
     };
 
-    privateKey = await Experimental.BlsSigner.getRandomBlsPrivateKey();
+    privateKey = await BlsSigner.getRandomBlsPrivateKey();
 
-    blsProvider = new Experimental.BlsProvider(
+    blsProvider = new BlsProvider(
       aggregatorUrl,
       verificationGateway,
       aggregatorUtilities,
@@ -63,7 +63,7 @@ describe("BlsProvider", () => {
   it("should return a new signer", async () => {
     // Arrange
     const newVerificationGateway = "newMockVerificationGatewayAddress";
-    const newBlsProvider = new Experimental.BlsProvider(
+    const newBlsProvider = new BlsProvider(
       aggregatorUrl,
       newVerificationGateway,
       aggregatorUtilities,
@@ -72,7 +72,7 @@ describe("BlsProvider", () => {
     );
 
     // Act
-    const newPrivateKey = await Experimental.BlsSigner.getRandomBlsPrivateKey();
+    const newPrivateKey = await BlsSigner.getRandomBlsPrivateKey();
 
     const newBlsSigner = newBlsProvider.getSigner(newPrivateKey);
 
@@ -198,9 +198,8 @@ describe("BlsProvider", () => {
 
   it("should be a provider", async () => {
     // Arrange & Act
-    const isProvider = Experimental.BlsProvider.isProvider(blsProvider);
-    const isProviderWithInvalidProvider =
-      Experimental.BlsProvider.isProvider(blsSigner);
+    const isProvider = BlsProvider.isProvider(blsProvider);
+    const isProviderWithInvalidProvider = BlsProvider.isProvider(blsSigner);
 
     // Assert
     expect(isProvider).to.equal(true);

--- a/contracts/clients/test/BlsSigner.test.ts
+++ b/contracts/clients/test/BlsSigner.test.ts
@@ -1,7 +1,7 @@
 import { expect } from "chai";
 import { ethers } from "ethers";
 
-import { Experimental } from "../src";
+import { BlsProvider, BlsSigner } from "../src";
 import { UncheckedBlsSigner } from "../src/BlsSigner";
 
 let aggregatorUrl: string;
@@ -11,8 +11,8 @@ let rpcUrl: string;
 let network: ethers.providers.Networkish;
 
 let privateKey: string;
-let blsProvider: InstanceType<typeof Experimental.BlsProvider>;
-let blsSigner: InstanceType<typeof Experimental.BlsSigner>;
+let blsProvider: BlsProvider;
+let blsSigner: BlsSigner;
 
 describe("BlsSigner", () => {
   beforeEach(async () => {
@@ -25,9 +25,9 @@ describe("BlsSigner", () => {
       chainId: 0x7a69,
     };
 
-    privateKey = await Experimental.BlsSigner.getRandomBlsPrivateKey();
+    privateKey = await BlsSigner.getRandomBlsPrivateKey();
 
-    blsProvider = new Experimental.BlsProvider(
+    blsProvider = new BlsProvider(
       aggregatorUrl,
       verificationGateway,
       aggregatorUtilities,
@@ -74,13 +74,13 @@ describe("BlsSigner", () => {
 
     // Assert
     expect(provider._isProvider).to.be.true;
-    expect(provider).to.be.instanceOf(Experimental.BlsProvider);
+    expect(provider).to.be.instanceOf(BlsProvider);
   });
 
   it("should detect whether an object is a valid signer", async () => {
     // Arrange & Act
-    const validSigner = Experimental.BlsSigner.isSigner(blsSigner);
-    const invalidSigner = Experimental.BlsSigner.isSigner({});
+    const validSigner = BlsSigner.isSigner(blsSigner);
+    const invalidSigner = BlsSigner.isSigner({});
 
     // Assert
     expect(validSigner).to.be.true;

--- a/contracts/test-integration/BlsProvider.test.ts
+++ b/contracts/test-integration/BlsProvider.test.ts
@@ -6,7 +6,8 @@ import { formatEther, parseEther } from "ethers/lib/utils";
 import {
   BlsWalletWrapper,
   bundleToDto,
-  Experimental,
+  BlsProvider,
+  BlsSigner,
   MockERC20__factory,
   NetworkConfig,
 } from "../clients/src";
@@ -21,8 +22,8 @@ let rpcUrl: string;
 let network: ethers.providers.Networkish;
 
 let privateKey: string;
-let blsProvider: InstanceType<typeof Experimental.BlsProvider>;
-let blsSigner: InstanceType<typeof Experimental.BlsSigner>;
+let blsProvider: BlsProvider;
+let blsSigner: BlsSigner;
 
 let regularProvider: ethers.providers.JsonRpcProvider;
 
@@ -39,9 +40,9 @@ describe("BlsProvider", () => {
       chainId: 0x539, // 1337
     };
 
-    privateKey = await Experimental.BlsSigner.getRandomBlsPrivateKey();
+    privateKey = await BlsSigner.getRandomBlsPrivateKey();
 
-    blsProvider = new Experimental.BlsProvider(
+    blsProvider = new BlsProvider(
       aggregatorUrl,
       verificationGateway,
       aggregatorUtilities,

--- a/contracts/test-integration/BlsProviderContractInteraction.test.ts
+++ b/contracts/test-integration/BlsProviderContractInteraction.test.ts
@@ -2,7 +2,7 @@ import { expect } from "chai";
 import { ethers } from "hardhat";
 import { BigNumber, utils, Wallet } from "ethers";
 
-import { Experimental } from "../clients/src";
+import { BlsProvider, BlsSigner } from "../clients/src";
 import getNetworkConfig from "../shared/helpers/getNetworkConfig";
 
 describe("Provider tests", function () {
@@ -12,7 +12,7 @@ describe("Provider tests", function () {
 
   this.beforeAll(async () => {
     const networkConfig = await getNetworkConfig("local");
-    const privateKey = await Experimental.BlsSigner.getRandomBlsPrivateKey();
+    const privateKey = await BlsSigner.getRandomBlsPrivateKey();
     const aggregatorUrl = "http://localhost:3000";
     const verificationGateway = networkConfig.addresses.verificationGateway;
     const aggregatorUtilities = networkConfig.addresses.utilities;
@@ -21,7 +21,7 @@ describe("Provider tests", function () {
       name: "localhost",
       chainId: 0x539, // 1337
     };
-    blsProvider = new Experimental.BlsProvider(
+    blsProvider = new BlsProvider(
       aggregatorUrl,
       verificationGateway,
       aggregatorUtilities,

--- a/contracts/test-integration/BlsSigner.test.ts
+++ b/contracts/test-integration/BlsSigner.test.ts
@@ -10,7 +10,8 @@ import {
 import sinon from "sinon";
 
 import {
-  Experimental,
+  BlsProvider,
+  BlsSigner,
   ActionData,
   BlsWalletWrapper,
   NetworkConfig,
@@ -29,8 +30,8 @@ let rpcUrl: string;
 let network: ethers.providers.Networkish;
 
 let privateKey: string;
-let blsProvider: InstanceType<typeof Experimental.BlsProvider>;
-let blsSigner: InstanceType<typeof Experimental.BlsSigner>;
+let blsProvider: BlsProvider;
+let blsSigner: BlsSigner;
 
 let regularProvider: ethers.providers.JsonRpcProvider;
 let fundedWallet: ethers.Wallet;
@@ -48,9 +49,9 @@ describe("BlsSigner", () => {
       chainId: 0x539, // 1337
     };
 
-    privateKey = await Experimental.BlsSigner.getRandomBlsPrivateKey();
+    privateKey = await BlsSigner.getRandomBlsPrivateKey();
 
-    blsProvider = new Experimental.BlsProvider(
+    blsProvider = new BlsProvider(
       aggregatorUrl,
       verificationGateway,
       aggregatorUtilities,
@@ -424,7 +425,7 @@ describe("BlsSigner", () => {
 
   it("should throw an error when invalid private key is supplied", async () => {
     // Arrange
-    const newBlsProvider = new Experimental.BlsProvider(
+    const newBlsProvider = new BlsProvider(
       aggregatorUrl,
       verificationGateway,
       aggregatorUtilities,
@@ -799,7 +800,7 @@ describe("BlsSigner", () => {
 
   it("should await the init promise when connecting to an unchecked bls signer", async () => {
     // Arrange
-    const newPrivateKey = await Experimental.BlsSigner.getRandomBlsPrivateKey();
+    const newPrivateKey = await BlsSigner.getRandomBlsPrivateKey();
     const newBlsSigner = blsProvider.getSigner(newPrivateKey);
     const uncheckedBlsSigner = newBlsSigner.connectUnchecked();
 
@@ -827,14 +828,14 @@ describe("BlsSigner", () => {
 
   it("should get the transaction receipt when using a new provider and connecting to an unchecked bls signer", async () => {
     // Arrange & Act
-    const newBlsProvider = new Experimental.BlsProvider(
+    const newBlsProvider = new BlsProvider(
       aggregatorUrl,
       verificationGateway,
       aggregatorUtilities,
       rpcUrl,
       network,
     );
-    const newPrivateKey = await Experimental.BlsSigner.getRandomBlsPrivateKey();
+    const newPrivateKey = await BlsSigner.getRandomBlsPrivateKey();
     const newBlsSigner = newBlsProvider.getSigner(newPrivateKey);
     const uncheckedBlsSigner = newBlsSigner.connectUnchecked();
 
@@ -989,7 +990,7 @@ describe("BlsSigner", () => {
 
   it("should return the result of call using the transactionRequest, with the signer account address being used as the from field", async () => {
     // Arrange
-    const spy = chai.spy.on(Experimental.BlsProvider.prototype, "call");
+    const spy = chai.spy.on(BlsProvider.prototype, "call");
 
     // eslint-disable-next-line camelcase
     const testERC20 = MockERC20__factory.connect(
@@ -1017,7 +1018,7 @@ describe("BlsSigner", () => {
 
   it("should estimate gas without throwing an error, with the signer account address being used as the from field.", async () => {
     // Arrange
-    const spy = chai.spy.on(Experimental.BlsProvider.prototype, "estimateGas");
+    const spy = chai.spy.on(BlsProvider.prototype, "estimateGas");
     const recipient = ethers.Wallet.createRandom().address;
 
     // Act

--- a/contracts/test-integration/BlsSignerContractInteraction.test.ts
+++ b/contracts/test-integration/BlsSignerContractInteraction.test.ts
@@ -3,12 +3,10 @@ import { ethers } from "hardhat";
 import { BigNumber, utils, Wallet } from "ethers";
 import sinon from "sinon";
 
-import { Experimental, BlsWalletWrapper } from "../clients/src";
+import { BlsProvider, BlsSigner, BlsWalletWrapper } from "../clients/src";
 import getNetworkConfig from "../shared/helpers/getNetworkConfig";
 
-async function getRandomSigners(
-  numSigners: number,
-): Promise<typeof Experimental.BlsSigner[]> {
+async function getRandomSigners(numSigners: number): Promise<BlsSigner[]> {
   const networkConfig = await getNetworkConfig("local");
 
   const aggregatorUrl = "http://localhost:3000";
@@ -22,8 +20,8 @@ async function getRandomSigners(
 
   const signers = [];
   for (let i = 0; i < numSigners; i++) {
-    const privateKey = await Experimental.BlsSigner.getRandomBlsPrivateKey();
-    const blsProvider = new Experimental.BlsProvider(
+    const privateKey = await BlsSigner.getRandomBlsPrivateKey();
+    const blsProvider = new BlsProvider(
       aggregatorUrl,
       verificationGateway,
       aggregatorUtilities,

--- a/docs/use_bls_provider.md
+++ b/docs/use_bls_provider.md
@@ -15,7 +15,7 @@ The `BlsProvider` and `BlsSigner` are covered by over 100 test cases, including 
 ### Instantiating a BlsProvider
 
 ```ts
-import { Experimental } from "bls-wallet-clients";
+import { BlsProvider } from "bls-wallet-clients";
 
 const aggregatorUrl = "http://localhost:3000";
 const verificationGateway = "0x123";
@@ -26,7 +26,7 @@ const network = {
     chainId: 0x539, // 1337
 };
 
-const provider = new Experimental.BlsProvider(
+const provider = new BlsProvider(
     aggregatorUrl,
     verificationGateway,
     aggregatorUtilities,
@@ -40,9 +40,9 @@ const provider = new Experimental.BlsProvider(
 **Important:** Ensure that the BLS wallet you are linking the `BlsSigner` to via the private key is funded. Alternatively, if a wallet doesn't yet exist, it will be lazily created on the first transaction. In this scenario, you can create a random BLS private key with the following helper method and fund that account. It will need to be funded in order to send its first transaction.
 
 ```ts
-import { Experimental } from "bls-wallet-clients";
+import { BlsSigner } from "bls-wallet-clients";
 
-const privateKey = await Experimental.BlsSigner.getRandomBlsPrivateKey();
+const privateKey = await BlsSigner.getRandomBlsPrivateKey();
 
 const signer = provider.getSigner(privateKey);
 

--- a/extension/package.json
+++ b/extension/package.json
@@ -36,7 +36,7 @@
     "advanced-css-reset": "^1.2.2",
     "async-mutex": "^0.3.2",
     "axios": "^0.27.2",
-    "bls-wallet-clients": "0.8.2-1452ef5",
+    "bls-wallet-clients": "0.8.2-de12b3c",
     "browser-passworder": "^2.0.3",
     "bs58check": "^2.1.2",
     "crypto-browserify": "^3.12.0",

--- a/extension/package.json
+++ b/extension/package.json
@@ -36,7 +36,7 @@
     "advanced-css-reset": "^1.2.2",
     "async-mutex": "^0.3.2",
     "axios": "^0.27.2",
-    "bls-wallet-clients": "0.8.2-de12b3c",
+    "bls-wallet-clients": "0.8.3",
     "browser-passworder": "^2.0.3",
     "bs58check": "^2.1.2",
     "crypto-browserify": "^3.12.0",

--- a/extension/yarn.lock
+++ b/extension/yarn.lock
@@ -2907,10 +2907,10 @@ blakejs@^1.1.0:
   resolved "https://registry.yarnpkg.com/blakejs/-/blakejs-1.2.1.tgz#5057e4206eadb4a97f7c0b6e197a505042fc3814"
   integrity sha512-QXUSXI3QVc/gJME0dBpXrag1kbzOqCjCX8/b54ntNyW6sjtoqxqRk3LTmXzaJoh71zMsDCjM+47jS7XiwN/+fQ==
 
-bls-wallet-clients@0.8.2-1452ef5:
-  version "0.8.2-1452ef5"
-  resolved "https://registry.yarnpkg.com/bls-wallet-clients/-/bls-wallet-clients-0.8.2-1452ef5.tgz#d76e938ca45ec5da44c8e59699d1bd5f6c69dcd2"
-  integrity sha512-bg7WLr9NRbvDzj+zgkLNfaPzr1m0m13Cc8RJoZ2s6s+ic7WxSiwxTkZGc2SChFgmG8ZGi1O9DnR6//lrTsMVUA==
+bls-wallet-clients@0.8.2-de12b3c:
+  version "0.8.2-de12b3c"
+  resolved "https://registry.yarnpkg.com/bls-wallet-clients/-/bls-wallet-clients-0.8.2-de12b3c.tgz#819ac2d80533c728900616f35918353dd07eb2c2"
+  integrity sha512-quoDibpDL3Injw4b4/2FjhMhH/Rq9hjO4n7sVMMa5jRe5Ttd1gCzCvGMkvNpL856k7zDxV20PNPxJf7GQgziCw==
   dependencies:
     "@thehubbleproject/bls" "^0.5.1"
     ethers "^5.7.2"

--- a/extension/yarn.lock
+++ b/extension/yarn.lock
@@ -2907,10 +2907,10 @@ blakejs@^1.1.0:
   resolved "https://registry.yarnpkg.com/blakejs/-/blakejs-1.2.1.tgz#5057e4206eadb4a97f7c0b6e197a505042fc3814"
   integrity sha512-QXUSXI3QVc/gJME0dBpXrag1kbzOqCjCX8/b54ntNyW6sjtoqxqRk3LTmXzaJoh71zMsDCjM+47jS7XiwN/+fQ==
 
-bls-wallet-clients@0.8.2-de12b3c:
-  version "0.8.2-de12b3c"
-  resolved "https://registry.yarnpkg.com/bls-wallet-clients/-/bls-wallet-clients-0.8.2-de12b3c.tgz#819ac2d80533c728900616f35918353dd07eb2c2"
-  integrity sha512-quoDibpDL3Injw4b4/2FjhMhH/Rq9hjO4n7sVMMa5jRe5Ttd1gCzCvGMkvNpL856k7zDxV20PNPxJf7GQgziCw==
+bls-wallet-clients@0.8.3:
+  version "0.8.3"
+  resolved "https://registry.yarnpkg.com/bls-wallet-clients/-/bls-wallet-clients-0.8.3.tgz#7d3ee34ad3508ee730f3c4766980301bc3625d61"
+  integrity sha512-U5CQ7dZXIDmThu7spZyEhAgXyZ1FkamQk5jjV024L3egPr5zhenaeghdRqnjgp5YJ0PuxeFbe0c3SC5s42z7tQ==
   dependencies:
     "@thehubbleproject/bls" "^0.5.1"
     ethers "^5.7.2"


### PR DESCRIPTION
## What is this PR doing?
- Removes BlsProvider & BlsSigner from Experimental namespace
- Publishes new client module release - v0.8.3

I've manually tested the new release against testnet and a local aggregator. I did this by adding the provider to the browser wallet and sending a tx to and from the wallet.

## How can these changes be manually tested?
- test provider on testnet with browser wallet (I've already done this)

## Does this PR resolve or contribute to any issues?
Resolves #567 

## Checklist
- [x] I have manually tested these changes
- [x] Post a link to the PR in the group chat

## Guidelines
- If your PR is not ready, mark it as a draft
- The `resolve conversation` button is for reviewers, not authors
  - (But add a 'done' comment or similar)
