### PR TITLE
Fix expander lookup

### DIFF
--- a/contracts/clients/src/BlsRegistrationCompressor.ts
+++ b/contracts/clients/src/BlsRegistrationCompressor.ts
@@ -165,6 +165,10 @@ export default class BlsRegistrationCompressor implements IOperationCompressor {
     return await BlsRegistrationCompressor.wrap(blsRegistration);
   }
 
+  getExpanderAddress(): string {
+    return this.blsRegistration.address;
+  }
+
   async compress(blsPublicKey: PublicKey, operation: Operation) {
     if (operation.actions.length > 2) {
       return undefined;

--- a/contracts/clients/src/BundleCompressor.ts
+++ b/contracts/clients/src/BundleCompressor.ts
@@ -3,6 +3,7 @@ import { encodeVLQ, hexJoin } from "./encodeUtils";
 import IOperationCompressor from "./IOperationCompressor";
 import { Bundle, Operation, PublicKey } from "./signer";
 import Range from "./helpers/Range";
+import { BLSExpanderDelegator } from "../typechain-types";
 
 /**
  * Produces compressed bundles that can be passed to `BLSExpanderDelegator.run`
@@ -18,9 +19,24 @@ import Range from "./helpers/Range";
 export default class BundleCompressor {
   compressors: [number, IOperationCompressor][] = [];
 
+  constructor(public blsExpanderDelegator: BLSExpanderDelegator) {}
+
   /** Add an operation compressor. */
-  addCompressor(expanderIndex: number, compressor: IOperationCompressor) {
-    this.compressors.push([expanderIndex, compressor]);
+  async addCompressor(compressor: IOperationCompressor) {
+    const registrations = await this.blsExpanderDelegator.queryFilter(
+      this.blsExpanderDelegator.filters.ExpanderRegistered(
+        null,
+        compressor.getExpanderAddress(),
+      ),
+    );
+
+    const id = registrations.at(0)?.args?.id;
+
+    if (id === undefined) {
+      throw new Error("Expander not registered");
+    }
+
+    this.compressors.push([id.toNumber(), compressor]);
   }
 
   /** Compresses a single operation. */

--- a/contracts/clients/src/Erc20Compressor.ts
+++ b/contracts/clients/src/Erc20Compressor.ts
@@ -160,6 +160,10 @@ export default class Erc20Compressor implements IOperationCompressor {
     return await Erc20Compressor.wrap(erc20Expander);
   }
 
+  getExpanderAddress(): string {
+    return this.erc20Expander.address;
+  }
+
   async compress(blsPublicKey: PublicKey, operation: Operation) {
     const result: string[] = [];
 

--- a/contracts/clients/src/FallbackCompressor.ts
+++ b/contracts/clients/src/FallbackCompressor.ts
@@ -162,6 +162,10 @@ export default class FallbackCompressor implements IOperationCompressor {
     return await FallbackCompressor.wrap(fallbackExpander);
   }
 
+  getExpanderAddress(): string {
+    return this.fallbackExpander.address;
+  }
+
   async compress(blsPublicKey: PublicKey, operation: Operation) {
     const result: string[] = [];
 

--- a/contracts/clients/src/IOperationCompressor.ts
+++ b/contracts/clients/src/IOperationCompressor.ts
@@ -1,6 +1,8 @@
 import { Operation, PublicKey } from "./signer";
 
 type IOperationCompressor = {
+  getExpanderAddress(): string;
+
   compress(
     blsPublicKey: PublicKey,
     operation: Operation,

--- a/contracts/contracts/BLSExpanderDelegator.sol
+++ b/contracts/contracts/BLSExpanderDelegator.sol
@@ -20,7 +20,10 @@ contract BLSExpanderDelegator {
     uint8 constant BLS_KEY_LEN = 4;
 
     IBundleProcessor gateway;
+
+    uint256 public nextExpanderId = 0;
     mapping(uint256 => IExpander) public expanders;
+    event ExpanderRegistered(uint256 id, IExpander indexed expanderAddress);
 
     constructor(IBundleProcessor gatewayParam) {
         gateway = gatewayParam;
@@ -80,14 +83,12 @@ contract BLSExpanderDelegator {
     }
 
     function registerExpander(
-        uint256 expanderIndex,
         IExpander expander
     ) external {
-        require(
-            expanders[expanderIndex] == IExpander(address(0)),
-            "Index not available"
-        );
+        uint256 expanderId = nextExpanderId;
+        nextExpanderId += 1;
+        expanders[expanderId] = expander;
 
-        expanders[expanderIndex] = expander;
+        emit ExpanderRegistered(expanderId, expander);
     }
 }

--- a/contracts/shared/deploy.ts
+++ b/contracts/shared/deploy.ts
@@ -164,10 +164,10 @@ async function deployExpanders(
     salt,
   );
 
-  await registerExpanders(blsExpanderDelegator, [
-    fallbackExpander.address,
-    blsRegistration.address,
-    erc20Expander.address,
+  await Promise.all([
+    registerExpanderIfNeeded(blsExpanderDelegator, fallbackExpander.address),
+    registerExpanderIfNeeded(blsExpanderDelegator, blsRegistration.address),
+    registerExpanderIfNeeded(blsExpanderDelegator, erc20Expander.address),
   ]);
 
   return {
@@ -181,17 +181,17 @@ async function deployExpanders(
   };
 }
 
-async function registerExpanders(
+async function registerExpanderIfNeeded(
   blsExpanderDelegator: BLSExpanderDelegator,
-  expanders: string[],
+  expander: string,
 ) {
-  for (const [i, expander] of expanders.entries()) {
-    const existingExpander = await blsExpanderDelegator.expanders(i);
+  const registrations = await blsExpanderDelegator.queryFilter(
+    blsExpanderDelegator.filters.ExpanderRegistered(null, expander),
+  );
 
-    if (existingExpander === ethers.constants.AddressZero) {
-      await receiptOf(blsExpanderDelegator.registerExpander(i, expander));
-    } else if (existingExpander !== expanders[i]) {
-      throw new Error(`Existing expander at index ${i} is not ${expander}`);
-    }
+  if (registrations.length > 0) {
+    return;
   }
+
+  await receiptOf(blsExpanderDelegator.registerExpander(expander));
 }

--- a/contracts/shared/deploy.ts
+++ b/contracts/shared/deploy.ts
@@ -164,11 +164,12 @@ async function deployExpanders(
     salt,
   );
 
-  await Promise.all([
-    registerExpanderIfNeeded(blsExpanderDelegator, fallbackExpander.address),
-    registerExpanderIfNeeded(blsExpanderDelegator, blsRegistration.address),
-    registerExpanderIfNeeded(blsExpanderDelegator, erc20Expander.address),
-  ]);
+  await registerExpanderIfNeeded(
+    blsExpanderDelegator,
+    fallbackExpander.address,
+  );
+  await registerExpanderIfNeeded(blsExpanderDelegator, blsRegistration.address);
+  await registerExpanderIfNeeded(blsExpanderDelegator, erc20Expander.address);
 
   return {
     blsExpander,

--- a/contracts/shared/helpers/Fixture.ts
+++ b/contracts/shared/helpers/Fixture.ts
@@ -104,10 +104,10 @@ export default class Fixture {
       throw new Error("BLS registration compressor not set up correctly");
     }
 
-    const bundleCompressor = new BundleCompressor();
-    bundleCompressor.addCompressor(2, erc20Compressor);
-    bundleCompressor.addCompressor(1, blsRegistrationCompressor);
-    bundleCompressor.addCompressor(0, fallbackCompressor);
+    const bundleCompressor = new BundleCompressor(blsExpanderDelegator);
+    await bundleCompressor.addCompressor(erc20Compressor);
+    await bundleCompressor.addCompressor(blsRegistrationCompressor);
+    await bundleCompressor.addCompressor(fallbackCompressor);
 
     const privateKey = await BlsWalletWrapper.getRandomBlsPrivateKey();
 


### PR DESCRIPTION
## What is this PR doing?

Before this change, I've been assuming that expanders were installed at fixed IDs in the top-level expander (`BLSExpanderDelegator`). That's fine for testing, but exporting to the aggregator I realized it would be bad to rely on that.

Rather than exporting a configuration or scanning the registered expanders to find the appropriate IDs, this change adds an indexed event for expander registration so that those can be used instead. This avoids both problems so that initializing the compressor should be pretty painless (including adding more compressor+expander pairs in future).

## How can these changes be manually tested?

`yarn hardhat test`

## Does this PR resolve or contribute to any issues?

Contributes to #406.

## Checklist
- [x] I have manually tested these changes
- [x] Post a link to the PR in the group chat

## Guidelines
- If your PR is not ready, mark it as a draft
- The `resolve conversation` button is for reviewers, not authors
  - (But add a 'done' comment or similar)
