### PR TITLE
Add wait for contract deploy script to agg workflow

### DIFF
--- a/.github/workflows/aggregator.yml
+++ b/.github/workflows/aggregator.yml
@@ -73,6 +73,8 @@ jobs:
       run: yarn start &
     - working-directory: ./contracts
       run: ./scripts/wait-for-rpc.sh
+    - working-directory: ./contracts
+      run: ./scripts/wait-for-contract-deploy.sh
 
     - run: cp .env.local.example .env
     - run: deno test --allow-net --allow-env --allow-read

--- a/aggregator/src/app/app.ts
+++ b/aggregator/src/app/app.ts
@@ -16,6 +16,8 @@ import BundleTable from "./BundleTable.ts";
 import AggregationStrategy from "./AggregationStrategy.ts";
 import AggregationStrategyRouter from "./AggregationStrategyRouter.ts";
 
+// Temporary comment to test CI
+
 export default async function app(emit: (evt: AppEvent) => void) {
   const { addresses } = await getNetworkConfig();
 

--- a/aggregator/src/app/app.ts
+++ b/aggregator/src/app/app.ts
@@ -16,8 +16,6 @@ import BundleTable from "./BundleTable.ts";
 import AggregationStrategy from "./AggregationStrategy.ts";
 import AggregationStrategyRouter from "./AggregationStrategyRouter.ts";
 
-// Temporary comment to test CI
-
 export default async function app(emit: (evt: AppEvent) => void) {
   const { addresses } = await getNetworkConfig();
 


### PR DESCRIPTION
## What is this PR doing?
Testing and adding a fix for the periodic aggregator tests failure. See example of [failing run](https://github.com/web3well/bls-wallet/actions/runs/4553205530/jobs/8029491358). This is likely due to a race condition where the tests are running before the contracts are deployed/local.json is generated.

Error: `error: NotFound: No such file or directory (os error 2): readfile '../contracts/networks/local.json'`

### Changes made
- Added the `wait-for-contract-deploy.sh` to the aggregator workflow file. This ensures the workflow waits for the contract deploy before running the tests

Blake was able ssh into the container running the tests and validated that `'../contracts/networks/local.json'` was getting generated, which validated the idea that this was a race condition.

## How can these changes be manually tested?
Compare: 
1. Aggregator test [workflow runs](https://github.com/web3well/bls-wallet/actions/runs/4562877937) on this branch
2. Aggregator test [workflow runs](https://github.com/web3well/bls-wallet/actions/runs/4563533937) on [control branch](https://github.com/web3well/bls-wallet/pull/573)

Notice that the aggregator tests haven't failed once on this branch (run 1 failed because of a typescript issue and run 3 failed because of temporary deno issue, so those failures can be ignored).

Whereas the control branch has only been run 4 times and the tests have failed twice (attempt 1 & 3).

## Does this PR resolve or contribute to any issues?

## Checklist
- [x] I have manually tested these changes
- [x] Post a link to the PR in the group chat

## Guidelines
- If your PR is not ready, mark it as a draft
- The `resolve conversation` button is for reviewers, not authors
  - (But add a 'done' comment or similar)
