### PR TITLE
Add name and version to bls wallet domains

### DIFF
--- a/contracts/clients/src/NetworkConfig.ts
+++ b/contracts/clients/src/NetworkConfig.ts
@@ -23,11 +23,15 @@ export type NetworkConfig = {
   auxiliary: {
     chainid: number;
     /**
-     * Domain used for BLS signing
+     * Domain used for signing BLS Proof of Possession messages
      */
-    domain: string;
+    walletDomain: string;
     /**
-     * Starting block contracts began dpeloyment at
+     * Domain used for signing BLS Bundle messages
+     */
+    bundleDomain: string;
+    /**
+     * Starting block contracts began deployment at
      */
     genesisBlock: number;
     /**
@@ -64,7 +68,8 @@ export function validateConfig(cfg: UnvalidatedConfig): NetworkConfig {
     },
     auxiliary: {
       chainid: assertNumber(cfg.auxiliary.chainid),
-      domain: assertString(cfg.auxiliary.domain),
+      walletDomain: assertString(cfg.auxiliary.walletDomain),
+      bundleDomain: assertString(cfg.auxiliary.bundleDomain),
       genesisBlock: assertNumber(cfg.auxiliary.genesisBlock),
       deployedBy: assertString(cfg.auxiliary.deployedBy),
       version: assertString(cfg.auxiliary.version),

--- a/contracts/clients/src/signer/getDomain.ts
+++ b/contracts/clients/src/signer/getDomain.ts
@@ -2,13 +2,15 @@ import { arrayify, solidityPack } from "ethers/lib/utils";
 import { utils } from "ethers";
 
 export default (
+  name: string,
+  version: string,
   chainId: number,
   verificationGatewayAddress: string,
   type: string,
 ): Uint8Array => {
   const encoded = solidityPack(
-    ["uint256", "address", "string"],
-    [chainId, verificationGatewayAddress, type],
+    ["string", "string", "uint256", "address", "string"],
+    [name, version, chainId, verificationGatewayAddress, type],
   );
 
   return arrayify(utils.keccak256(encoded));

--- a/contracts/clients/src/signer/index.ts
+++ b/contracts/clients/src/signer/index.ts
@@ -32,8 +32,23 @@ export async function initBlsWalletSigner({
   // properly initialized for all use cases, not just signing.
   const signerFactory = await signer.BlsSignerFactory.new();
 
-  const bundleDomain = getDomain(chainId, verificationGatewayAddress, "Bundle");
-  const walletDomain = getDomain(chainId, verificationGatewayAddress, "Wallet");
+  const domainName = "BLS_WALLET";
+  const domainVersion = "1";
+
+  const bundleDomain = getDomain(
+    domainName,
+    domainVersion,
+    chainId,
+    verificationGatewayAddress,
+    "Bundle",
+  );
+  const walletDomain = getDomain(
+    domainName,
+    domainVersion,
+    chainId,
+    verificationGatewayAddress,
+    "Wallet",
+  );
 
   return {
     aggregate,

--- a/contracts/clients/test/config.test.ts
+++ b/contracts/clients/test/config.test.ts
@@ -20,7 +20,8 @@ const getSingleConfig = (networkKey: string): NetworkConfig => ({
   },
   auxiliary: {
     chainid: 123,
-    domain: getValue(networkKey, "domain"),
+    walletDomain: getValue(networkKey, "walletDomain"),
+    bundleDomain: getValue(networkKey, "bundleDomain"),
     genesisBlock: 456,
     deployedBy: getValue(networkKey, "deployedBy"),
     version: getValue(networkKey, "version"),

--- a/contracts/clients/test/index.test.ts
+++ b/contracts/clients/test/index.test.ts
@@ -61,8 +61,8 @@ describe("index", () => {
     const bundle = sign(bundleTemplate, walletAddress);
 
     expect(bundle.signature).to.deep.equal([
-      "0x21135f40b38f55236ceb637ad8f2d6d4e8081bc1c37ea08273838f839008b9cd",
-      "0x16515fb0821c039e127dd8e4a70c7004aec1baf698802fc16e7cf8d2ae0bb14a",
+      "0x117171c1a4af03133390b454989658d9c6ae7a7fe1c3958ad545e584e63ab5e3",
+      "0x2f90b24bbc03de665816b3a632e0c7b5fb837c87541d9337480671613cf1359c",
     ]);
 
     expect(verify(bundle, walletAddress)).to.equal(true);
@@ -127,8 +127,8 @@ describe("index", () => {
     const aggBundle = aggregate([bundle1, bundle2]);
 
     expect(aggBundle.signature).to.deep.equal([
-      "0x20c3afd45d2c7cd72003752377cf6853569bccd23abf962967a9245091b69c3b",
-      "0x1ff4a18f1e920206f849e50df41e7bab6377d3908a8198d9c9268ca01ae70552",
+      "0x18b917c1f52155d9748025bd94aa07c0017af31dd2ef2a00289931f660e88ec9",
+      "0x0235a99bcd1f0793efb7f3307cd349f211a433f60cfab795f5f976298f17a768",
     ]);
 
     expect(verify(bundle1, walletAddress)).to.equal(true);

--- a/contracts/contracts/VerificationGateway.sol
+++ b/contracts/contracts/VerificationGateway.sol
@@ -21,6 +21,8 @@ contract VerificationGateway
 {
     bytes32 WALLET_DOMAIN;
     bytes32 BUNDLE_DOMAIN;
+    string constant BLS_DOMAIN_NAME = "BLS_WALLET";
+    string constant BLS_DOMAIN_VERSION = "1";
     uint8 constant BLS_KEY_LEN = 4;
 
     IBLS public immutable blsLib;
@@ -64,11 +66,15 @@ contract VerificationGateway
         blsLib = bls;
         blsWalletLogic.initialize(address(0));
         WALLET_DOMAIN = keccak256(abi.encodePacked(
+            BLS_DOMAIN_NAME,
+            BLS_DOMAIN_VERSION,
             block.chainid,
             address(this),
             "Wallet"
         ));
         BUNDLE_DOMAIN = keccak256(abi.encodePacked(
+            BLS_DOMAIN_NAME,
+            BLS_DOMAIN_VERSION,
             block.chainid,
             address(this),
             "Bundle"

--- a/contracts/scripts/deploy_all.ts
+++ b/contracts/scripts/deploy_all.ts
@@ -79,8 +79,8 @@ async function main() {
     },
     auxiliary: {
       chainid,
-      walletDomain: ethers.utils.toUtf8String(walletDomain),
-      bundleDomain: ethers.utils.toUtf8String(bundleDomain),
+      walletDomain: ethers.utils.hexlify(walletDomain),
+      bundleDomain: ethers.utils.hexlify(bundleDomain),
       genesisBlock,
       deployedBy: signer.address,
       version,

--- a/contracts/scripts/deploy_all.ts
+++ b/contracts/scripts/deploy_all.ts
@@ -13,6 +13,7 @@ import { writeFile } from "fs/promises";
 import { ethers } from "hardhat";
 import { NetworkConfig } from "../clients/src";
 import deploy from "../shared/deploy";
+import getDomain from "../clients/src/signer/getDomain";
 
 dotenv.config();
 const exec = util.promisify(execCb);
@@ -48,6 +49,24 @@ async function main() {
   // These can be run in parallel
   const [testToken, version] = await Promise.all([deployToken(), getVersion()]);
 
+  const domainName = "BLS_WALLET";
+  const domainVersion = "1";
+  const walletDomain = getDomain(
+    domainName,
+    domainVersion,
+    chainid,
+    deployment.verificationGateway.address,
+    "Wallet",
+  );
+
+  const bundleDomain = getDomain(
+    domainName,
+    domainVersion,
+    chainid,
+    deployment.verificationGateway.address,
+    "Bundle",
+  );
+
   const netCfg: NetworkConfig = {
     parameters: {},
     addresses: {
@@ -60,9 +79,8 @@ async function main() {
     },
     auxiliary: {
       chainid,
-      // From VerificationGateway.sol:BLS_DOMAIN
-      domain:
-        "0x0054159611832e24cdd64c6a133e71d373c5f8553dde6c762e6bffe707ad83cc",
+      walletDomain: ethers.utils.toUtf8String(walletDomain),
+      bundleDomain: ethers.utils.toUtf8String(bundleDomain),
       genesisBlock,
       deployedBy: signer.address,
       version,


### PR DESCRIPTION
## What is this PR doing?
Adds name and version to BLS Wallet domains. Following offline discussion with @jzaki, we decided that we do not need to implement EIP-712 at the contract level. Instead, the EIP-712 smart contract changes are mainly relevant at the dapp/protocol level, not the contract level for smart contract wallets.

The audit did not specify directly implementing 712, but instead, using it as inspiration and additional information for completing audit issue 7 - #571:

> Other recommendations are to also include a version and a name fields to allow protocol upgrades. Consider using the EIP712 domain as inspiration and additional information.

Although the contracts don't need EIP-712 support, we may want to consider adding support for EIP-712 in Quill in another issue, as it currently does not. 

## How can these changes be manually tested?
- run tests

## Does this PR resolve or contribute to any issues?
resolves #25 

## Checklist
- [x] I have manually tested these changes
- [x] Post a link to the PR in the group chat

## Guidelines
- If your PR is not ready, mark it as a draft
- The `resolve conversation` button is for reviewers, not authors
  - (But add a 'done' comment or similar)
