### PR TITLE
Contracts connector

### DIFF
--- a/contracts/clients/src/ContractsConnector.ts
+++ b/contracts/clients/src/ContractsConnector.ts
@@ -1,0 +1,156 @@
+import { ethers } from "ethers";
+import { SafeSingletonFactoryViewer } from "./SafeSingletonFactory";
+import SignerOrProvider from "./helpers/SignerOrProvider";
+import assert from "./helpers/assert";
+import {
+  AddressRegistry__factory as AddressRegistryFactory,
+  AggregatorUtilities__factory as AggregatorUtilitiesFactory,
+  BLSExpanderDelegator__factory as BLSExpanderDelegatorFactory,
+  BLSExpander__factory as BLSExpanderFactory,
+  BLSOpen__factory as BLSOpenFactory,
+  BLSPublicKeyRegistry__factory as BLSPublicKeyRegistryFactory,
+  BLSRegistration__factory as BLSRegistrationFactory,
+  BNPairingPrecompileCostEstimator__factory as BNPairingPrecompileCostEstimatorFactory,
+  ERC20Expander__factory as ERC20ExpanderFactory,
+  FallbackExpander__factory as FallbackExpanderFactory,
+  VerificationGateway__factory as VerificationGatewayFactory,
+} from "../typechain-types";
+
+export default class ContractsConnector {
+  constructor(
+    public factoryViewer: SafeSingletonFactoryViewer,
+    public salt: ethers.utils.BytesLike = ethers.utils.solidityPack(
+      ["uint256"],
+      [0],
+    ),
+  ) {}
+
+  static async create(signerOrProvider: SignerOrProvider) {
+    let provider: ethers.providers.Provider;
+
+    if ("getNetwork" in signerOrProvider) {
+      provider = signerOrProvider;
+    } else {
+      assert(
+        signerOrProvider.provider !== undefined,
+        "When using a signer, it's required to have a provider",
+      );
+
+      provider = signerOrProvider.provider;
+    }
+
+    const chainId = (await provider.getNetwork()).chainId;
+
+    const factoryViewer = new SafeSingletonFactoryViewer(
+      signerOrProvider,
+      chainId,
+    );
+
+    return new ContractsConnector(factoryViewer);
+  }
+
+  BNPairingPrecompileCostEstimator = once(async () =>
+    this.factoryViewer.connectOrThrow(
+      BNPairingPrecompileCostEstimatorFactory,
+      [],
+      this.salt,
+    ),
+  );
+
+  BLSOpen = once(() =>
+    this.factoryViewer.connectOrThrow(BLSOpenFactory, [], this.salt),
+  );
+
+  VerificationGateway = once(async () =>
+    this.factoryViewer.connectOrThrow(
+      VerificationGatewayFactory,
+      [(await this.BLSOpen()).address],
+      this.salt,
+    ),
+  );
+
+  AggregatorUtilities = once(async () =>
+    this.factoryViewer.connectOrThrow(
+      AggregatorUtilitiesFactory,
+      [],
+      this.salt,
+    ),
+  );
+
+  BLSExpander = once(async () =>
+    this.factoryViewer.connectOrThrow(
+      BLSExpanderFactory,
+      [(await this.VerificationGateway()).address],
+      this.salt,
+    ),
+  );
+
+  BLSExpanderDelegator = once(async () =>
+    this.factoryViewer.connectOrThrow(
+      BLSExpanderDelegatorFactory,
+      [(await this.VerificationGateway()).address],
+      this.salt,
+    ),
+  );
+
+  BLSPublicKeyRegistry = once(async () =>
+    this.factoryViewer.connectOrThrow(
+      BLSPublicKeyRegistryFactory,
+      [],
+      this.salt,
+    ),
+  );
+
+  AddressRegistry = once(async () =>
+    this.factoryViewer.connectOrThrow(AddressRegistryFactory, [], this.salt),
+  );
+
+  FallbackExpander = once(async () =>
+    this.factoryViewer.connectOrThrow(
+      FallbackExpanderFactory,
+      await Promise.all([
+        this.BLSPublicKeyRegistry().then((c) => c.address),
+        this.AddressRegistry().then((c) => c.address),
+        this.AggregatorUtilities().then((c) => c.address),
+      ]),
+      this.salt,
+    ),
+  );
+
+  BLSRegistration = once(async () =>
+    this.factoryViewer.connectOrThrow(
+      BLSRegistrationFactory,
+      await Promise.all([
+        this.BLSPublicKeyRegistry().then((c) => c.address),
+        this.AddressRegistry().then((c) => c.address),
+        this.AggregatorUtilities().then((c) => c.address),
+      ]),
+      this.salt,
+    ),
+  );
+
+  ERC20Expander = once(async () =>
+    this.factoryViewer.connectOrThrow(
+      ERC20ExpanderFactory,
+      await Promise.all([
+        this.BLSPublicKeyRegistry().then((c) => c.address),
+        this.AddressRegistry().then((c) => c.address),
+        this.AggregatorUtilities().then((c) => c.address),
+      ]),
+      this.salt,
+    ),
+  );
+}
+
+function once<T extends {}>(fn: () => T): () => T {
+  let result: T | undefined;
+
+  return () => {
+    if (result === undefined) {
+      result = fn();
+      (fn as unknown as undefined) = undefined;
+    }
+
+    return result;
+  };
+}

