### PR TITLE
Use compression in aggregator

### DIFF
--- a/aggregator/deps.ts
+++ b/aggregator/deps.ts
@@ -54,21 +54,26 @@ export type {
   PublicKey,
   Signature,
   VerificationGateway,
-} from "https://esm.sh/bls-wallet-clients@0.8.3-c34db60";
+} from "https://esm.sh/bls-wallet-clients@0.8.3-bee2034";
 
 export {
   Aggregator as AggregatorClient,
   AggregatorUtilitiesFactory,
+  BlsRegistrationCompressor,
   BlsWalletWrapper,
+  BundleCompressor,
+  ContractsConnector,
   decodeError,
+  Erc20Compressor,
   ERC20Factory,
+  FallbackCompressor,
   getConfig,
   MockERC20Factory,
   VerificationGatewayFactory,
-} from "https://esm.sh/bls-wallet-clients@0.8.3-c34db60";
+} from "https://esm.sh/bls-wallet-clients@0.8.3-bee2034";
 
 // Workaround for esbuild's export-star bug
-import blsWalletClients from "https://esm.sh/bls-wallet-clients@0.8.3-c34db60";
+import blsWalletClients from "https://esm.sh/bls-wallet-clients@0.8.3-bee2034";
 const { bundleFromDto, bundleToDto, initBlsWalletSigner } = blsWalletClients;
 export { bundleFromDto, bundleToDto, initBlsWalletSigner };
 

--- a/aggregator/manualTests/helpers/receiptOf.ts
+++ b/aggregator/manualTests/helpers/receiptOf.ts
@@ -1,0 +1,10 @@
+import { ethers } from "../../deps.ts";
+
+export default async function receiptOf(
+  responsePromise: Promise<ethers.providers.TransactionResponse>,
+): Promise<ethers.providers.TransactionReceipt> {
+  const response = await responsePromise;
+  const receipt = await response.wait();
+
+  return receipt;
+}

--- a/aggregator/manualTests/mint1ViaEthereumService.ts
+++ b/aggregator/manualTests/mint1ViaEthereumService.ts
@@ -14,8 +14,6 @@ const ethereumService = await EthereumService.create(
   (evt) => {
     console.log(evt);
   },
-  addresses.verificationGateway,
-  addresses.utilities,
   env.PRIVATE_KEY_AGG,
 );
 

--- a/aggregator/manualTests/registerWallet.ts
+++ b/aggregator/manualTests/registerWallet.ts
@@ -1,0 +1,34 @@
+#!/usr/bin/env -S deno run --allow-net --allow-env --allow-read
+
+import { ContractsConnector, ethers } from "../deps.ts";
+import * as env from "../src/env.ts";
+import AdminWallet from "../src/chain/AdminWallet.ts";
+import receiptOf from "./helpers/receiptOf.ts";
+
+const provider = new ethers.providers.JsonRpcProvider(env.RPC_URL);
+
+const adminWallet = AdminWallet(provider);
+
+const connector = await ContractsConnector.create(adminWallet);
+
+const addressRegistry = await connector.AddressRegistry();
+const blsPublicKeyRegistry = await connector.BLSPublicKeyRegistry();
+
+await receiptOf(
+  addressRegistry.register("0xCB1ca1e8DF1055636d7D07c3099c9de3c65CAAB4"),
+);
+
+await receiptOf(
+  blsPublicKeyRegistry.register(
+    // You can get this in Quill by running this in the console of the wallet
+    // page (the page you get by clicking on the extension icon)
+    // JSON.stringify(debug.wallets[0].blsWalletSigner.getPublicKey())
+
+    [
+      "0x0ad7e63a4bbfdad440beda1fe7fdfb77a59f2a6d991700c6cf4c3654a52389a9",
+      "0x0adaa93bdfda0f6b259a80c1af7ccf3451c35c1e175483927a8052bdbf59f801",
+      "0x1f56aa1bb1419c741f0a474e51f33da0ffc81ea870e2e2c440db72539a9efb9e",
+      "0x2f1f7e5d586d6ca5de3c8c198c3be3b998a2b6df7ee8a367a1e58f8b36fd524d",
+    ],
+  ),
+);

