### PR TITLE
551 run quill against geth node and pay aggregator fees

### DIFF
--- a/contracts/README.md
+++ b/contracts/README.md
@@ -116,7 +116,7 @@ For each network, the deployer contract can be deployed with the following scrip
 
 To run integration tests:
 
-1. cd into `./contracts` and run `yarn start-hardhat`
+1. cd into `./contracts` and run `yarn start`
 2. cd into `./aggregator` and run `./programs/aggregator.ts`
 3. from `./contracts`, run `yarn test-integration`.
 

--- a/contracts/clients/test/BlsSigner.test.ts
+++ b/contracts/clients/test/BlsSigner.test.ts
@@ -22,7 +22,7 @@ describe("BlsSigner", () => {
     rpcUrl = "http://localhost:8545";
     network = {
       name: "localhost",
-      chainId: 0x7a69,
+      chainId: 0x539,
     };
 
     privateKey = await BlsSigner.getRandomBlsPrivateKey();

--- a/contracts/hardhat.config.ts
+++ b/contracts/hardhat.config.ts
@@ -131,6 +131,7 @@ const config: HardhatUserConfig = {
   },
   networks: {
     hardhat: {
+      chainId: 1337,
       initialBaseFeePerGas: 0, // workaround from https://github.com/sc-forks/solidity-coverage/issues/652#issuecomment-896330136 . Remove when that issue is closed.
       accounts,
       blockGasLimit: 30_000_000,

--- a/docs/local_development.md
+++ b/docs/local_development.md
@@ -109,6 +109,7 @@ yarn run dev:chrome # or dev:firefox, dev:opera
 - In general, the bundle or submission issues we've encountered have been us misconfiguring the data in the bundle or not configuring the aggregator properly.
 - Be careful using Hardhat accounts 0 and 1 in your code when running a local aggregator. This is because the local aggregator config uses the same key pairs as Hardhat accounts 0 and 1 by default. You can get around this by not using accounts 0 and 1 elsewhere, or changing the default accounts that the aggregator uses locally.
 - When packages are updated in the aggregator, you'll need to reload the deno cache as the setup script won't do this for you. You can do this with `deno cache -r deps.ts` in the `./aggregator` directory.
+- If running Quill against a local hardhat node with (`yarn start-hardhat`) instead of the local geth node (`yarn start`), you'll need to update the local network in `./extension/config.json` to use chainId `31337`. This is because the geth node uses a chainId of `1337` instead. If you're using MetaMask to fund Quill, make sure the localhost network uses chainId `31337` too.
 
 ### Tests
 

--- a/docs/local_development.md
+++ b/docs/local_development.md
@@ -109,7 +109,8 @@ yarn run dev:chrome # or dev:firefox, dev:opera
 - In general, the bundle or submission issues we've encountered have been us misconfiguring the data in the bundle or not configuring the aggregator properly.
 - Be careful using Hardhat accounts 0 and 1 in your code when running a local aggregator. This is because the local aggregator config uses the same key pairs as Hardhat accounts 0 and 1 by default. You can get around this by not using accounts 0 and 1 elsewhere, or changing the default accounts that the aggregator uses locally.
 - When packages are updated in the aggregator, you'll need to reload the deno cache as the setup script won't do this for you. You can do this with `deno cache -r deps.ts` in the `./aggregator` directory.
-- If running Quill against a local hardhat node with (`yarn start-hardhat`) instead of the local geth node (`yarn start`), you'll need to update the local network in `./extension/config.json` to use chainId `31337`. This is because the geth node uses a chainId of `1337` instead. If you're using MetaMask to fund Quill, make sure the localhost network uses chainId `31337` too.
+- If running Quill against a local node, and if you're using MetaMask to fund Quill, make sure the MetaMask 
+localhost network  uses chainId `1337`.
 
 ### Tests
 

--- a/docs/local_development.md
+++ b/docs/local_development.md
@@ -100,6 +100,7 @@ yarn run dev:chrome # or dev:firefox, dev:opera
 
 - pull latest from `main` and run the setup script from the root directory `./setup.ts`.
 - Restart the node and redeploy contracts
+- Delete `aggregator.sqlite` in `./aggregator`. This is the local DB which will get regenerated when the aggregator is started.
 - Restart the aggregator and add the "-r" flag to the command e.g `./programs/aggregator.ts -r`.
 - Reset the Quill extension in your browser if you're developing with Quill. You can do this by removing the extension and then re-adding via "Load unpacked" again. Or run `debug.reset();` twice in the background page console.
 
@@ -107,6 +108,7 @@ yarn run dev:chrome # or dev:firefox, dev:opera
 
 - In general, the bundle or submission issues we've encountered have been us misconfiguring the data in the bundle or not configuring the aggregator properly.
 - Be careful using Hardhat accounts 0 and 1 in your code when running a local aggregator. This is because the local aggregator config uses the same key pairs as Hardhat accounts 0 and 1 by default. You can get around this by not using accounts 0 and 1 elsewhere, or changing the default accounts that the aggregator uses locally.
+- When packages are updated in the aggregator, you'll need to reload the deno cache as the setup script won't do this for you. You can do this with `deno cache -r deps.ts` in the `./aggregator` directory.
 
 ### Tests
 

--- a/extension/README.md
+++ b/extension/README.md
@@ -25,7 +25,7 @@ To run the dev server:
 yarn run dev:chrome # or dev:firefox etc, see scripts in package.json
 ```
 
-Reset the extension. This is useful for getting the wallet to clean slate in development. You can acheive this in your browser by either:
+Reset the extension. This is useful for getting the wallet to a clean slate in development. You can achieve this in your browser by either:
 
 - Removing the extension and then re-adding via "Load unpacked".
 - Or run `debug.reset();` twice in the background page console.

--- a/extension/README.md
+++ b/extension/README.md
@@ -17,6 +17,19 @@ Interaction with web3 applications can be slow, costly, and risky.
 3. transfer L2 erc20 tokens
 4. use contract wallet with L2 dapps (coming soon)
 
+## Getting started
+
+To run the dev server:
+
+```sh
+yarn run dev:chrome # or dev:firefox etc, see scripts in package.json
+```
+
+Reset the extension. This is useful for getting the wallet to clean slate in development. You can acheive this in your browser by either:
+
+- Removing the extension and then re-adding via "Load unpacked".
+- Or run `debug.reset();` twice in the background page console.
+
 ## Feature Summary
 
 ### MVP (uses Optimism)
@@ -89,10 +102,3 @@ Interaction with web3 applications can be slow, costly, and risky.
     - method name - nonce - (send)
   - (aggregate) - (send all)
 
-## Development
-
-To run the dev server:
-
-```sh
-yarn run dev:chrome # or dev:firefox etc, see scripts in package.json
-```

--- a/extension/config.example.json
+++ b/extension/config.example.json
@@ -15,7 +15,7 @@
     },
     "local": {
       "blockExplorerUrl": "N/A",
-      "chainId": "0x7a69",
+      "chainId": "0x539",
       "displayName": "Local Network",
       "logo": "",
       "rpcTarget": "http://127.0.0.1:8545",

--- a/extension/config.release.json
+++ b/extension/config.release.json
@@ -15,7 +15,7 @@
     },
     "local": {
       "blockExplorerUrl": "N/A",
-      "chainId": "0x7a69",
+      "chainId": "0x539",
       "displayName": "Local Network",
       "logo": "",
       "rpcTarget": "http://127.0.0.1:8545",

--- a/extension/source/background/AggregatorController.ts
+++ b/extension/source/background/AggregatorController.ts
@@ -1,7 +1,11 @@
-import { Aggregator, BlsWalletWrapper, ActionData } from 'bls-wallet-clients';
+import {
+  Aggregator,
+  BlsWalletWrapper,
+  AggregatorUtilities__factory as AggregatorUtilitiesFactory,
+  ActionData,
+} from 'bls-wallet-clients';
 import { BigNumber, ethers } from 'ethers';
 
-import { AggregatorUtilities__factory as AggregatorUtilitiesFactory } from 'bls-wallet-clients/dist/typechain-types';
 import assert from '../helpers/assert';
 import ensureType from '../helpers/ensureType';
 import { PartialRpcImpl, RpcClient, SendTransactionParams } from '../types/Rpc';


### PR DESCRIPTION
## What is this PR doing?
1. Changes the chainId of local Quill network config to `0x539` (1337), from `0x7a69` (31337).
2. Adds logic so that Quill pays the aggregator fees

## How can these changes be manually tested?
- Send a transaction locally with Quill, using `yarn start`, instead of `yarn start-hardhat`
- You may need to change you MetaMask localhost chainId to 1337.

## Does this PR resolve or contribute to any issues?
resolves #551 

## Checklist
- [x] I have manually tested these changes
- [x] Post a link to the PR in the group chat

## Guidelines
- If your PR is not ready, mark it as a draft
- The `resolve conversation` button is for reviewers, not authors
  - (But add a 'done' comment or similar)
