### PR TITLE
Add `ExpanderEntryPoint` to avoid solidity abi

### DIFF
--- a/aggregator/deps.ts
+++ b/aggregator/deps.ts
@@ -54,7 +54,7 @@ export type {
   PublicKey,
   Signature,
   VerificationGateway,
-} from "https://esm.sh/bls-wallet-clients@0.8.3-bee2034";
+} from "https://esm.sh/bls-wallet-clients@0.8.3-dc488ec";
 
 export {
   Aggregator as AggregatorClient,
@@ -70,10 +70,10 @@ export {
   getConfig,
   MockERC20Factory,
   VerificationGatewayFactory,
-} from "https://esm.sh/bls-wallet-clients@0.8.3-bee2034";
+} from "https://esm.sh/bls-wallet-clients@0.8.3-dc488ec";
 
 // Workaround for esbuild's export-star bug
-import blsWalletClients from "https://esm.sh/bls-wallet-clients@0.8.3-bee2034";
+import blsWalletClients from "https://esm.sh/bls-wallet-clients@0.8.3-dc488ec";
 const { bundleFromDto, bundleToDto, initBlsWalletSigner } = blsWalletClients;
 export { bundleFromDto, bundleToDto, initBlsWalletSigner };
 

--- a/contracts/clients/src/ContractsConnector.ts
+++ b/contracts/clients/src/ContractsConnector.ts
@@ -12,6 +12,7 @@ import {
   BLSRegistration__factory as BLSRegistrationFactory,
   BNPairingPrecompileCostEstimator__factory as BNPairingPrecompileCostEstimatorFactory,
   ERC20Expander__factory as ERC20ExpanderFactory,
+  ExpanderEntryPoint__factory as ExpanderEntryPointFactory,
   FallbackExpander__factory as FallbackExpanderFactory,
   VerificationGateway__factory as VerificationGatewayFactory,
 } from "../typechain-types";
@@ -137,6 +138,14 @@ export default class ContractsConnector {
         this.AddressRegistry().then((c) => c.address),
         this.AggregatorUtilities().then((c) => c.address),
       ]),
+      this.salt,
+    ),
+  );
+
+  ExpanderEntryPoint = once(async () =>
+    this.factoryViewer.connectOrThrow(
+      ExpanderEntryPointFactory,
+      [(await this.BLSExpanderDelegator()).address],
       this.salt,
     ),
   );

--- a/contracts/contracts/ExpanderEntryPoint.sol
+++ b/contracts/contracts/ExpanderEntryPoint.sol
@@ -1,0 +1,24 @@
+//SPDX-License-Identifier: Unlicense
+pragma solidity >=0.7.0 <0.9.0;
+pragma abicoder v2;
+
+interface IExpanderDelegator {
+    function run(
+        bytes calldata stream
+    ) external returns (bool[] memory successes, bytes[][] memory results);
+}
+
+contract ExpanderEntryPoint {
+    IExpanderDelegator expanderDelegator;
+
+    constructor(IExpanderDelegator expanderDelegatorParam) {
+        expanderDelegator = expanderDelegatorParam;
+    }
+
+    fallback(bytes calldata stream) external returns (bytes memory) {
+        (bool[] memory successes, bytes[][] memory results) = expanderDelegator
+            .run{ gas: type(uint256).max }(stream);
+
+        return abi.encode(successes, results);
+    }
+}

--- a/contracts/shared/deploy.ts
+++ b/contracts/shared/deploy.ts
@@ -22,6 +22,8 @@ import {
   BLSRegistration,
   ERC20Expander,
   ERC20Expander__factory as ERC20ExpanderFactory,
+  ExpanderEntryPoint,
+  ExpanderEntryPoint__factory as ExpanderEntryPointFactory,
 } from "../typechain-types";
 
 import { SafeSingletonFactory } from "../clients/src";