--- a/contracts/clients/src/SafeSingletonFactory.ts
+++ b/contracts/clients/src/SafeSingletonFactory.ts
@@ -15,11 +15,11 @@ type NonOptionalElementsOf<A extends unknown[]> = A extends [
   ? []
   : never;
 
-type ContractFactoryConstructor = {
+export type ContractFactoryConstructor = {
   new (): ethers.ContractFactory;
 };
 
-type DeployParams<CFC extends ContractFactoryConstructor> =
+export type DeployParams<CFC extends ContractFactoryConstructor> =
   NonOptionalElementsOf<Parameters<InstanceType<CFC>["deploy"]>>;
 
 type Deployment = {
@@ -345,6 +345,32 @@ export class SafeSingletonFactoryViewer {
 
     if (this.signer) {
       contract = contract.connect(this.signer) as typeof contract;
+    }
+
+    return contract;
+  }
+
+  async connectOrThrow<CFC extends ContractFactoryConstructor>(
+    ContractFactoryConstructor: CFC,
+    deployParams: DeployParams<CFC>,
+    salt: ethers.utils.BytesLike = ethers.utils.solidityPack(["uint256"], [0]),
+  ): Promise<ReturnType<InstanceType<CFC>["attach"]>> {
+    const contract = await this.connectIfDeployed(
+      ContractFactoryConstructor,
+      deployParams,
+      salt,
+    );
+
+    if (!contract) {
+      throw new Error(
+        `Contract ${
+          ContractFactoryConstructor.name
+        } not deployed at ${this.calculateAddress(
+          ContractFactoryConstructor,
+          deployParams,
+          salt,
+        )}`,
+      );
     }
 
     return contract;

--- a/contracts/clients/src/index.ts
+++ b/contracts/clients/src/index.ts
@@ -42,4 +42,5 @@ export { default as FallbackCompressor } from "./FallbackCompressor";
 export { default as Erc20Compressor } from "./Erc20Compressor";
 export { default as BlsRegistrationCompressor } from "./BlsRegistrationCompressor";
 export { default as BundleCompressor } from "./BundleCompressor";
+export { default as ContractsConnector } from "./ContractsConnector";
 export * from "./encodeUtils";


### PR DESCRIPTION
# *Dependent PR*

This PR depends on https://github.com/web3well/bls-wallet/pull/585.

After that's merged, toggle the target branch back and forth or push an empty commit to fix the diff. (Preview of [this PR's changes](https://github.com/web3well/bls-wallet/compare/fix-expander-lookup...contracts-connector).)

(If you want, you can also just review+merge this one directly. Github will automerge the previous PRs.)

## What is this PR doing?

Adds a new utility `ContractsConnector` to bls-wallet-clients.

Now that we use SafeSingletonFactory, there's no need to deal with configured addresses - instead you just connect to the contracts predetermined address (or throw an error if it's no there). The only problem is that you need the init data to figure out the address, and that init data can be another predetermined address. Our contracts are a small network of singletons that are initialized in a tree. `ContractsConnector` is just making this easy by dealing with the init data for you.

## How can these changes be manually tested?

`yarn hardhat test`

## Does this PR resolve or contribute to any issues?

Contributes to #406.

## Checklist
- [x] I have manually tested these changes
- [x] Post a link to the PR in the group chat

## Guidelines
- If your PR is not ready, mark it as a draft
- The `resolve conversation` button is for reviewers, not authors
  - (But add a 'done' comment or similar)
