### PR TITLE
fix: assing TransactionReceipt to getOperationResults always results in no WalletOperationProcessed events found in transaction error

### DIFF
--- a/contracts/clients/src/OperationResults.ts
+++ b/contracts/clients/src/OperationResults.ts
@@ -117,6 +117,12 @@ const getError = (
 export const getOperationResults = (
   txnReceipt: ContractReceipt,
 ): OperationResult[] => {
+  if (!txnReceipt.events?.length) {
+    throw new Error(
+      `no events found in transaction ${txnReceipt.transactionHash}, are you sure it is a ContractReceipt from a VerificationGateway.processBundle transaction?`,
+    );
+  }
+
   const walletOpProcessedEvents = txnReceipt.events?.filter(
     (e) => e.event === "WalletOperationProcessed",
   );

--- a/contracts/clients/test/OperationResults.test.ts
+++ b/contracts/clients/test/OperationResults.test.ts
@@ -118,7 +118,7 @@ describe("OperationResults", () => {
       } as ContractReceipt;
 
       expect(() => getOperationResults(txnReceipt)).to.throw(
-        `no WalletOperationProcessed events found in transaction ${txnReceipt.transactionHash}`,
+        `no events found in transaction ${txnReceipt.transactionHash}, are you sure it is a ContractReceipt from a VerificationGateway.processBundle transaction?`,
       );
     });
 


### PR DESCRIPTION

## What is this PR doing?
This PR adds an additional check on the truthiness of txnReceipt.events in getOperationResults function and throws an error with a message such as "no events found in transaction [TXN_HASH], are you sure it is a ContractReceipt from a VerificationGateway.processBundle transaction?", when there are no events found.

## How can these changes be manually tested?
You can test these changes by running the existing test suite, which will include the new test case for this change.

## Does this PR resolve or contribute to any issues?
This PR resolves the issue #563 

## Checklist
- [x] I have manually tested these changes
- [ ] Post a link to the PR in the group chat

## Guidelines
- If your PR is not ready, mark it as a draft
- The `resolve conversation` button is for reviewers, not authors
  - (But add a 'done' comment or similar)