@@ -40,6 +42,7 @@ export type Deployment = {
   blsExpanderDelegator: BLSExpanderDelegator;
   aggregatorUtilities: AggregatorUtilities;
   blsRegistration: BLSRegistration;
+  expanderEntryPoint: ExpanderEntryPoint;
 };
 
 export default async function deploy(
@@ -89,6 +92,12 @@ export default async function deploy(
     salt,
   );
 
+  const expanderEntryPoint = await singletonFactory.connectOrDeploy(
+    ExpanderEntryPointFactory,
+    [blsExpanderDelegator.address],
+    salt,
+  );
+
   return {
     singletonFactory,
     precompileCostEstimator,
@@ -102,6 +111,7 @@ export default async function deploy(
     blsExpanderDelegator,
     aggregatorUtilities,
     blsRegistration,
+    expanderEntryPoint,
   };
 }
 

--- a/contracts/test/expanders-test.ts
+++ b/contracts/test/expanders-test.ts
@@ -67,7 +67,7 @@ describe("Expanders", async function () {
     */
     expect(hexLen(compressedBundle)).to.eq(223);
 
-    await receiptOf(fx.blsExpanderDelegator.run(compressedBundle));
+    await fx.processCompressedBundle(compressedBundle);
 
     await expect(fx.provider.getBalance(sendWallet.address)).to.eventually.eq(
       0,
@@ -142,7 +142,7 @@ describe("Expanders", async function () {
     */
     expect(hexLen(compressedBundle)).to.eq(81);
 
-    await receiptOf(fx.blsExpanderDelegator.run(compressedBundle));
+    await fx.processCompressedBundle(compressedBundle);
 
     await expect(fx.provider.getBalance(sendWallet.address)).to.eventually.eq(
       0,
@@ -229,7 +229,7 @@ describe("Expanders", async function () {
     expect(hexLen(compressedBundle)).to.eq(83);
     // Just 2 extra bytes for the tx.origin payment
 
-    await receiptOf(fx.blsExpanderDelegator.run(compressedBundle));
+    await fx.processCompressedBundle(compressedBundle);
 
     await expect(fx.provider.getBalance(sendWallet.address)).to.eventually.eq(
       0,
@@ -290,7 +290,7 @@ describe("Expanders", async function () {
     const compressedBundle = await fx.bundleCompressor.compress(bundle);
     expect(hexLen(compressedBundle)).to.eq(200);
 
-    await receiptOf(fx.processCompressedBundleWithExtraGas(compressedBundle));
+    await fx.processCompressedBundleWithExtraGas(compressedBundle);
 
     await expect(
       fx.fallbackCompressor.addressRegistry.reverseLookup(wallet.address),
@@ -364,7 +364,7 @@ describe("Expanders", async function () {
     const compressedBundle = await fx.bundleCompressor.compress(bundle);
     expect(hexLen(compressedBundle)).to.eq(201);
 
-    await receiptOf(fx.processCompressedBundleWithExtraGas(compressedBundle));
+    await fx.processCompressedBundleWithExtraGas(compressedBundle);
 
     await expect(
       fx.fallbackCompressor.addressRegistry.reverseLookup(wallet.address),
@@ -499,7 +499,8 @@ describe("Expanders", async function () {
       13e9fe34f0ec3465d44718cb6f93697dfbb0000a54287b3acaea5594f36b9aa1
               - signature
     */
-    await receiptOf(fx.blsExpanderDelegator.run(compressedBundle012));
+
+    await fx.processCompressedBundle(compressedBundle012);
 
     await expect(fx.provider.getBalance(wallets[0].address)).to.eventually.eq(
       ethers.utils
@@ -588,7 +589,7 @@ describe("Expanders", async function () {
 
     const compressedBundle = await fx.bundleCompressor.compress(bundle);
 
-    await receiptOf(fx.blsExpanderDelegator.run(compressedBundle));
+    await fx.processCompressedBundle(compressedBundle);
 
     await expect(erc20.balanceOf(sendWallet.address)).to.eventually.eq(
       ethers.utils.parseEther("0.9"),
@@ -666,7 +667,7 @@ describe("Expanders", async function () {
       erc20.allowance(sendWallet.address, recvWallet.address),
     ).to.eventually.eq(0);
 
-    await receiptOf(fx.blsExpanderDelegator.run(compressedBundle));
+    await fx.processCompressedBundle(compressedBundle);
 
     await expect(
       erc20.allowance(sendWallet.address, recvWallet.address),


### PR DESCRIPTION
# *Dependent PR*

This PR depends on https://github.com/web3well/bls-wallet/pull/584.

After that's merged, toggle the target branch back and forth or push an empty commit to fix the diff. (Preview of [this PR's changes](https://github.com/web3well/bls-wallet/compare/bw-406-aggregator-compression...bw-589-avoid-solidity-abi).)

## What is this PR doing?

Before:

<img width="768" alt="Screen Shot 2023-04-24 at 3 33 17 pm" src="https://user-images.githubusercontent.com/9291586/233912276-3be08073-d114-4cc7-8e2a-3324b4bcf530.png">

```
3a276523
0000000000000000000000000000000000000000000000000000000000000020
0000000000000000000000000000000000000000000000000000000000000056
- ABI overhead

010007000000010cb730027900000001003092cbb31e
- Compressed operation

0b018b1989c5c62d43b0a0427f04781f2a4e201ab2c938ad23aa2d0a6c0a284a
03f37bd9fbdac1b34f3046363244c0e47a2a73add7cdfac41c2f134285256dfc
- BLS Signature

00000000000000000000
- ABI overhead
```

[Explorer link](https://goerli.arbiscan.io/tx/0x9c24c938c16b08ee16d0b19d82ca711630c7b7781f20961435c1943e8e135eb5)

After:

<img width="766" alt="Screen Shot 2023-04-27 at 11 17 48 am" src="https://user-images.githubusercontent.com/9291586/234735356-862a01b8-bb33-49d1-b79c-530e34afd7a9.png">

```
010007000000020cb7300281000000010010a1ceebf4ae0a
- Compressed operation

0b1eaa43dcf48118dd1572d57b353103c2260c40c583132d0203139aa03b8ad7
0d122b7ca7f5af2d7b01cf50ff027d38f84426da4727216101cd62b25fd5aa7a
- BLS Signature
```

[Explorer link](https://goerli.arbiscan.io/tx/0x008af796fa304b5f205bd154560273417a60ec51e2b5a24172402b595068f698)

This is achieved by using `ExpanderEntryPoint` which uses `fallback()` in order to accept calldata bytes directly. This is superior to a function that takes a `bytes` argument, because the solidity ABI adds a surprising amount of stuff to encode that:

- 4 bytes for a method ID
- 32 bytes for the calldata offset location of the `bytes` argument
- 32 bytes for the length of the `bytes` argument
- 0-31 bytes padding at the end to ensure the calldata length is a multiple of 32

By using `fallback()`, we just accept the raw calldata directly. No method ID necessary. There is no calldata offset because we just get the full calldata unmodified. The length doesn't need to be encoded because there's an EVM instruction to get the calldata length. And the padding simply isn't needed.

## How can these changes be manually tested?

(Replicating this test isn't required.)

Register the source BLS key and address and destination address, and do an ETH transfer. View the calldata in the block explorer (or otherwise) and confirm it's under 100 bytes.

## Does this PR resolve or contribute to any issues?

Resolves #589.

## Checklist
- [x] I have manually tested these changes
- [x] Post a link to the PR in the group chat

## Guidelines
- If your PR is not ready, mark it as a draft
- The `resolve conversation` button is for reviewers, not authors
  - (But add a 'done' comment or similar)
