### PR TITLE
Configure cors for geth dev

### DIFF
--- a/contracts/scripts/start.sh
+++ b/contracts/scripts/start.sh
@@ -19,6 +19,7 @@ docker run --name $CONTAINER --rm -p8545:8545 ethereum/client-go:stable \
   --http.api eth,web3,personal,net \
   --http.addr=0.0.0.0 \
   --http.vhosts='*' \
+  --http.corsdomain='*' \
   --dev \
   --dev.period=0 \
   &


### PR DESCRIPTION
## What is this PR doing?

Today my brave decided to get upset about cors headers on the geth node.

I'm not sure why cors headers weren't required previously? Perhaps localhost is usually given an exemption but mid-way through my testing today brave decided to get strict about it.

Or maybe something changed in geth. Seems unlikely though since they've had this setting for enabling cors for a long time and it wasn't turned on.

Anyway, this adds the option so that geth dev will just allow cors, as it obviously should.

## How can these changes be manually tested?

```
yarn start
```

```
curl -v -X OPTIONS -H 'Origin: example.com' http://localhost:8545
```

check that the response has this line:

```
...
< Access-Control-Allow-Origin: *
...
```

## Does this PR resolve or contribute to any issues?

Nurp.

## Checklist
- [x] I have manually tested these changes
- [x] Post a link to the PR in the group chat

## Guidelines
- If your PR is not ready, mark it as a draft
- The `resolve conversation` button is for reviewers, not authors
  - (But add a 'done' comment or similar)