--- a/aggregator/manualTests/zeroAddressError.ts
+++ b/aggregator/manualTests/zeroAddressError.ts
@@ -15,8 +15,6 @@ const provider = new ethers.providers.JsonRpcProvider(env.RPC_URL);
 //   (evt) => {
 //     console.log(evt);
 //   },
-//   addresses.verificationGateway,
-//   addresses.utilities,
 //   env.PRIVATE_KEY_AGG,
 // );
 

--- a/aggregator/src/app/AggregationStrategy.ts
+++ b/aggregator/src/app/AggregationStrategy.ts
@@ -459,7 +459,9 @@ export default class AggregationStrategy {
       .callStaticSequenceWithMeasure(
         feeToken
           ? es.Call(feeToken, "balanceOf", [es.wallet.address])
-          : es.Call(es.utilities, "ethBalanceOf", [es.wallet.address]),
+          : es.Call(es.aggregatorUtilities, "ethBalanceOf", [
+            es.wallet.address,
+          ]),
         bundles.map((bundle) =>
           es.Call(
             es.verificationGateway,

--- a/aggregator/src/app/AppEvent.ts
+++ b/aggregator/src/app/AppEvent.ts
@@ -15,6 +15,7 @@ type AppEvent =
     data: {
       includedRows: number;
       bundleOverheadCost: string;
+      bundleOverheadLen: number;
       expectedFee: string;
       expectedMaxCost: string;
     };
@@ -44,7 +45,12 @@ type AppEvent =
   | { type: "unprofitable-despite-breakeven-operations" }
   | {
     type: "submission-attempt";
-    data: { publicKeyShorts: string[]; attemptNumber: number };
+    data: {
+      publicKeyShorts: string[];
+      attemptNumber: number;
+      txLen: number;
+      compressedTxLen: number;
+    };
   }
   | {
     type: "submission-attempt-failed";
@@ -96,6 +102,5 @@ type AppEvent =
       duration: number;
     };
   };
-
 
 export default AppEvent;

--- a/aggregator/src/app/BundleService.ts
+++ b/aggregator/src/app/BundleService.ts
@@ -257,6 +257,7 @@ export default class BundleService {
         aggregateBundle,
         includedRows,
         bundleOverheadCost,
+        bundleOverheadLen,
         expectedFee,
         expectedMaxCost,
         failedRows,
@@ -268,6 +269,7 @@ export default class BundleService {
         data: {
           includedRows: includedRows.length,
           bundleOverheadCost: ethers.utils.formatEther(bundleOverheadCost),
+          bundleOverheadLen,
           expectedFee: ethers.utils.formatEther(expectedFee),
           expectedMaxCost: ethers.utils.formatEther(expectedMaxCost),
         },

--- a/aggregator/src/app/app.ts
+++ b/aggregator/src/app/app.ts
@@ -10,7 +10,6 @@ import errorHandler from "./errorHandler.ts";
 import notFoundHandler from "./notFoundHandler.ts";
 import Mutex from "../helpers/Mutex.ts";
 import Clock from "../helpers/Clock.ts";
-import getNetworkConfig from "../helpers/getNetworkConfig.ts";
 import AppEvent from "./AppEvent.ts";
 import BundleTable from "./BundleTable.ts";
 import AggregationStrategy from "./AggregationStrategy.ts";
@@ -19,8 +18,6 @@ import HealthService from "./HealthService.ts";
 import HealthRouter from "./HealthRouter.ts";
 
 export default async function app(emit: (evt: AppEvent) => void) {
-  const { addresses } = await getNetworkConfig();
-
   const clock = Clock.create();
 
   const bundleTableMutex = new Mutex();

--- a/aggregator/src/app/app.ts
+++ b/aggregator/src/app/app.ts
@@ -39,8 +39,6 @@ export default async function app(emit: (evt: AppEvent) => void) {
 
   const ethereumService = await EthereumService.create(
     emit,
-    addresses.verificationGateway,
-    addresses.utilities,
     env.PRIVATE_KEY_AGG,
   );
 

--- a/aggregator/test/BundleServiceFees.test.ts
+++ b/aggregator/test/BundleServiceFees.test.ts
@@ -48,13 +48,13 @@ function approveAndSendTokensToOrigin(
         contractAddress: fx.testErc20.address,
         encodedFunction: fx.testErc20.interface.encodeFunctionData(
           "approve",
-          [es.utilities.address, amount],
+          [es.aggregatorUtilities.address, amount],
         ),
       },
       {
         ethValue: 0,
-        contractAddress: es.utilities.address,
-        encodedFunction: es.utilities.interface.encodeFunctionData(
+        contractAddress: es.aggregatorUtilities.address,
+        encodedFunction: es.aggregatorUtilities.interface.encodeFunctionData(
           "sendTokenToTxOrigin",
           [fx.testErc20.address, amount],
         ),
@@ -164,8 +164,8 @@ Fixture.test("submits bundle with sufficient eth fee", async (fx) => {
       actions: [
         {
           ethValue: 1,
-          contractAddress: es.utilities.address,
-          encodedFunction: es.utilities.interface.encodeFunctionData(
+          contractAddress: es.aggregatorUtilities.address,
+          encodedFunction: es.aggregatorUtilities.interface.encodeFunctionData(
             "sendEthToTxOrigin",
           ),
         },
@@ -189,8 +189,8 @@ Fixture.test("submits bundle with sufficient eth fee", async (fx) => {
     actions: [
       {
         ethValue: fee,
-        contractAddress: es.utilities.address,
-        encodedFunction: es.utilities.interface.encodeFunctionData(
+        contractAddress: es.aggregatorUtilities.address,
+        encodedFunction: es.aggregatorUtilities.interface.encodeFunctionData(
           "sendEthToTxOrigin",
         ),
       },

--- a/aggregator/test/EthereumService.test.ts
+++ b/aggregator/test/EthereumService.test.ts
@@ -260,9 +260,9 @@ Fixture.test("callStaticSequence - correctly measures transfer", async (fx) => {
   const es = fx.ethereumService;
 
   const results = await es.callStaticSequence(
-    es.Call(es.utilities, "ethBalanceOf", [recvWallet.address]),
+    es.Call(es.aggregatorUtilities, "ethBalanceOf", [recvWallet.address]),
     es.Call(es.verificationGateway, "processBundle", [bundle]),
-    es.Call(es.utilities, "ethBalanceOf", [recvWallet.address]),
+    es.Call(es.aggregatorUtilities, "ethBalanceOf", [recvWallet.address]),
   );
 
   const [balanceResultBefore, , balanceResultAfter] = results;

--- a/aggregator/test/helpers/Fixture.ts
+++ b/aggregator/test/helpers/Fixture.ts
@@ -79,8 +79,6 @@ export default class Fixture {
 
     const ethereumService = await EthereumService.create(
       emit,
-      netCfg.addresses.verificationGateway,
-      netCfg.addresses.utilities,
       env.PRIVATE_KEY_AGG,
     );
 
@@ -296,10 +294,10 @@ export default class Fixture {
 
     return wallets;
   }
-  
+
   createHealthCheckService() {
     const healthCheckService = new HealthService();
-    
+
     return healthCheckService;
   }
 

--- a/contracts/clients/src/SafeSingletonFactory.ts
+++ b/contracts/clients/src/SafeSingletonFactory.ts
@@ -224,7 +224,9 @@ export default class SafeSingletonFactory {
 
       throw new Error(
         [
-          "Insufficient funds:",
+          "Account",
+          await this.signer.getAddress(),
+          "has insufficient funds:",
           ethers.utils.formatEther(balance),
           "ETH, need (approx):",
           ethers.utils.formatEther(gasEstimate.mul(gasPrice)),

--- a/contracts/networks/arbitrum-goerli.json
+++ b/contracts/networks/arbitrum-goerli.json
@@ -1,20 +1,18 @@
 {
     "parameters": {},
     "addresses": {
-        "create2Deployer": "0x036d996D6855B83cd80142f2933d8C2617dA5617",
-        "precompileCostEstimator": "0x22E4a5251C1F02de8369Dd6f192033F6CB7531A4",
-        "blsLibrary": "0xF8a11BA6eceC43e23c9896b857128a4269290e39",
-        "verificationGateway": "0xae7DF242c589D479A5cF8fEA681736e0E0Bb1FB9",
-        "blsExpander": "0x4473e39a5F33A83B81387bb5F816354F04E724a3",
-        "utilities": "0x76cE3c1F2E6d87c355560fCbd28ccAcAe03f95F6",
-        "testToken": "0x5081a39b8A5f0E35a8D959395a630b68B74Dd30f",
-        "safeSingletonFactory": "n/a"
+        "safeSingletonFactory": "0x914d7Fec6aaC8cd542e72Bca78B30650d45643d7",
+        "precompileCostEstimator": "0x6eb8F8d661eFe36daB11147830A1e690249bB830",
+        "verificationGateway": "0x84e09390992F481E98eeb100bA4f19910c145Ede",
+        "blsExpander": "0x3F99eFb259ff4d15F3a07C2449a019ab1bF7CEa5",
+        "utilities": "0x4bD2E4e99B50A2a9e6b9dABfA3C8dCD1f885F008",
+        "testToken": "0x783746Fda55512043e0BCB9b06dB620277859E02"
     },
     "auxiliary": {
         "chainid": 421613,
         "domain": "0x0054159611832e24cdd64c6a133e71d373c5f8553dde6c762e6bffe707ad83cc",
-        "genesisBlock": 1206441,
-        "deployedBy": "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266",
-        "version": "bc3d1463f163b742026f951a2574016966b5c857"
+        "genesisBlock": 17602348,
+        "deployedBy": "0x9D5e5038c47da189f8C67A587c66a952a8b45bAb",
+        "version": "52d22bb114dd2abcc4754a05bca757435a2f33fd"
     }
 }


### PR DESCRIPTION
# *Dependent PR*

This PR depends on https://github.com/web3well/bls-wallet/pull/586.

After that's merged, toggle the target branch back and forth or push an empty commit to fix the diff. (Preview of [this PR's changes](https://github.com/web3well/bls-wallet/compare/contracts-connector...bw-406-aggregator-compression).)

(If you want, you can also just review+merge this one directly. Github will automerge the previous PRs.)

## What is this PR doing?

Uses compression in aggregator. Reduces the `data` field when sending a single ETH transfer from 836 bytes down to 164 bytes.

## How can these changes be manually tested?

(Replicating this test isn't required.)

Use Quill to do an ETH transfer and verify the transaction data is about 324 bytes. Here's what I got on arbitrum goerli:

<img width="785" alt="Screen Shot 2023-04-24 at 3 33 07 pm" src="https://user-images.githubusercontent.com/9291586/233908281-94a10b1f-f796-4819-a7cd-98c6a667fbd4.png">

[Explorer link](https://goerli.arbiscan.io/tx/0xb5936256c8ee83d4ad58e1f565534cf8f8f731a88b7d5f1d2a3e5da14ac0d35d)

To reduce this further, use `./manualTests/registerWallet.ts` to register the source BLS key and address, as well as the destination address. Verify that reduces the transaction data down to about 164 bytes:

<img width="768" alt="Screen Shot 2023-04-24 at 3 33 17 pm" src="https://user-images.githubusercontent.com/9291586/233912276-3be08073-d114-4cc7-8e2a-3324b4bcf530.png">

[Explorer link](https://goerli.arbiscan.io/tx/0x9c24c938c16b08ee16d0b19d82ca711630c7b7781f20961435c1943e8e135eb5)

For comparison I used version `f8a8c490` (`git checkout f8a8c490`) (this is right before the `contract-updates` merge, which naturally changes the contracts so `main` currently doesn't work with the existing deployment). Here's the transaction data from that one:

<img width="548" alt="Screen Shot 2023-04-24 at 3 55 20 pm" src="https://user-images.githubusercontent.com/9291586/233911732-48551ddb-7256-4783-8c40-00c579cf8781.png">

[Explorer link](https://goerli.arbiscan.io/tx/0xd4d2bdc98beb7012c6b0b4789301d87a134ecdbe1e20ffba0f657cdda093c52d)

## Wait, wait, still 164 bytes? 😰

Yeah. That's just the data field too. If you include the full transaction data (including the envelope with the aggregator's signature and gas settings etc), then there's another 115 bytes or so (total is about 279 bytes).

Anyway, 164 bytes in the data field is a lot more than we need, and it's because there's still some cleanup to do. Here's the breakdown of those bytes:

```
0x

3a276523
  - method id of run()

0000000000000000000000000000000000000000000000000000000000000020
  - location of byte array for `stream` calldata argument

0000000000000000000000000000000000000000000000000000000000000056
  - `stream` is 86 bytes long
    (==0x56 but solidity abi uses an entire uint256 word for this)

01
  - one operation

00
  - use expander id 0 (fallback expander)

07
  - 0x07 = 0b111 - bit stream:
    - 1: Use registry for sendWallet's public key
    - 1: Include a tx.origin payment
    - 1: Use registry for recvWallet's address

000000
  - id of sender's bls public key

01
  - nonce

0cb730
  - 56,708 gas

02
  - two actions (send ETH and pay tx.origin)

7900
  - 0.0001 ETH

000001
  - id recipient's address

00
  - zero bytes for encodedFunction

3092cbb31e
  - pay 0.0000311872752 ETH to tx.origin

0b018b1989c5c62d43b0a0427f04781f2a4e201ab2c938ad23aa2d0a6c0a284a
03f37bd9fbdac1b34f3046363244c0e47a2a73add7cdfac41c2f134285256dfc
  - BLS signature

00000000000000000000
  - padding bytes from the solidity abi to make a multiple of 32 bytes
```

In summary:
- 78 bytes of ABI overhead
- 1 byte to say that there's one operation
- 21 bytes for the actual operation (send ETH to recipient and pay tx.origin)
- 64 bytes for the signature

We should be able to remove the ABI overhead by introducing another contract whose whole purpose is to call the expander with its raw argument.

Focusing on the positive, very small encodings for the actual operations *have* been achieved, and this means that the *marginal* data cost of each operation is this low number (20 bytes or so). This means you could add 100 transactions for 2100 bytes, so the whole transaction would be 2100+279=2379 bytes, or about 24 bytes per transaction. Then the marginal cost becomes dominant, BUT you need to wait for 100 transactions before you can submit.

Related improvements to work on:
- Fix those 78 bytes of overhead
- Round up to 3 significant figures for gas limit and tx.origin payment (would bring 21 bytes above down to 17)
- Add registration functionality to Quill

## Does this PR resolve or contribute to any issues?

Resolves #406.

## Checklist
- [x] I have manually tested these changes
- [x] Post a link to the PR in the group chat

## Guidelines
- If your PR is not ready, mark it as a draft
- The `resolve conversation` button is for reviewers, not authors
  - (But add a 'done' comment or similar)
