### PR TITLE
Fix page move when border is increased

### DIFF
--- a/extension/source/Home/Onboarding/ReviewSecretPhrasePanel.tsx
+++ b/extension/source/Home/Onboarding/ReviewSecretPhrasePanel.tsx
@@ -26,7 +26,7 @@ const WordInReview: FunctionComponent<{
 
     if (guess === word) {
       return [
-        'border-2',
+        'padding-border-2',
         'border-positive-500',
         'bg-positive-500',
         'focus:border-positive-500',
@@ -35,7 +35,7 @@ const WordInReview: FunctionComponent<{
 
     if (word.startsWith(guess)) {
       return [
-        'border-2',
+        'padding-border-2',
         'border-neutral-500',
         'bg-neutral-500',
         'focus:border-neutral-500',
@@ -43,7 +43,7 @@ const WordInReview: FunctionComponent<{
     }
 
     return [
-      'border-2',
+      'padding-border-2',
       'border-alert-500',
       'bg-alert-500',
       'focus:border-alert-500',

--- a/extension/source/styles/_quill.scss
+++ b/extension/source/styles/_quill.scss
@@ -290,4 +290,10 @@
       vertical-align: top;
     }
   }
+
+  .padding-border-2 {
+    --variable-border-width: 0.125rem;
+    padding: calc(0.5rem - var(--variable-border-width)/2) calc(0.7rem - var(--variable-border-width)/2);
+    border-width: var(--variable-border-width);
+  }
 }


### PR DESCRIPTION
## What is this PR doing?

When we start typing the border of textfield get increased which causes whole page move up and down. So We need to keep the padding of text field same as before will be a solution to this problem. We can decrease the padding of textfiled by let say 1px if we increase the padding by 2px etc.

The issue is we are using padding in rem unit but when we increase the border width we are using pixels. So its hard to get exact amount of padding we need to decrease at the time we increase the border.

I have used below method which is dynamically calculated the padding of textfield.

```
.padding-border-2 {
    --variable-border-width: 0.125rem;
    padding: calc(0.5rem - var(--variable-border-width)/2) calc(0.7rem - var(--variable-border-width)/2);
    border-width: var(--variable-border-width);
  }
```

So i have removed the class border-2 which increased our border to 2px. We can use the rem unit and convert the same 2px to 0.125 rem to stay consistent as before. Though we can use 2px as well then we have to use padding in pixels or mixture of pixels and rems. 

When we start type we will decrease the current text field padding by border-width/2. Because when page is rendered we already have 1px border so padding already adjusted for 1px of border. Now if we increase 1 more pixel we have to adjust the padding with respect to rest 1 pixel only means border-width(2px)/2.


## How can these changes be manually tested?
Yes i have tested them manually on 3 browsers, chrome, firefox and opera because these 3 are mentioned for packaging the extensions.

 Chrome Testing:
[Chrome-Padding-Issue.webm](https://user-images.githubusercontent.com/61174028/231143273-625e2f2c-2a05-4f63-bfc3-c8d37abaa33e.webm)

Firefox Testing:
[Firefox-Padding-Issue.webm](https://user-images.githubusercontent.com/61174028/231143347-b30ec210-7c5b-4c1f-8455-24bb5773acb7.webm)

Opera testing:
[Opera-Padding-Issue.webm](https://user-images.githubusercontent.com/61174028/231143541-bb6e62f1-bae0-4037-8c6f-f5c6fd9669c2.webm)


## Does this PR resolve or contribute to any issues?
 Yes It resolves https://github.com/web3well/bls-wallet/issues/213

## Checklist
- [x] I have manually tested these changes
- [ ] Post a link to the PR in the group chat

## Guidelines
- If your PR is not ready, mark it as a draft
- The `resolve conversation` button is for reviewers, not authors
  - (But add a 'done' comment or similar)
