### PR TITLE
Merge in contract updates

### DIFF
--- a/aggregator/deps.ts
+++ b/aggregator/deps.ts
@@ -54,7 +54,7 @@ export type {
   PublicKey,
   Signature,
   VerificationGateway,
-} from "https://esm.sh/bls-wallet-clients@0.8.3-bee2034";
+} from "https://esm.sh/bls-wallet-clients@0.8.3-dc488ec";
 
 export {
   Aggregator as AggregatorClient,
@@ -70,10 +70,10 @@ export {
   getConfig,
   MockERC20Factory,
   VerificationGatewayFactory,
-} from "https://esm.sh/bls-wallet-clients@0.8.3-bee2034";
+} from "https://esm.sh/bls-wallet-clients@0.8.3-dc488ec";
 
 // Workaround for esbuild's export-star bug
-import blsWalletClients from "https://esm.sh/bls-wallet-clients@0.8.3-bee2034";
+import blsWalletClients from "https://esm.sh/bls-wallet-clients@0.8.3-dc488ec";
 const { bundleFromDto, bundleToDto, initBlsWalletSigner } = blsWalletClients;
 export { bundleFromDto, bundleToDto, initBlsWalletSigner };
 

--- a/aggregator/deps.ts
+++ b/aggregator/deps.ts
@@ -54,7 +54,7 @@ export type {
   PublicKey,
   Signature,
   VerificationGateway,
-} from "https://esm.sh/bls-wallet-clients@0.8.3-dc488ec";
+} from "https://esm.sh/bls-wallet-clients@0.8.3-0d52ddb";
 
 export {
   Aggregator as AggregatorClient,
@@ -70,10 +70,10 @@ export {
   getConfig,
   MockERC20Factory,
   VerificationGatewayFactory,
-} from "https://esm.sh/bls-wallet-clients@0.8.3-dc488ec";
+} from "https://esm.sh/bls-wallet-clients@0.8.3-0d52ddb";
 
 // Workaround for esbuild's export-star bug
-import blsWalletClients from "https://esm.sh/bls-wallet-clients@0.8.3-dc488ec";
+import blsWalletClients from "https://esm.sh/bls-wallet-clients@0.8.3-0d52ddb";
 const { bundleFromDto, bundleToDto, initBlsWalletSigner } = blsWalletClients;
 export { bundleFromDto, bundleToDto, initBlsWalletSigner };
 

--- a/aggregator/deps.ts
+++ b/aggregator/deps.ts
@@ -54,21 +54,26 @@ export type {
   PublicKey,
   Signature,
   VerificationGateway,
-} from "https://esm.sh/bls-wallet-clients@0.8.3-c34db60";
+} from "https://esm.sh/bls-wallet-clients@0.8.3-bee2034";
 
 export {
   Aggregator as AggregatorClient,
   AggregatorUtilitiesFactory,
+  BlsRegistrationCompressor,
   BlsWalletWrapper,
+  BundleCompressor,
+  ContractsConnector,
   decodeError,
+  Erc20Compressor,
   ERC20Factory,
+  FallbackCompressor,
   getConfig,
   MockERC20Factory,
   VerificationGatewayFactory,
-} from "https://esm.sh/bls-wallet-clients@0.8.3-c34db60";
+} from "https://esm.sh/bls-wallet-clients@0.8.3-bee2034";
 
 // Workaround for esbuild's export-star bug
-import blsWalletClients from "https://esm.sh/bls-wallet-clients@0.8.3-c34db60";
+import blsWalletClients from "https://esm.sh/bls-wallet-clients@0.8.3-bee2034";
 const { bundleFromDto, bundleToDto, initBlsWalletSigner } = blsWalletClients;
 export { bundleFromDto, bundleToDto, initBlsWalletSigner };
 

--- a/aggregator/manualTests/helpers/receiptOf.ts
+++ b/aggregator/manualTests/helpers/receiptOf.ts
@@ -1,0 +1,10 @@
+import { ethers } from "../../deps.ts";
+
+export default async function receiptOf(
+  responsePromise: Promise<ethers.providers.TransactionResponse>,
+): Promise<ethers.providers.TransactionReceipt> {
+  const response = await responsePromise;
+  const receipt = await response.wait();
+
+  return receipt;
+}

--- a/aggregator/manualTests/mint1ViaEthereumService.ts
+++ b/aggregator/manualTests/mint1ViaEthereumService.ts
@@ -14,8 +14,6 @@ const ethereumService = await EthereumService.create(
   (evt) => {
     console.log(evt);
   },
-  addresses.verificationGateway,
-  addresses.utilities,
   env.PRIVATE_KEY_AGG,
 );
 

--- a/aggregator/manualTests/registerWallet.ts
+++ b/aggregator/manualTests/registerWallet.ts
@@ -1,0 +1,34 @@
+#!/usr/bin/env -S deno run --allow-net --allow-env --allow-read
+
+import { ContractsConnector, ethers } from "../deps.ts";
+import * as env from "../src/env.ts";
+import AdminWallet from "../src/chain/AdminWallet.ts";
+import receiptOf from "./helpers/receiptOf.ts";
+
+const provider = new ethers.providers.JsonRpcProvider(env.RPC_URL);
+
+const adminWallet = AdminWallet(provider);
+
+const connector = await ContractsConnector.create(adminWallet);
+
+const addressRegistry = await connector.AddressRegistry();
+const blsPublicKeyRegistry = await connector.BLSPublicKeyRegistry();
+
+await receiptOf(
+  addressRegistry.register("0xCB1ca1e8DF1055636d7D07c3099c9de3c65CAAB4"),
+);
+
+await receiptOf(
+  blsPublicKeyRegistry.register(
+    // You can get this in Quill by running this in the console of the wallet
+    // page (the page you get by clicking on the extension icon)
+    // JSON.stringify(debug.wallets[0].blsWalletSigner.getPublicKey())
+
+    [
+      "0x0ad7e63a4bbfdad440beda1fe7fdfb77a59f2a6d991700c6cf4c3654a52389a9",
+      "0x0adaa93bdfda0f6b259a80c1af7ccf3451c35c1e175483927a8052bdbf59f801",
+      "0x1f56aa1bb1419c741f0a474e51f33da0ffc81ea870e2e2c440db72539a9efb9e",
+      "0x2f1f7e5d586d6ca5de3c8c198c3be3b998a2b6df7ee8a367a1e58f8b36fd524d",
+    ],
+  ),
+);

--- a/aggregator/manualTests/zeroAddressError.ts
+++ b/aggregator/manualTests/zeroAddressError.ts
@@ -15,8 +15,6 @@ const provider = new ethers.providers.JsonRpcProvider(env.RPC_URL);
 //   (evt) => {
 //     console.log(evt);
 //   },
-//   addresses.verificationGateway,
-//   addresses.utilities,
 //   env.PRIVATE_KEY_AGG,
 // );
 

--- a/aggregator/programs/helpers/shell.ts
+++ b/aggregator/programs/helpers/shell.ts
@@ -1,4 +1,6 @@
 export async function run(...cmd: string[]): Promise<void> {
+  // https://github.com/web3well/bls-wallet/issues/595
+  // deno-lint-ignore no-deprecated-deno-api
   const process = Deno.run({ cmd, stdout: "inherit", stderr: "inherit" });
 
   const unloadListener = () => {
@@ -20,6 +22,8 @@ export async function run(...cmd: string[]): Promise<void> {
 }
 
 export async function String(...cmd: string[]): Promise<string> {
+  // https://github.com/web3well/bls-wallet/issues/595
+  // deno-lint-ignore no-deprecated-deno-api
   const process = Deno.run({ cmd, stdout: "piped" });
 
   if (process.stdout === null) {

--- a/aggregator/src/app/AggregationStrategy.ts
+++ b/aggregator/src/app/AggregationStrategy.ts
@@ -459,7 +459,9 @@ export default class AggregationStrategy {
       .callStaticSequenceWithMeasure(
         feeToken
           ? es.Call(feeToken, "balanceOf", [es.wallet.address])
-          : es.Call(es.utilities, "ethBalanceOf", [es.wallet.address]),
+          : es.Call(es.aggregatorUtilities, "ethBalanceOf", [
+            es.wallet.address,
+          ]),
         bundles.map((bundle) =>
           es.Call(
             es.verificationGateway,

--- a/aggregator/src/app/AppEvent.ts
+++ b/aggregator/src/app/AppEvent.ts
@@ -15,6 +15,7 @@ type AppEvent =
     data: {
       includedRows: number;
       bundleOverheadCost: string;
+      bundleOverheadLen: number;
       expectedFee: string;
       expectedMaxCost: string;
     };
@@ -44,7 +45,12 @@ type AppEvent =
   | { type: "unprofitable-despite-breakeven-operations" }
   | {
     type: "submission-attempt";
-    data: { publicKeyShorts: string[]; attemptNumber: number };
+    data: {
+      publicKeyShorts: string[];
+      attemptNumber: number;
+      txLen: number;
+      compressedTxLen: number;
+    };
   }
   | {
     type: "submission-attempt-failed";
@@ -96,6 +102,5 @@ type AppEvent =
       duration: number;
     };
   };
-
 
 export default AppEvent;

--- a/aggregator/src/app/BundleService.ts
+++ b/aggregator/src/app/BundleService.ts
@@ -257,6 +257,7 @@ export default class BundleService {
         aggregateBundle,
         includedRows,
         bundleOverheadCost,
+        bundleOverheadLen,
         expectedFee,
         expectedMaxCost,
         failedRows,
@@ -268,6 +269,7 @@ export default class BundleService {
         data: {
           includedRows: includedRows.length,
           bundleOverheadCost: ethers.utils.formatEther(bundleOverheadCost),
+          bundleOverheadLen,
           expectedFee: ethers.utils.formatEther(expectedFee),
           expectedMaxCost: ethers.utils.formatEther(expectedMaxCost),
         },

--- a/aggregator/src/app/app.ts
+++ b/aggregator/src/app/app.ts
@@ -10,7 +10,6 @@ import errorHandler from "./errorHandler.ts";
 import notFoundHandler from "./notFoundHandler.ts";
 import Mutex from "../helpers/Mutex.ts";
 import Clock from "../helpers/Clock.ts";
-import getNetworkConfig from "../helpers/getNetworkConfig.ts";
 import AppEvent from "./AppEvent.ts";
 import BundleTable from "./BundleTable.ts";
 import AggregationStrategy from "./AggregationStrategy.ts";
@@ -19,8 +18,6 @@ import HealthService from "./HealthService.ts";
 import HealthRouter from "./HealthRouter.ts";
 
 export default async function app(emit: (evt: AppEvent) => void) {
-  const { addresses } = await getNetworkConfig();
-
   const clock = Clock.create();
 
   const bundleTableMutex = new Mutex();

--- a/aggregator/src/app/app.ts
+++ b/aggregator/src/app/app.ts
@@ -39,8 +39,6 @@ export default async function app(emit: (evt: AppEvent) => void) {
 
   const ethereumService = await EthereumService.create(
     emit,
-    addresses.verificationGateway,
-    addresses.utilities,
     env.PRIVATE_KEY_AGG,
   );
 

--- a/aggregator/test/BundleServiceFees.test.ts
+++ b/aggregator/test/BundleServiceFees.test.ts
@@ -48,13 +48,13 @@ function approveAndSendTokensToOrigin(
         contractAddress: fx.testErc20.address,
         encodedFunction: fx.testErc20.interface.encodeFunctionData(
           "approve",
-          [es.utilities.address, amount],
+          [es.aggregatorUtilities.address, amount],
         ),
       },
       {
         ethValue: 0,
-        contractAddress: es.utilities.address,
-        encodedFunction: es.utilities.interface.encodeFunctionData(
+        contractAddress: es.aggregatorUtilities.address,
+        encodedFunction: es.aggregatorUtilities.interface.encodeFunctionData(
           "sendTokenToTxOrigin",
           [fx.testErc20.address, amount],
         ),
@@ -164,8 +164,8 @@ Fixture.test("submits bundle with sufficient eth fee", async (fx) => {
       actions: [
         {
           ethValue: 1,
-          contractAddress: es.utilities.address,
-          encodedFunction: es.utilities.interface.encodeFunctionData(
+          contractAddress: es.aggregatorUtilities.address,
+          encodedFunction: es.aggregatorUtilities.interface.encodeFunctionData(
             "sendEthToTxOrigin",
           ),
         },
@@ -189,8 +189,8 @@ Fixture.test("submits bundle with sufficient eth fee", async (fx) => {
     actions: [
       {
         ethValue: fee,
-        contractAddress: es.utilities.address,
-        encodedFunction: es.utilities.interface.encodeFunctionData(
+        contractAddress: es.aggregatorUtilities.address,
+        encodedFunction: es.aggregatorUtilities.interface.encodeFunctionData(
           "sendEthToTxOrigin",
         ),
       },

--- a/aggregator/test/EthereumService.test.ts
+++ b/aggregator/test/EthereumService.test.ts
@@ -260,9 +260,9 @@ Fixture.test("callStaticSequence - correctly measures transfer", async (fx) => {
   const es = fx.ethereumService;
 
   const results = await es.callStaticSequence(
-    es.Call(es.utilities, "ethBalanceOf", [recvWallet.address]),
+    es.Call(es.aggregatorUtilities, "ethBalanceOf", [recvWallet.address]),
     es.Call(es.verificationGateway, "processBundle", [bundle]),
-    es.Call(es.utilities, "ethBalanceOf", [recvWallet.address]),
+    es.Call(es.aggregatorUtilities, "ethBalanceOf", [recvWallet.address]),
   );
 
   const [balanceResultBefore, , balanceResultAfter] = results;

--- a/aggregator/test/helpers/Fixture.ts
+++ b/aggregator/test/helpers/Fixture.ts
@@ -79,8 +79,6 @@ export default class Fixture {
 
     const ethereumService = await EthereumService.create(
       emit,
-      netCfg.addresses.verificationGateway,
-      netCfg.addresses.utilities,
       env.PRIVATE_KEY_AGG,
     );
 
@@ -296,10 +294,10 @@ export default class Fixture {
 
     return wallets;
   }
-  
+
   createHealthCheckService() {
     const healthCheckService = new HealthService();
-    
+
     return healthCheckService;
   }
 

--- a/contracts/clients/src/BlsProvider.ts
+++ b/contracts/clients/src/BlsProvider.ts
@@ -79,12 +79,12 @@ export default class BlsProvider extends ethers.providers.JsonRpcProvider {
       this,
     );
 
-    const feeEstimate = await this.aggregator.estimateFee(
-      throwawayBlsWalletWrapper.sign({
-        nonce,
-        actions: [...actionWithFeePaymentAction],
-      }),
-    );
+    const bundle = await throwawayBlsWalletWrapper.signWithGasEstimate({
+      nonce,
+      actions: [...actionWithFeePaymentAction],
+    });
+
+    const feeEstimate = await this.aggregator.estimateFee(bundle);
 
     const feeRequired = BigNumber.from(feeEstimate.feeRequired);
     return addSafetyPremiumToFee(feeRequired);

--- a/contracts/clients/src/BlsRegistrationCompressor.ts
+++ b/contracts/clients/src/BlsRegistrationCompressor.ts
@@ -165,6 +165,10 @@ export default class BlsRegistrationCompressor implements IOperationCompressor {
     return await BlsRegistrationCompressor.wrap(blsRegistration);
   }
 
+  getExpanderAddress(): string {
+    return this.blsRegistration.address;
+  }
+
   async compress(blsPublicKey: PublicKey, operation: Operation) {
     if (operation.actions.length > 2) {
       return undefined;

--- a/contracts/clients/src/BlsSigner.ts
+++ b/contracts/clients/src/BlsSigner.ts
@@ -130,7 +130,7 @@ export default class BlsSigner extends Signer {
       feeEstimate,
     );
 
-    const bundle = this.wallet.sign({
+    const bundle = await this.wallet.signWithGasEstimate({
       nonce,
       actions: [...actionsWithSafeFee],
     });
@@ -181,11 +181,13 @@ export default class BlsSigner extends Signer {
     const actionsWithFeePaymentAction =
       this.provider._addFeePaymentActionForFeeEstimation(actions);
 
+    const bundleWithFeePaymentAction = await this.wallet.signWithGasEstimate({
+      nonce,
+      actions: [...actionsWithFeePaymentAction],
+    });
+
     const feeEstimate = await this.provider.aggregator.estimateFee(
-      this.wallet.sign({
-        nonce,
-        actions: [...actionsWithFeePaymentAction],
-      }),
+      bundleWithFeePaymentAction,
     );
 
     const safeFee = addSafetyPremiumToFee(
@@ -197,7 +199,7 @@ export default class BlsSigner extends Signer {
       safeFee,
     );
 
-    const bundle = this.wallet.sign({
+    const bundle = await this.wallet.signWithGasEstimate({
       nonce,
       actions: [...actionsWithSafeFee],
     });
@@ -277,7 +279,7 @@ export default class BlsSigner extends Signer {
       feeEstimate,
     );
 
-    const bundle = this.wallet.sign({
+    const bundle = await this.wallet.signWithGasEstimate({
       nonce,
       actions: [...actionsWithSafeFee],
     });
@@ -318,11 +320,13 @@ export default class BlsSigner extends Signer {
     const actionsWithFeePaymentAction =
       this.provider._addFeePaymentActionForFeeEstimation(actions);
 
+    const bundleWithFeePaymentAction = await this.wallet.signWithGasEstimate({
+      nonce,
+      actions: [...actionsWithFeePaymentAction],
+    });
+
     const feeEstimate = await this.provider.aggregator.estimateFee(
-      this.wallet.sign({
-        nonce,
-        actions: [...actionsWithFeePaymentAction],
-      }),
+      bundleWithFeePaymentAction,
     );
 
     const safeFee = addSafetyPremiumToFee(
@@ -334,7 +338,7 @@ export default class BlsSigner extends Signer {
       safeFee,
     );
 
-    const bundle = this.wallet.sign({
+    const bundle = await this.wallet.signWithGasEstimate({
       nonce,
       actions: [...actionsWithSafeFee],
     });

--- a/contracts/clients/src/BundleCompressor.ts
+++ b/contracts/clients/src/BundleCompressor.ts
@@ -31,7 +31,13 @@ export default class BundleCompressor {
     let expanderIndexAndData: [number, string] | undefined;
 
     for (const [expanderIndex, compressor] of this.compressors) {
-      const data = await compressor.compress(blsPublicKey, operation);
+      let data: string | undefined;
+
+      try {
+        data = await compressor.compress(blsPublicKey, operation);
+      } catch {
+        continue;
+      }
 
       if (data === undefined) {
         continue;

--- a/contracts/clients/src/BundleCompressor.ts
+++ b/contracts/clients/src/BundleCompressor.ts
@@ -3,6 +3,7 @@ import { encodeVLQ, hexJoin } from "./encodeUtils";
 import IOperationCompressor from "./IOperationCompressor";
 import { Bundle, Operation, PublicKey } from "./signer";
 import Range from "./helpers/Range";
+import { BLSExpanderDelegator } from "../typechain-types";
 
 /**
  * Produces compressed bundles that can be passed to `BLSExpanderDelegator.run`
@@ -18,9 +19,24 @@ import Range from "./helpers/Range";
 export default class BundleCompressor {
   compressors: [number, IOperationCompressor][] = [];
 
+  constructor(public blsExpanderDelegator: BLSExpanderDelegator) {}
+
   /** Add an operation compressor. */
-  addCompressor(expanderIndex: number, compressor: IOperationCompressor) {
-    this.compressors.push([expanderIndex, compressor]);
+  async addCompressor(compressor: IOperationCompressor) {
+    const registrations = await this.blsExpanderDelegator.queryFilter(
+      this.blsExpanderDelegator.filters.ExpanderRegistered(
+        null,
+        compressor.getExpanderAddress(),
+      ),
+    );
+
+    const id = registrations.at(0)?.args?.id;
+
+    if (id === undefined) {
+      throw new Error("Expander not registered");
+    }
+
+    this.compressors.push([id.toNumber(), compressor]);
   }
 
   /** Compresses a single operation. */

--- a/contracts/clients/src/ContractsConnector.ts
+++ b/contracts/clients/src/ContractsConnector.ts
@@ -12,6 +12,7 @@ import {
   BLSRegistration__factory as BLSRegistrationFactory,
   BNPairingPrecompileCostEstimator__factory as BNPairingPrecompileCostEstimatorFactory,
   ERC20Expander__factory as ERC20ExpanderFactory,
+  ExpanderEntryPoint__factory as ExpanderEntryPointFactory,
   FallbackExpander__factory as FallbackExpanderFactory,
   VerificationGateway__factory as VerificationGatewayFactory,
 } from "../typechain-types";
@@ -137,6 +138,14 @@ export default class ContractsConnector {
         this.AddressRegistry().then((c) => c.address),
         this.AggregatorUtilities().then((c) => c.address),
       ]),
+      this.salt,
+    ),
+  );
+
+  ExpanderEntryPoint = once(async () =>
+    this.factoryViewer.connectOrThrow(
+      ExpanderEntryPointFactory,
+      [(await this.BLSExpanderDelegator()).address],
       this.salt,
     ),
   );

--- a/contracts/clients/src/ContractsConnector.ts
+++ b/contracts/clients/src/ContractsConnector.ts
@@ -1,0 +1,156 @@
+import { ethers } from "ethers";
+import { SafeSingletonFactoryViewer } from "./SafeSingletonFactory";
+import SignerOrProvider from "./helpers/SignerOrProvider";
+import assert from "./helpers/assert";
+import {
+  AddressRegistry__factory as AddressRegistryFactory,
+  AggregatorUtilities__factory as AggregatorUtilitiesFactory,
+  BLSExpanderDelegator__factory as BLSExpanderDelegatorFactory,
+  BLSExpander__factory as BLSExpanderFactory,
+  BLSOpen__factory as BLSOpenFactory,
+  BLSPublicKeyRegistry__factory as BLSPublicKeyRegistryFactory,
+  BLSRegistration__factory as BLSRegistrationFactory,
+  BNPairingPrecompileCostEstimator__factory as BNPairingPrecompileCostEstimatorFactory,
+  ERC20Expander__factory as ERC20ExpanderFactory,
+  FallbackExpander__factory as FallbackExpanderFactory,
+  VerificationGateway__factory as VerificationGatewayFactory,
+} from "../typechain-types";
+
+export default class ContractsConnector {
+  constructor(
+    public factoryViewer: SafeSingletonFactoryViewer,
+    public salt: ethers.utils.BytesLike = ethers.utils.solidityPack(
+      ["uint256"],
+      [0],
+    ),
+  ) {}
+
+  static async create(signerOrProvider: SignerOrProvider) {
+    let provider: ethers.providers.Provider;
+
+    if ("getNetwork" in signerOrProvider) {
+      provider = signerOrProvider;
+    } else {
+      assert(
+        signerOrProvider.provider !== undefined,
+        "When using a signer, it's required to have a provider",
+      );
+
+      provider = signerOrProvider.provider;
+    }
+
+    const chainId = (await provider.getNetwork()).chainId;
+
+    const factoryViewer = new SafeSingletonFactoryViewer(
+      signerOrProvider,
+      chainId,
+    );
+
+    return new ContractsConnector(factoryViewer);
+  }
+
+  BNPairingPrecompileCostEstimator = once(async () =>
+    this.factoryViewer.connectOrThrow(
+      BNPairingPrecompileCostEstimatorFactory,
+      [],
+      this.salt,
+    ),
+  );
+
+  BLSOpen = once(() =>
+    this.factoryViewer.connectOrThrow(BLSOpenFactory, [], this.salt),
+  );
+
+  VerificationGateway = once(async () =>
+    this.factoryViewer.connectOrThrow(
+      VerificationGatewayFactory,
+      [(await this.BLSOpen()).address],
+      this.salt,
+    ),
+  );
+
+  AggregatorUtilities = once(async () =>
+    this.factoryViewer.connectOrThrow(
+      AggregatorUtilitiesFactory,
+      [],
+      this.salt,
+    ),
+  );
+
+  BLSExpander = once(async () =>
+    this.factoryViewer.connectOrThrow(
+      BLSExpanderFactory,
+      [(await this.VerificationGateway()).address],
+      this.salt,
+    ),
+  );
+
+  BLSExpanderDelegator = once(async () =>
+    this.factoryViewer.connectOrThrow(
+      BLSExpanderDelegatorFactory,
+      [(await this.VerificationGateway()).address],
+      this.salt,
+    ),
+  );
+
+  BLSPublicKeyRegistry = once(async () =>
+    this.factoryViewer.connectOrThrow(
+      BLSPublicKeyRegistryFactory,
+      [],
+      this.salt,
+    ),
+  );
+
+  AddressRegistry = once(async () =>
+    this.factoryViewer.connectOrThrow(AddressRegistryFactory, [], this.salt),
+  );
+
+  FallbackExpander = once(async () =>
+    this.factoryViewer.connectOrThrow(
+      FallbackExpanderFactory,
+      await Promise.all([
+        this.BLSPublicKeyRegistry().then((c) => c.address),
+        this.AddressRegistry().then((c) => c.address),
+        this.AggregatorUtilities().then((c) => c.address),
+      ]),
+      this.salt,
+    ),
+  );
+
+  BLSRegistration = once(async () =>
+    this.factoryViewer.connectOrThrow(
+      BLSRegistrationFactory,
+      await Promise.all([
+        this.BLSPublicKeyRegistry().then((c) => c.address),
+        this.AddressRegistry().then((c) => c.address),
+        this.AggregatorUtilities().then((c) => c.address),
+      ]),
+      this.salt,
+    ),
+  );
+
+  ERC20Expander = once(async () =>
+    this.factoryViewer.connectOrThrow(
+      ERC20ExpanderFactory,
+      await Promise.all([
+        this.BLSPublicKeyRegistry().then((c) => c.address),
+        this.AddressRegistry().then((c) => c.address),
+        this.AggregatorUtilities().then((c) => c.address),
+      ]),
+      this.salt,
+    ),
+  );
+}
+
+function once<T extends {}>(fn: () => T): () => T {
+  let result: T | undefined;
+
+  return () => {
+    if (result === undefined) {
+      result = fn();
+      (fn as unknown as undefined) = undefined;
+    }
+
+    return result;
+  };
+}

--- a/contracts/clients/src/Erc20Compressor.ts
+++ b/contracts/clients/src/Erc20Compressor.ts
@@ -221,8 +221,6 @@ export default class Erc20Compressor implements IOperationCompressor {
         result.push(encodeRegIndex(addressId));
       }
 
-      // TODO: Be different here
-
       const success = await this.compressFunctionCall(
         action.encodedFunction,
         result,

--- a/contracts/clients/src/Erc20Compressor.ts
+++ b/contracts/clients/src/Erc20Compressor.ts
@@ -1,0 +1,392 @@
+import { BigNumber, ethers, Signer } from "ethers";
+import {
+  AddressRegistry__factory as AddressRegistryFactory,
+  BLSPublicKeyRegistry__factory as BLSPublicKeyRegistryFactory,
+  ERC20Expander,
+  ERC20Expander__factory as ERC20ExpanderFactory,
+  AggregatorUtilities,
+  AggregatorUtilities__factory as AggregatorUtilitiesFactory,
+} from "../typechain-types";
+import AddressRegistryWrapper from "./AddressRegistryWrapper";
+import BlsPublicKeyRegistryWrapper from "./BlsPublicKeyRegistryWrapper";
+import {
+  encodeBitStream,
+  encodePseudoFloat,
+  encodeRegIndex,
+  encodeVLQ,
+  hexJoin,
+} from "./encodeUtils";
+import SignerOrProvider from "./helpers/SignerOrProvider";
+import IOperationCompressor from "./IOperationCompressor";
+import SafeSingletonFactory, {
+  SafeSingletonFactoryViewer,
+} from "./SafeSingletonFactory";
+import { ActionData, Operation, PublicKey } from "./signer/types";
+
+export default class Erc20Compressor implements IOperationCompressor {
+  private constructor(
+    public erc20Expander: ERC20Expander,
+    public blsPublicKeyRegistry: BlsPublicKeyRegistryWrapper,
+    public addressRegistry: AddressRegistryWrapper,
+    public aggregatorUtilities: AggregatorUtilities,
+  ) {}
+
+  static async wrap(erc20Expander: ERC20Expander): Promise<Erc20Compressor> {
+    const [
+      blsPublicKeyRegistryAddress,
+      addressRegistryAddress,
+      aggregatorUtilitiesAddress,
+    ] = await Promise.all([
+      erc20Expander.blsPublicKeyRegistry(),
+      erc20Expander.addressRegistry(),
+      erc20Expander.aggregatorUtilities(),
+    ]);
+
+    return new Erc20Compressor(
+      erc20Expander,
+      new BlsPublicKeyRegistryWrapper(
+        BLSPublicKeyRegistryFactory.connect(
+          blsPublicKeyRegistryAddress,
+          erc20Expander.signer,
+        ),
+      ),
+      new AddressRegistryWrapper(
+        AddressRegistryFactory.connect(
+          addressRegistryAddress,
+          erc20Expander.signer,
+        ),
+      ),
+      AggregatorUtilitiesFactory.connect(
+        aggregatorUtilitiesAddress,
+        erc20Expander.signer,
+      ),
+    );
+  }
+
+  static async deployNew(signer: Signer): Promise<Erc20Compressor> {
+    const blsPublicKeyRegistryFactory = new BLSPublicKeyRegistryFactory(signer);
+    const addressRegistryFactory = new AddressRegistryFactory(signer);
+    const aggregatorUtilitiesFactory = new AggregatorUtilitiesFactory(signer);
+
+    const [
+      blsPublicKeyRegistryContract,
+      addressRegistryContract,
+      aggregatorUtilitiesContract,
+    ] = await Promise.all([
+      blsPublicKeyRegistryFactory.deploy(),
+      addressRegistryFactory.deploy(),
+      aggregatorUtilitiesFactory.deploy(),
+    ]);
+
+    const erc20ExpanderFactory = new ERC20ExpanderFactory(signer);
+
+    const erc20ExpanderContract = await erc20ExpanderFactory.deploy(
+      blsPublicKeyRegistryContract.address,
+      addressRegistryContract.address,
+      aggregatorUtilitiesContract.address,
+    );
+
+    return new Erc20Compressor(
+      erc20ExpanderContract,
+      new BlsPublicKeyRegistryWrapper(blsPublicKeyRegistryContract),
+      new AddressRegistryWrapper(addressRegistryContract),
+      aggregatorUtilitiesContract,
+    );
+  }
+
+  static async connectOrDeploy(
+    signerOrFactory: Signer | SafeSingletonFactory,
+    salt: ethers.utils.BytesLike = ethers.utils.solidityPack(["uint256"], [0]),
+  ): Promise<Erc20Compressor> {
+    const factory = await SafeSingletonFactory.from(signerOrFactory);
+
+    const [blsPublicKeyRegistry, addressRegistry, aggregatorUtilities] =
+      await Promise.all([
+        BlsPublicKeyRegistryWrapper.connectOrDeploy(factory, salt),
+        AddressRegistryWrapper.connectOrDeploy(factory, salt),
+        factory.connectOrDeploy(AggregatorUtilitiesFactory, [], salt),
+      ]);
+
+    const erc20ExpanderContract = await factory.connectOrDeploy(
+      ERC20ExpanderFactory,
+      [
+        blsPublicKeyRegistry.registry.address,
+        addressRegistry.registry.address,
+        aggregatorUtilities.address,
+      ],
+      salt,
+    );
+
+    return new Erc20Compressor(
+      erc20ExpanderContract,
+      blsPublicKeyRegistry,
+      addressRegistry,
+      aggregatorUtilities,
+    );
+  }
+
+  static async connectIfDeployed(
+    signerOrProvider: SignerOrProvider,
+    salt: ethers.utils.BytesLike = ethers.utils.solidityPack(["uint256"], [0]),
+  ): Promise<Erc20Compressor | undefined> {
+    const factoryViewer = await SafeSingletonFactoryViewer.from(
+      signerOrProvider,
+    );
+
+    const [
+      blsPublicKeyRegistryAddress,
+      addressRegistryAddress,
+      aggregatorUtilitiesAddress,
+    ] = await Promise.all([
+      factoryViewer.calculateAddress(BLSPublicKeyRegistryFactory, [], salt),
+      factoryViewer.calculateAddress(AddressRegistryFactory, [], salt),
+      factoryViewer.calculateAddress(AggregatorUtilitiesFactory, [], salt),
+    ]);
+
+    const erc20Expander = await factoryViewer.connectIfDeployed(
+      ERC20ExpanderFactory,
+      [
+        blsPublicKeyRegistryAddress,
+        addressRegistryAddress,
+        aggregatorUtilitiesAddress,
+      ],
+      salt,
+    );
+
+    if (!erc20Expander) {
+      return undefined;
+    }
+
+    return await Erc20Compressor.wrap(erc20Expander);
+  }
+
+  async compress(blsPublicKey: PublicKey, operation: Operation) {
+    const result: string[] = [];
+
+    const resultIndexForRegUsageBitStream = result.length;
+    const bitStream: boolean[] = [];
+    result.push("0x"); // Placeholder to overwrite
+
+    const blsPublicKeyId = await this.blsPublicKeyRegistry.reverseLookup(
+      blsPublicKey,
+    );
+
+    if (blsPublicKeyId === undefined) {
+      bitStream.push(false);
+
+      result.push(
+        ethers.utils.defaultAbiCoder.encode(["uint256[4]"], [blsPublicKey]),
+      );
+    } else {
+      bitStream.push(true);
+      result.push(encodeRegIndex(blsPublicKeyId));
+    }
+
+    result.push(encodeVLQ(operation.nonce));
+    result.push(encodePseudoFloat(operation.gas));
+
+    result.push(encodeVLQ(operation.actions.length));
+
+    const lastAction = operation.actions.at(-1);
+    let txOriginPaymentAction: ActionData | undefined;
+
+    let regularActions: ActionData[];
+
+    if (
+      lastAction !== undefined &&
+      lastAction.contractAddress === this.aggregatorUtilities.address &&
+      ethers.utils.hexlify(lastAction.encodedFunction) ===
+        this.aggregatorUtilities.interface.encodeFunctionData(
+          "sendEthToTxOrigin",
+        )
+    ) {
+      bitStream.push(true);
+      txOriginPaymentAction = lastAction;
+      regularActions = operation.actions.slice(0, -1);
+    } else {
+      bitStream.push(false);
+      regularActions = operation.actions;
+    }
+
+    for (const action of regularActions) {
+      const addressId = await this.addressRegistry.reverseLookup(
+        action.contractAddress,
+      );
+
+      if (addressId === undefined) {
+        bitStream.push(false);
+        result.push(action.contractAddress);
+      } else {
+        bitStream.push(true);
+        result.push(encodeRegIndex(addressId));
+      }
+
+      // TODO: Be different here
+
+      const success = await this.compressFunctionCall(
+        action.encodedFunction,
+        result,
+        bitStream,
+      );
+
+      if (!success) {
+        return undefined;
+      }
+    }
+
+    if (txOriginPaymentAction !== undefined) {
+      result.push(encodePseudoFloat(txOriginPaymentAction.ethValue));
+    }
+
+    result[resultIndexForRegUsageBitStream] = encodeBitStream(bitStream);
+
+    return hexJoin(result);
+  }
+
+  private async compressFunctionCall(
+    encodedFunction: ethers.utils.BytesLike,
+    result: string[],
+    bitStream: boolean[],
+  ): Promise<boolean> {
+    const encodedFunctionHex = ethers.utils.hexlify(encodedFunction);
+    const parametersHex = ethers.utils.hexDataSlice(encodedFunctionHex, 4);
+
+    if (isMethod("transfer(address,uint256)", encodedFunction)) {
+      return this.compressTransfer(parametersHex, result, bitStream);
+    }
+
+    if (isMethod("transferFrom(address,address,uint256)", encodedFunction)) {
+      return this.compressTransferFrom(parametersHex, result, bitStream);
+    }
+
+    if (isMethod("approve(address,uint256)", encodedFunction)) {
+      return this.compressApprove(parametersHex, result, bitStream);
+    }
+
+    if (isMethod("mint(address,uint256)", encodedFunction)) {
+      return this.compressMint(parametersHex, result, bitStream);
+    }
+
+    return false;
+  }
+
+  private async compressTransfer(
+    parametersHex: string,
+    result: string[],
+    bitStream: boolean[],
+  ): Promise<boolean> {
+    if (ethers.utils.hexDataLength(parametersHex) !== 2 * 32) {
+      return false;
+    }
+
+    result.push(encodeVLQ(0));
+
+    const [to, value] = ethers.utils.defaultAbiCoder.decode(
+      ["address", "uint256"],
+      parametersHex,
+    ) as [string, BigNumber];
+
+    await this.compressAddress(to, result, bitStream);
+    result.push(encodePseudoFloat(value));
+
+    return true;
+  }
+
+  private async compressTransferFrom(
+    parametersHex: string,
+    result: string[],
+    bitStream: boolean[],
+  ): Promise<boolean> {
+    if (ethers.utils.hexDataLength(parametersHex) !== 3 * 32) {
+      return false;
+    }
+
+    result.push(encodeVLQ(1));
+
+    const [from, to, value] = ethers.utils.defaultAbiCoder.decode(
+      ["address", "address", "uint256"],
+      parametersHex,
+    ) as [string, string, BigNumber];
+
+    await this.compressAddress(from, result, bitStream);
+    await this.compressAddress(to, result, bitStream);
+    result.push(encodePseudoFloat(value));
+
+    return true;
+  }
+
+  private async compressApprove(
+    parametersHex: string,
+    result: string[],
+    bitStream: boolean[],
+  ): Promise<boolean> {
+    if (ethers.utils.hexDataLength(parametersHex) !== 2 * 32) {
+      return false;
+    }
+
+    const [spender, value] = ethers.utils.defaultAbiCoder.decode(
+      ["address", "uint256"],
+      parametersHex,
+    ) as [string, BigNumber];
+
+    if (value.eq(ethers.constants.MaxUint256)) {
+      result.push(encodeVLQ(3));
+      await this.compressAddress(spender, result, bitStream);
+    } else {
+      result.push(encodeVLQ(2));
+      await this.compressAddress(spender, result, bitStream);
+      result.push(encodePseudoFloat(value));
+    }
+
+    return true;
+  }
+
+  private async compressMint(
+    parametersHex: string,
+    result: string[],
+    bitStream: boolean[],
+  ): Promise<boolean> {
+    if (ethers.utils.hexDataLength(parametersHex) !== 2 * 32) {
+      return false;
+    }
+
+    result.push(encodeVLQ(4));
+
+    const [to, value] = ethers.utils.defaultAbiCoder.decode(
+      ["address", "uint256"],
+      parametersHex,
+    ) as [string, BigNumber];
+
+    await this.compressAddress(to, result, bitStream);
+    result.push(encodePseudoFloat(value));
+
+    return true;
+  }
+
+  private async compressAddress(
+    address: string,
+    result: string[],
+    bitStream: boolean[],
+  ) {
+    const addressId = await this.addressRegistry.reverseLookup(address);
+
+    if (addressId === undefined) {
+      bitStream.push(false);
+      result.push(address);
+    } else {
+      bitStream.push(true);
+      result.push(encodeRegIndex(addressId));
+    }
+  }
+}
+
+function isMethod(
+  signature: string,
+  encodedFunction: ethers.utils.BytesLike,
+): boolean {
+  const methodId = ethers.utils
+    .keccak256(ethers.utils.toUtf8Bytes(signature))
+    .slice(0, 10);
+
+  return ethers.utils.hexlify(encodedFunction).startsWith(methodId);
+}

--- a/contracts/clients/src/Erc20Compressor.ts
+++ b/contracts/clients/src/Erc20Compressor.ts
@@ -160,6 +160,10 @@ export default class Erc20Compressor implements IOperationCompressor {
     return await Erc20Compressor.wrap(erc20Expander);
   }
 
+  getExpanderAddress(): string {
+    return this.erc20Expander.address;
+  }
+
   async compress(blsPublicKey: PublicKey, operation: Operation) {
     const result: string[] = [];
 

--- a/contracts/clients/src/FallbackCompressor.ts
+++ b/contracts/clients/src/FallbackCompressor.ts
@@ -162,6 +162,10 @@ export default class FallbackCompressor implements IOperationCompressor {
     return await FallbackCompressor.wrap(fallbackExpander);
   }
 
+  getExpanderAddress(): string {
+    return this.fallbackExpander.address;
+  }
+
   async compress(blsPublicKey: PublicKey, operation: Operation) {
     const result: string[] = [];
 

--- a/contracts/clients/src/IOperationCompressor.ts
+++ b/contracts/clients/src/IOperationCompressor.ts
@@ -1,6 +1,8 @@
 import { Operation, PublicKey } from "./signer";
 
 type IOperationCompressor = {
+  getExpanderAddress(): string;
+
   compress(
     blsPublicKey: PublicKey,
     operation: Operation,

--- a/contracts/clients/src/NetworkConfig.ts
+++ b/contracts/clients/src/NetworkConfig.ts
@@ -23,11 +23,15 @@ export type NetworkConfig = {
   auxiliary: {
     chainid: number;
     /**
-     * Domain used for BLS signing
+     * Domain used for signing BLS Proof of Possession messages
      */
-    domain: string;
+    walletDomain: string;
     /**
-     * Starting block contracts began dpeloyment at
+     * Domain used for signing BLS Bundle messages
+     */
+    bundleDomain: string;
+    /**
+     * Starting block contracts began deployment at
      */
     genesisBlock: number;
     /**
@@ -64,7 +68,8 @@ export function validateConfig(cfg: UnvalidatedConfig): NetworkConfig {
     },
     auxiliary: {
       chainid: assertNumber(cfg.auxiliary.chainid),
-      domain: assertString(cfg.auxiliary.domain),
+      walletDomain: assertString(cfg.auxiliary.walletDomain),
+      bundleDomain: assertString(cfg.auxiliary.bundleDomain),
       genesisBlock: assertNumber(cfg.auxiliary.genesisBlock),
       deployedBy: assertString(cfg.auxiliary.deployedBy),
       version: assertString(cfg.auxiliary.version),

--- a/contracts/clients/src/SafeSingletonFactory.ts
+++ b/contracts/clients/src/SafeSingletonFactory.ts
@@ -15,11 +15,11 @@ type NonOptionalElementsOf<A extends unknown[]> = A extends [
   ? []
   : never;
 
-type ContractFactoryConstructor = {
+export type ContractFactoryConstructor = {
   new (): ethers.ContractFactory;
 };
 
-type DeployParams<CFC extends ContractFactoryConstructor> =
+export type DeployParams<CFC extends ContractFactoryConstructor> =
   NonOptionalElementsOf<Parameters<InstanceType<CFC>["deploy"]>>;
 
 type Deployment = {
@@ -345,6 +345,32 @@ export class SafeSingletonFactoryViewer {
 
     if (this.signer) {
       contract = contract.connect(this.signer) as typeof contract;
+    }
+
+    return contract;
+  }
+
+  async connectOrThrow<CFC extends ContractFactoryConstructor>(
+    ContractFactoryConstructor: CFC,
+    deployParams: DeployParams<CFC>,
+    salt: ethers.utils.BytesLike = ethers.utils.solidityPack(["uint256"], [0]),
+  ): Promise<ReturnType<InstanceType<CFC>["attach"]>> {
+    const contract = await this.connectIfDeployed(
+      ContractFactoryConstructor,
+      deployParams,
+      salt,
+    );
+
+    if (!contract) {
+      throw new Error(
+        `Contract ${
+          ContractFactoryConstructor.name
+        } not deployed at ${this.calculateAddress(
+          ContractFactoryConstructor,
+          deployParams,
+          salt,
+        )}`,
+      );
     }
 
     return contract;

--- a/contracts/clients/src/SafeSingletonFactory.ts
+++ b/contracts/clients/src/SafeSingletonFactory.ts
@@ -224,7 +224,9 @@ export default class SafeSingletonFactory {
 
       throw new Error(
         [
-          "Insufficient funds:",
+          "Account",
+          await this.signer.getAddress(),
+          "has insufficient funds:",
           ethers.utils.formatEther(balance),
           "ETH, need (approx):",
           ethers.utils.formatEther(gasEstimate.mul(gasPrice)),

--- a/contracts/clients/src/index.ts
+++ b/contracts/clients/src/index.ts
@@ -42,4 +42,5 @@ export { default as FallbackCompressor } from "./FallbackCompressor";
 export { default as Erc20Compressor } from "./Erc20Compressor";
 export { default as BlsRegistrationCompressor } from "./BlsRegistrationCompressor";
 export { default as BundleCompressor } from "./BundleCompressor";
+export { default as ContractsConnector } from "./ContractsConnector";
 export * from "./encodeUtils";

--- a/contracts/clients/src/index.ts
+++ b/contracts/clients/src/index.ts
@@ -37,6 +37,7 @@ export {
 export { default as AddressRegistryWrapper } from "./AddressRegistryWrapper";
 export { default as BlsPublicKeyRegistryWrapper } from "./BlsPublicKeyRegistryWrapper";
 export { default as FallbackCompressor } from "./FallbackCompressor";
+export { default as Erc20Compressor } from "./Erc20Compressor";
 export { default as BlsRegistrationCompressor } from "./BlsRegistrationCompressor";
 export { default as BundleCompressor } from "./BundleCompressor";
 export * from "./encodeUtils";

--- a/contracts/clients/src/signer/getDomain.ts
+++ b/contracts/clients/src/signer/getDomain.ts
@@ -2,13 +2,15 @@ import { arrayify, solidityPack } from "ethers/lib/utils";
 import { utils } from "ethers";
 
 export default (
+  name: string,
+  version: string,
   chainId: number,
   verificationGatewayAddress: string,
   type: string,
 ): Uint8Array => {
   const encoded = solidityPack(
-    ["uint256", "address", "string"],
-    [chainId, verificationGatewayAddress, type],
+    ["string", "string", "uint256", "address", "string"],
+    [name, version, chainId, verificationGatewayAddress, type],
   );
 
   return arrayify(utils.keccak256(encoded));

--- a/contracts/clients/src/signer/index.ts
+++ b/contracts/clients/src/signer/index.ts
@@ -32,8 +32,23 @@ export async function initBlsWalletSigner({
   // properly initialized for all use cases, not just signing.
   const signerFactory = await signer.BlsSignerFactory.new();
 
-  const bundleDomain = getDomain(chainId, verificationGatewayAddress, "Bundle");
-  const walletDomain = getDomain(chainId, verificationGatewayAddress, "Wallet");
+  const domainName = "BLS_WALLET";
+  const domainVersion = "1";
+
+  const bundleDomain = getDomain(
+    domainName,
+    domainVersion,
+    chainId,
+    verificationGatewayAddress,
+    "Bundle",
+  );
+  const walletDomain = getDomain(
+    domainName,
+    domainVersion,
+    chainId,
+    verificationGatewayAddress,
+    "Wallet",
+  );
 
   return {
     aggregate,

--- a/contracts/clients/test/config.test.ts
+++ b/contracts/clients/test/config.test.ts
@@ -20,7 +20,8 @@ const getSingleConfig = (networkKey: string): NetworkConfig => ({
   },
   auxiliary: {
     chainid: 123,
-    domain: getValue(networkKey, "domain"),
+    walletDomain: getValue(networkKey, "walletDomain"),
+    bundleDomain: getValue(networkKey, "bundleDomain"),
     genesisBlock: 456,
     deployedBy: getValue(networkKey, "deployedBy"),
     version: getValue(networkKey, "version"),

--- a/contracts/clients/test/index.test.ts
+++ b/contracts/clients/test/index.test.ts
@@ -61,8 +61,8 @@ describe("index", () => {
     const bundle = sign(bundleTemplate, walletAddress);
 
     expect(bundle.signature).to.deep.equal([
-      "0x21135f40b38f55236ceb637ad8f2d6d4e8081bc1c37ea08273838f839008b9cd",
-      "0x16515fb0821c039e127dd8e4a70c7004aec1baf698802fc16e7cf8d2ae0bb14a",
+      "0x117171c1a4af03133390b454989658d9c6ae7a7fe1c3958ad545e584e63ab5e3",
+      "0x2f90b24bbc03de665816b3a632e0c7b5fb837c87541d9337480671613cf1359c",
     ]);
 
     expect(verify(bundle, walletAddress)).to.equal(true);
@@ -127,8 +127,8 @@ describe("index", () => {
     const aggBundle = aggregate([bundle1, bundle2]);
 
     expect(aggBundle.signature).to.deep.equal([
-      "0x20c3afd45d2c7cd72003752377cf6853569bccd23abf962967a9245091b69c3b",
-      "0x1ff4a18f1e920206f849e50df41e7bab6377d3908a8198d9c9268ca01ae70552",
+      "0x18b917c1f52155d9748025bd94aa07c0017af31dd2ef2a00289931f660e88ec9",
+      "0x0235a99bcd1f0793efb7f3307cd349f211a433f60cfab795f5f976298f17a768",
     ]);
 
     expect(verify(bundle1, walletAddress)).to.equal(true);

--- a/contracts/contracts/BLSExpanderDelegator.sol
+++ b/contracts/contracts/BLSExpanderDelegator.sol
@@ -20,7 +20,10 @@ contract BLSExpanderDelegator {
     uint8 constant BLS_KEY_LEN = 4;
 
     IBundleProcessor gateway;
+
+    uint256 public nextExpanderId = 0;
     mapping(uint256 => IExpander) public expanders;
+    event ExpanderRegistered(uint256 id, IExpander indexed expanderAddress);
 
     constructor(IBundleProcessor gatewayParam) {
         gateway = gatewayParam;
@@ -80,14 +83,12 @@ contract BLSExpanderDelegator {
     }
 
     function registerExpander(
-        uint256 expanderIndex,
         IExpander expander
     ) external {
-        require(
-            expanders[expanderIndex] == IExpander(address(0)),
-            "Index not available"
-        );
+        uint256 expanderId = nextExpanderId;
+        nextExpanderId += 1;
+        expanders[expanderId] = expander;
 
-        expanders[expanderIndex] = expander;
+        emit ExpanderRegistered(expanderId, expander);
     }
 }

--- a/contracts/contracts/ERC20Expander.sol
+++ b/contracts/contracts/ERC20Expander.sol
@@ -1,0 +1,263 @@
+//SPDX-License-Identifier: Unlicense
+pragma solidity >=0.7.0 <0.9.0;
+pragma abicoder v2;
+
+import "./AddressRegistry.sol";
+import "./BLSPublicKeyRegistry.sol";
+import "./AggregatorUtilities.sol";
+import "./lib/RegIndex.sol";
+import "./lib/VLQ.sol";
+import "./lib/PseudoFloat.sol";
+import "./interfaces/IExpander.sol";
+import "./interfaces/IWallet.sol";
+
+/**
+ * TODO
+ */
+contract ERC20Expander is IExpander {
+    BLSPublicKeyRegistry public blsPublicKeyRegistry;
+    AddressRegistry public addressRegistry;
+    AggregatorUtilities public aggregatorUtilities;
+
+    constructor(
+        BLSPublicKeyRegistry blsPublicKeyRegistryParam,
+        AddressRegistry addressRegistryParam,
+        AggregatorUtilities aggregatorUtilitiesParam
+    ) {
+        blsPublicKeyRegistry = blsPublicKeyRegistryParam;
+        addressRegistry = addressRegistryParam;
+        aggregatorUtilities = aggregatorUtilitiesParam;
+    }
+
+    function expand(bytes calldata stream) external view returns (
+        uint256[4] memory senderPublicKey,
+        IWallet.Operation memory operation,
+        uint256 bytesRead
+    ) {
+        uint256 originalStreamLen = stream.length;
+        uint256 decodedValue;
+        bool decodedBit;
+        uint256 bitStream;
+
+        (bitStream, stream) = VLQ.decode(stream);
+
+        (decodedBit, bitStream) = decodeBit(
+            bitStream
+        );
+
+        if (decodedBit) {
+            (decodedValue, stream) = RegIndex.decode(stream);
+            senderPublicKey = blsPublicKeyRegistry.lookup(decodedValue);
+        } else {
+            senderPublicKey = abi.decode(stream[:128], (uint256[4]));
+            stream = stream[128:];
+        }
+
+        (decodedValue, stream) = VLQ.decode(stream);
+        operation.nonce = decodedValue;
+
+        (decodedValue, stream) = PseudoFloat.decode(stream);
+        operation.gas = decodedValue;
+
+        uint256 actionLen;
+        (actionLen, stream) = VLQ.decode(stream);
+        operation.actions = new IWallet.ActionData[](actionLen);
+
+        // hasTxOriginPayment
+        (decodedBit, bitStream) = decodeBit(bitStream);
+
+        if (decodedBit) {
+            // We would use a separate variable for this, but the solidity
+            // compiler makes it important to minimize local variables.
+            actionLen -= 1;
+        }
+
+        for (uint256 i = 0; i < actionLen; i++) {
+            (
+                operation.actions[i].contractAddress,
+                stream,
+                bitStream
+            ) = decodeAddress(
+                stream,
+                bitStream
+            );
+
+            (
+                operation.actions[i].encodedFunction,
+                stream,
+                bitStream
+            ) = decodeFunctionCall(
+                stream,
+                bitStream
+            );
+        }
+
+        if (actionLen < operation.actions.length) {
+            (decodedValue, stream) = PseudoFloat.decode(stream);
+
+            operation.actions[actionLen] = IWallet.ActionData({
+                ethValue: decodedValue,
+                contractAddress: address(aggregatorUtilities),
+                encodedFunction: abi.encodeWithSignature("sendEthToTxOrigin()")
+            });
+        }
+
+        bytesRead = originalStreamLen - stream.length;
+    }
+
+    function decodeBit(uint256 bitStream) internal pure returns (bool, uint256) {
+        return ((bitStream & 1) == 1, bitStream >> 1);
+    }
+
+    // Following the naming convention this would be called
+    // decodeEncodedFunction, but that's pretty confusing.
+    function decodeFunctionCall(
+        bytes calldata stream,
+        uint256 bitStream
+    ) internal view returns (
+        bytes memory,
+        bytes calldata,
+        uint256
+    ) {
+        uint256 methodIndex;
+        (methodIndex, stream) = VLQ.decode(stream);
+
+        if (methodIndex == 0) {
+            return decodeTransfer(stream, bitStream);
+        }
+
+        if (methodIndex == 1) {
+            return decodeTransferFrom(stream, bitStream);
+        }
+
+        if (methodIndex == 2) {
+            return decodeApprove(stream, bitStream);
+        }
+
+        if (methodIndex == 3) {
+            // Not a real method, but uint256Max is common for approve, and is
+            // not represented efficiently by PseudoFloat.
+            return decodeApproveMax(stream, bitStream);
+        }
+
+        revert("Unrecognized ERC20 method index");
+    }
+
+    function decodeTransfer(
+        bytes calldata stream,
+        uint256 bitStream
+    ) internal view returns (
+        bytes memory,
+        bytes calldata,
+        uint256
+    ) {
+        address to;
+        (to, stream, bitStream) = decodeAddress(stream, bitStream);
+
+        uint256 value;
+        (value, stream) = PseudoFloat.decode(stream);
+
+        return (
+            abi.encodeWithSignature("transfer(address,uint256)", to, value),
+            stream,
+            bitStream
+        );
+    }
+    
+    function decodeTransferFrom(
+        bytes calldata stream,
+        uint256 bitStream
+    ) internal view returns (
+        bytes memory,
+        bytes calldata,
+        uint256
+    ) {
+        address from;
+        (from, stream, bitStream) = decodeAddress(stream, bitStream);
+
+        address to;
+        (to, stream, bitStream) = decodeAddress(stream, bitStream);
+
+        uint256 value;
+        (value, stream) = PseudoFloat.decode(stream);
+
+        return (
+            abi.encodeWithSignature(
+                "transferFrom(address,address,uint256)",
+                from,
+                to,
+                value
+            ),
+            stream,
+            bitStream
+        );
+    }
+    
+    function decodeApprove(
+        bytes calldata stream,
+        uint256 bitStream
+    ) internal view returns (
+        bytes memory,
+        bytes calldata,
+        uint256
+    ) {
+        address spender;
+        (spender, stream, bitStream) = decodeAddress(stream, bitStream);
+
+        uint256 value;
+        (value, stream) = PseudoFloat.decode(stream);
+
+        return (
+            abi.encodeWithSignature(
+                "approve(address,uint256)",
+                spender,
+                value
+            ),
+            stream,
+            bitStream
+        );
+    }
+    
+    function decodeApproveMax(
+        bytes calldata stream,
+        uint256 bitStream
+    ) internal view returns (
+        bytes memory,
+        bytes calldata,
+        uint256
+    ) {
+        address spender;
+        (spender, stream, bitStream) = decodeAddress(stream, bitStream);
+
+        return (
+            abi.encodeWithSignature(
+                "approve(address,uint256)",
+                spender,
+                type(uint256).max
+            ),
+            stream,
+            bitStream
+        );
+    }
+
+    function decodeAddress(
+        bytes calldata stream,
+        uint256 bitStream
+    ) internal view returns (
+        address,
+        bytes calldata,
+        uint256
+    ) {
+        uint256 decodedValue;
+        bool decodedBit;
+
+        (decodedBit, bitStream) = decodeBit(bitStream);
+
+        if (decodedBit) {
+            (decodedValue, stream) = RegIndex.decode(stream);
+            return (addressRegistry.lookup(decodedValue), stream, bitStream);
+        }
+
+        return (address(bytes20(stream[:20])), stream[20:], bitStream);
+    }
+}

--- a/contracts/contracts/ERC20Expander.sol
+++ b/contracts/contracts/ERC20Expander.sol
@@ -12,7 +12,35 @@ import "./interfaces/IExpander.sol";
 import "./interfaces/IWallet.sol";
 
 /**
- * TODO
+ * An expander that supports ERC20 operations.
+ *
+ * This is a bit of a first pass, it could be more compact:
+ * - Optimize specifically for transfer
+ * - Require registries, removing the need for a bit stream
+ * - Use a fixed gas value
+ * - Use a dedicated ERC20 registry, allowing a single byte for popular
+ *   currencies (and 2 bytes for all but the most obscure currencies)
+ * - Use a fixed tx.origin reward (or call contract that computes an appropriate
+ *   reward)
+ *
+ * This would get us down to about 11 bytes. (Current example is 20 bytes.)
+ *
+ * Example:
+ *
+ * 0f      - 0x0f = 0b1111 bit stream:
+ *           - 1: Use registry for BLS key
+ *           - 1: Include a tx.origin payment
+ *           - 1: Use registry for ERC20 address
+ *           - 1: Use registry for recipient address
+ * 000000  - Registry index for sendWallet's public key
+ * 00      - nonce: 0
+ * 0bda28  - gas: 92,483
+ * 02      - two actions
+ * 000000  - Registry index for ERC20 address
+ * 00      - transfer
+ * 000002  - Registry index for recipient address
+ * 9100    - 0.1 MCK (amount/value)
+ * 6d00    - Pay 0.000005 ETH to tx.origin
  */
 contract ERC20Expander is IExpander {
     BLSPublicKeyRegistry public blsPublicKeyRegistry;

--- a/contracts/contracts/ERC20Expander.sol
+++ b/contracts/contracts/ERC20Expander.sol
@@ -140,6 +140,10 @@ contract ERC20Expander is IExpander {
             return decodeApproveMax(stream, bitStream);
         }
 
+        if (methodIndex == 4) {
+            return decodeMint(stream, bitStream);
+        }
+
         revert("Unrecognized ERC20 method index");
     }
 
@@ -235,6 +239,27 @@ contract ERC20Expander is IExpander {
                 spender,
                 type(uint256).max
             ),
+            stream,
+            bitStream
+        );
+    }
+
+    function decodeMint(
+        bytes calldata stream,
+        uint256 bitStream
+    ) internal view returns (
+        bytes memory,
+        bytes calldata,
+        uint256
+    ) {
+        address to;
+        (to, stream, bitStream) = decodeAddress(stream, bitStream);
+
+        uint256 value;
+        (value, stream) = PseudoFloat.decode(stream);
+
+        return (
+            abi.encodeWithSignature("mint(address,uint256)", to, value),
             stream,
             bitStream
         );

--- a/contracts/contracts/ExpanderEntryPoint.sol
+++ b/contracts/contracts/ExpanderEntryPoint.sol
@@ -1,0 +1,24 @@
+//SPDX-License-Identifier: Unlicense
+pragma solidity >=0.7.0 <0.9.0;
+pragma abicoder v2;
+
+interface IExpanderDelegator {
+    function run(
+        bytes calldata stream
+    ) external returns (bool[] memory successes, bytes[][] memory results);
+}
+
+contract ExpanderEntryPoint {
+    IExpanderDelegator expanderDelegator;
+
+    constructor(IExpanderDelegator expanderDelegatorParam) {
+        expanderDelegator = expanderDelegatorParam;
+    }
+
+    fallback(bytes calldata stream) external returns (bytes memory) {
+        (bool[] memory successes, bytes[][] memory results) = expanderDelegator
+            .run{ gas: type(uint256).max }(stream);
+
+        return abi.encode(successes, results);
+    }
+}

--- a/contracts/contracts/VerificationGateway.sol
+++ b/contracts/contracts/VerificationGateway.sol
@@ -21,6 +21,8 @@ contract VerificationGateway
 {
     bytes32 WALLET_DOMAIN;
     bytes32 BUNDLE_DOMAIN;
+    string constant BLS_DOMAIN_NAME = "BLS_WALLET";
+    string constant BLS_DOMAIN_VERSION = "1";
     uint8 constant BLS_KEY_LEN = 4;
 
     IBLS public immutable blsLib;
@@ -64,11 +66,15 @@ contract VerificationGateway
         blsLib = bls;
         blsWalletLogic.initialize(address(0));
         WALLET_DOMAIN = keccak256(abi.encodePacked(
+            BLS_DOMAIN_NAME,
+            BLS_DOMAIN_VERSION,
             block.chainid,
             address(this),
             "Wallet"
         ));
         BUNDLE_DOMAIN = keccak256(abi.encodePacked(
+            BLS_DOMAIN_NAME,
+            BLS_DOMAIN_VERSION,
             block.chainid,
             address(this),
             "Bundle"

--- a/contracts/networks/arbitrum-goerli.json
+++ b/contracts/networks/arbitrum-goerli.json
@@ -1,20 +1,18 @@
 {
     "parameters": {},
     "addresses": {
-        "create2Deployer": "0x036d996D6855B83cd80142f2933d8C2617dA5617",
-        "precompileCostEstimator": "0x22E4a5251C1F02de8369Dd6f192033F6CB7531A4",
-        "blsLibrary": "0xF8a11BA6eceC43e23c9896b857128a4269290e39",
-        "verificationGateway": "0xae7DF242c589D479A5cF8fEA681736e0E0Bb1FB9",
-        "blsExpander": "0x4473e39a5F33A83B81387bb5F816354F04E724a3",
-        "utilities": "0x76cE3c1F2E6d87c355560fCbd28ccAcAe03f95F6",
-        "testToken": "0x5081a39b8A5f0E35a8D959395a630b68B74Dd30f",
-        "safeSingletonFactory": "n/a"
+        "safeSingletonFactory": "0x914d7Fec6aaC8cd542e72Bca78B30650d45643d7",
+        "precompileCostEstimator": "0x6eb8F8d661eFe36daB11147830A1e690249bB830",
+        "verificationGateway": "0x84e09390992F481E98eeb100bA4f19910c145Ede",
+        "blsExpander": "0x3F99eFb259ff4d15F3a07C2449a019ab1bF7CEa5",
+        "utilities": "0x4bD2E4e99B50A2a9e6b9dABfA3C8dCD1f885F008",
+        "testToken": "0x783746Fda55512043e0BCB9b06dB620277859E02"
     },
     "auxiliary": {
         "chainid": 421613,
         "domain": "0x0054159611832e24cdd64c6a133e71d373c5f8553dde6c762e6bffe707ad83cc",
-        "genesisBlock": 1206441,
-        "deployedBy": "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266",
-        "version": "bc3d1463f163b742026f951a2574016966b5c857"
+        "genesisBlock": 17602348,
+        "deployedBy": "0x9D5e5038c47da189f8C67A587c66a952a8b45bAb",
+        "version": "52d22bb114dd2abcc4754a05bca757435a2f33fd"
     }
 }

--- a/contracts/networks/arbitrum-goerli.json
+++ b/contracts/networks/arbitrum-goerli.json
@@ -3,16 +3,17 @@
     "addresses": {
         "safeSingletonFactory": "0x914d7Fec6aaC8cd542e72Bca78B30650d45643d7",
         "precompileCostEstimator": "0x6eb8F8d661eFe36daB11147830A1e690249bB830",
-        "verificationGateway": "0x84e09390992F481E98eeb100bA4f19910c145Ede",
-        "blsExpander": "0x3F99eFb259ff4d15F3a07C2449a019ab1bF7CEa5",
+        "verificationGateway": "0xE25229F29BAD62B1198F05F32169B70a9edc84b8",
+        "blsExpander": "0x30Ae0d96Ba812F53F69deDefd8b472ce43af23A5",
         "utilities": "0x4bD2E4e99B50A2a9e6b9dABfA3C8dCD1f885F008",
-        "testToken": "0x783746Fda55512043e0BCB9b06dB620277859E02"
+        "testToken": "0x30e69AfbE8c2E8ECe8d6920512452C8d13F8962A"
     },
     "auxiliary": {
         "chainid": 421613,
-        "domain": "0x0054159611832e24cdd64c6a133e71d373c5f8553dde6c762e6bffe707ad83cc",
-        "genesisBlock": 17602348,
+        "walletDomain": "0xb8b27430df81daac9be5d58dcca2e4dd4aae72a95c3fb3f0ee9b77e5357f6bec",
+        "bundleDomain": "0xde7ef148d5c129757b1740441010559c8a17199c68ae144446131e62c0b953ff",
+        "genesisBlock": 18628869,
         "deployedBy": "0x9D5e5038c47da189f8C67A587c66a952a8b45bAb",
-        "version": "52d22bb114dd2abcc4754a05bca757435a2f33fd"
+        "version": "0d52ddb20f2a395f3fff13130459a8561533024b"
     }
 }

--- a/contracts/networks/optimism-goerli.json
+++ b/contracts/networks/optimism-goerli.json
@@ -1,20 +1,19 @@
 {
     "parameters": {},
     "addresses": {
-        "create2Deployer": "0x036d996D6855B83cd80142f2933d8C2617dA5617",
-        "precompileCostEstimator": "0x22E4a5251C1F02de8369Dd6f192033F6CB7531A4",
-        "blsLibrary": "0xF8a11BA6eceC43e23c9896b857128a4269290e39",
-        "verificationGateway": "0x643468269B044bA84D3F2190F601E3579d3236BB",
-        "blsExpander": "0x7E24FBC8A777418f519fdaB565168f19b1C8e2Fa",
-        "utilities": "0x76cE3c1F2E6d87c355560fCbd28ccAcAe03f95F6",
-        "testToken": "0xD2a233b4F7b49641eef0Aa0E4927A299737b39CB",
-        "safeSingletonFactory": "n/a"
+        "safeSingletonFactory": "0x914d7Fec6aaC8cd542e72Bca78B30650d45643d7",
+        "precompileCostEstimator": "0x6eb8F8d661eFe36daB11147830A1e690249bB830",
+        "verificationGateway": "0xE25229F29BAD62B1198F05F32169B70a9edc84b8",
+        "blsExpander": "0x30Ae0d96Ba812F53F69deDefd8b472ce43af23A5",
+        "utilities": "0x4bD2E4e99B50A2a9e6b9dABfA3C8dCD1f885F008",
+        "testToken": "0xf2149397e902D6D4E958d027F323Fd37F7Bd11eF"
     },
     "auxiliary": {
         "chainid": 420,
-        "domain": "0x0054159611832e24cdd64c6a133e71d373c5f8553dde6c762e6bffe707ad83cc",
-        "genesisBlock": 4101595,
-        "deployedBy": "0xe5deB006644a6FF28AC361Fe896D351a40AeA198",
-        "version": "1d35f4e80a5f5316158e7f01e61a721fe62f0103"
+        "walletDomain": "0x802fb686c57e5392e94fbeb158cf09881e634e133d41525be792fa87c47cfeaa",
+        "bundleDomain": "0xa5112f769feb56d1fa9bed9680d850f1362a970daff8bdffc7a231ed0fc02a84",
+        "genesisBlock": 8830153,
+        "deployedBy": "0x9D5e5038c47da189f8C67A587c66a952a8b45bAb",
+        "version": "090405ee0a630f4fb9f0c20ae995240f7474507d"
     }
 }

--- a/contracts/scripts/deploy_all.ts
+++ b/contracts/scripts/deploy_all.ts
@@ -79,8 +79,8 @@ async function main() {
     },
     auxiliary: {
       chainid,
-      walletDomain: ethers.utils.toUtf8String(walletDomain),
-      bundleDomain: ethers.utils.toUtf8String(bundleDomain),
+      walletDomain: ethers.utils.hexlify(walletDomain),
+      bundleDomain: ethers.utils.hexlify(bundleDomain),
       genesisBlock,
       deployedBy: signer.address,
       version,

--- a/contracts/scripts/deploy_all.ts
+++ b/contracts/scripts/deploy_all.ts
@@ -13,6 +13,7 @@ import { writeFile } from "fs/promises";
 import { ethers } from "hardhat";
 import { NetworkConfig } from "../clients/src";
 import deploy from "../shared/deploy";
+import getDomain from "../clients/src/signer/getDomain";
 
 dotenv.config();
 const exec = util.promisify(execCb);
@@ -48,6 +49,24 @@ async function main() {
   // These can be run in parallel
   const [testToken, version] = await Promise.all([deployToken(), getVersion()]);
 
+  const domainName = "BLS_WALLET";
+  const domainVersion = "1";
+  const walletDomain = getDomain(
+    domainName,
+    domainVersion,
+    chainid,
+    deployment.verificationGateway.address,
+    "Wallet",
+  );
+
+  const bundleDomain = getDomain(
+    domainName,
+    domainVersion,
+    chainid,
+    deployment.verificationGateway.address,
+    "Bundle",
+  );
+
   const netCfg: NetworkConfig = {
     parameters: {},
     addresses: {
@@ -60,9 +79,8 @@ async function main() {
     },
     auxiliary: {
       chainid,
-      // From VerificationGateway.sol:BLS_DOMAIN
-      domain:
-        "0x0054159611832e24cdd64c6a133e71d373c5f8553dde6c762e6bffe707ad83cc",
+      walletDomain: ethers.utils.toUtf8String(walletDomain),
+      bundleDomain: ethers.utils.toUtf8String(bundleDomain),
       genesisBlock,
       deployedBy: signer.address,
       version,

--- a/contracts/shared/deploy.ts
+++ b/contracts/shared/deploy.ts
@@ -20,6 +20,8 @@ import {
   VerificationGateway,
   VerificationGateway__factory as VerificationGatewayFactory,
   BLSRegistration,
+  ERC20Expander,
+  ERC20Expander__factory as ERC20ExpanderFactory,
 } from "../typechain-types";
 
 import { SafeSingletonFactory } from "../clients/src";
@@ -32,6 +34,7 @@ export type Deployment = {
   verificationGateway: VerificationGateway;
   blsExpander: BLSExpander;
   fallbackExpander: FallbackExpander;
+  erc20Expander: ERC20Expander;
   blsPublicKeyRegistry: BLSPublicKeyRegistry;
   addressRegistry: AddressRegistry;
   blsExpanderDelegator: BLSExpanderDelegator;
@@ -74,6 +77,7 @@ export default async function deploy(
   const {
     blsExpander,
     fallbackExpander,
+    erc20Expander,
     blsPublicKeyRegistry,
     addressRegistry,
     blsExpanderDelegator,
@@ -92,6 +96,7 @@ export default async function deploy(
     verificationGateway,
     blsExpander,
     fallbackExpander,
+    erc20Expander,
     blsPublicKeyRegistry,
     addressRegistry,
     blsExpanderDelegator,
@@ -149,14 +154,26 @@ async function deployExpanders(
     ],
   );
 
+  const erc20Expander = await singletonFactory.connectOrDeploy(
+    ERC20ExpanderFactory,
+    [
+      blsPublicKeyRegistry.address,
+      addressRegistry.address,
+      aggregatorUtilities.address,
+    ],
+    salt,
+  );
+
   await registerExpanders(blsExpanderDelegator, [
     fallbackExpander.address,
     blsRegistration.address,
+    erc20Expander.address,
   ]);
 
   return {
     blsExpander,
     fallbackExpander,
+    erc20Expander,
     blsPublicKeyRegistry,
     addressRegistry,
     blsExpanderDelegator,

--- a/contracts/shared/deploy.ts
+++ b/contracts/shared/deploy.ts
@@ -164,10 +164,10 @@ async function deployExpanders(
     salt,
   );
 
-  await registerExpanders(blsExpanderDelegator, [
-    fallbackExpander.address,
-    blsRegistration.address,
-    erc20Expander.address,
+  await Promise.all([
+    registerExpanderIfNeeded(blsExpanderDelegator, fallbackExpander.address),
+    registerExpanderIfNeeded(blsExpanderDelegator, blsRegistration.address),
+    registerExpanderIfNeeded(blsExpanderDelegator, erc20Expander.address),
   ]);
 
   return {
@@ -181,17 +181,17 @@ async function deployExpanders(
   };
 }
 
-async function registerExpanders(
+async function registerExpanderIfNeeded(
   blsExpanderDelegator: BLSExpanderDelegator,
-  expanders: string[],
+  expander: string,
 ) {
-  for (const [i, expander] of expanders.entries()) {
-    const existingExpander = await blsExpanderDelegator.expanders(i);
+  const registrations = await blsExpanderDelegator.queryFilter(
+    blsExpanderDelegator.filters.ExpanderRegistered(null, expander),
+  );
 
-    if (existingExpander === ethers.constants.AddressZero) {
-      await receiptOf(blsExpanderDelegator.registerExpander(i, expander));
-    } else if (existingExpander !== expanders[i]) {
-      throw new Error(`Existing expander at index ${i} is not ${expander}`);
-    }
+  if (registrations.length > 0) {
+    return;
   }
+
+  await receiptOf(blsExpanderDelegator.registerExpander(expander));
 }

--- a/contracts/shared/deploy.ts
+++ b/contracts/shared/deploy.ts
@@ -22,6 +22,8 @@ import {
   BLSRegistration,
   ERC20Expander,
   ERC20Expander__factory as ERC20ExpanderFactory,
+  ExpanderEntryPoint,
+  ExpanderEntryPoint__factory as ExpanderEntryPointFactory,
 } from "../typechain-types";
 
 import { SafeSingletonFactory } from "../clients/src";
@@ -40,6 +42,7 @@ export type Deployment = {
   blsExpanderDelegator: BLSExpanderDelegator;
   aggregatorUtilities: AggregatorUtilities;
   blsRegistration: BLSRegistration;
+  expanderEntryPoint: ExpanderEntryPoint;
 };
 
 export default async function deploy(
@@ -89,6 +92,12 @@ export default async function deploy(
     salt,
   );
 
+  const expanderEntryPoint = await singletonFactory.connectOrDeploy(
+    ExpanderEntryPointFactory,
+    [blsExpanderDelegator.address],
+    salt,
+  );
+
   return {
     singletonFactory,
     precompileCostEstimator,
@@ -102,6 +111,7 @@ export default async function deploy(
     blsExpanderDelegator,
     aggregatorUtilities,
     blsRegistration,
+    expanderEntryPoint,
   };
 }
 

--- a/contracts/shared/deploy.ts
+++ b/contracts/shared/deploy.ts
@@ -164,11 +164,12 @@ async function deployExpanders(
     salt,
   );
 
-  await Promise.all([
-    registerExpanderIfNeeded(blsExpanderDelegator, fallbackExpander.address),
-    registerExpanderIfNeeded(blsExpanderDelegator, blsRegistration.address),
-    registerExpanderIfNeeded(blsExpanderDelegator, erc20Expander.address),
-  ]);
+  await registerExpanderIfNeeded(
+    blsExpanderDelegator,
+    fallbackExpander.address,
+  );
+  await registerExpanderIfNeeded(blsExpanderDelegator, blsRegistration.address);
+  await registerExpanderIfNeeded(blsExpanderDelegator, erc20Expander.address);
 
   return {
     blsExpander,

--- a/contracts/shared/helpers/Fixture.ts
+++ b/contracts/shared/helpers/Fixture.ts
@@ -18,6 +18,7 @@ import {
   FallbackCompressor,
   BlsRegistrationCompressor,
   BundleCompressor,
+  Erc20Compressor,
 } from "../../clients/src";
 
 import Range from "./Range";
@@ -90,6 +91,12 @@ export default class Fixture {
       throw new Error("Fallback compressor not set up correctly");
     }
 
+    const erc20Compressor = await Erc20Compressor.connectIfDeployed(signers[0]);
+
+    if (erc20Compressor === undefined) {
+      throw new Error("ERC20 compressor not set up correctly");
+    }
+
     const blsRegistrationCompressor =
       await BlsRegistrationCompressor.connectIfDeployed(signers[0]);
 
@@ -98,6 +105,7 @@ export default class Fixture {
     }
 
     const bundleCompressor = new BundleCompressor();
+    bundleCompressor.addCompressor(2, erc20Compressor);
     bundleCompressor.addCompressor(1, blsRegistrationCompressor);
     bundleCompressor.addCompressor(0, fallbackCompressor);
 

--- a/contracts/shared/helpers/Fixture.ts
+++ b/contracts/shared/helpers/Fixture.ts
@@ -104,10 +104,10 @@ export default class Fixture {
       throw new Error("BLS registration compressor not set up correctly");
     }
 
-    const bundleCompressor = new BundleCompressor();
-    bundleCompressor.addCompressor(2, erc20Compressor);
-    bundleCompressor.addCompressor(1, blsRegistrationCompressor);
-    bundleCompressor.addCompressor(0, fallbackCompressor);
+    const bundleCompressor = new BundleCompressor(blsExpanderDelegator);
+    await bundleCompressor.addCompressor(erc20Compressor);
+    await bundleCompressor.addCompressor(blsRegistrationCompressor);
+    await bundleCompressor.addCompressor(fallbackCompressor);
 
     const privateKey = await BlsWalletWrapper.getRandomBlsPrivateKey();
 

--- a/contracts/test-integration/BlsProvider.test.ts
+++ b/contracts/test-integration/BlsProvider.test.ts
@@ -450,7 +450,6 @@ describe("BlsProvider", () => {
       to: ethers.Wallet.createRandom().address,
       value: parseEther("1"),
     });
-    const expectedToAddress = networkConfig.addresses.verificationGateway;
     const expectedFromAddress = "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266"; // Aggregator address (Hardhat account 0)
 
     // Act
@@ -463,7 +462,6 @@ describe("BlsProvider", () => {
     // Assert
     const expectedBlockNumber = await blsProvider.getBlockNumber();
     expect(transactionReceipt).to.be.an("object").that.deep.includes({
-      to: expectedToAddress,
       from: expectedFromAddress,
       contractAddress: null,
       transactionIndex: 0,
@@ -511,7 +509,6 @@ describe("BlsProvider", () => {
       value: parseEther("1"),
     });
 
-    const expectedToAddress = networkConfig.addresses.verificationGateway;
     const expectedFromAddress = "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266"; // Aggregator address (Hardhat account 0)
 
     // Act
@@ -522,7 +519,6 @@ describe("BlsProvider", () => {
     // Assert
     const expectedBlockNumber = await blsProvider.getBlockNumber();
     expect(transactionReceipt).to.be.an("object").that.deep.includes({
-      to: expectedToAddress,
       from: expectedFromAddress,
       contractAddress: null,
       transactionIndex: 0,
@@ -584,7 +580,6 @@ describe("BlsProvider", () => {
     // TODO: bls-wallet #481 Add Bls Provider getTransaction method
     expect(transactionResponse).to.be.an("object").that.deep.includes({
       hash: transactionReceipt.transactionHash,
-      to: verificationGateway,
 
       // TODO:
       // 1. When running LOCALLY, why is this hardhat account 2 instead of blsSigner.wallet.address?

--- a/contracts/test/expanders-test.ts
+++ b/contracts/test/expanders-test.ts
@@ -661,7 +661,6 @@ describe("Expanders", async function () {
     */
 
     const compressedBundle = await fx.bundleCompressor.compress(bundle);
-    console.log({ compressedBundle });
 
     await expect(
       erc20.allowance(sendWallet.address, recvWallet.address),

--- a/contracts/test/expanders-test.ts
+++ b/contracts/test/expanders-test.ts
@@ -649,7 +649,7 @@ describe("Expanders", async function () {
                 first)
       000000  - Registry index for sendWallet's public key
       00      - nonce: 0
-      0bb917  - gas: (TODO) 76,185
+      0bb917  - gas: 58,555
       01      - one action
       000000  - Registry index for ERC20 address
       03      - approve (max)

--- a/contracts/test/expanders-test.ts
+++ b/contracts/test/expanders-test.ts
@@ -67,7 +67,7 @@ describe("Expanders", async function () {
     */
     expect(hexLen(compressedBundle)).to.eq(223);
 
-    await receiptOf(fx.blsExpanderDelegator.run(compressedBundle));
+    await fx.processCompressedBundle(compressedBundle);
 
     await expect(fx.provider.getBalance(sendWallet.address)).to.eventually.eq(
       0,
@@ -142,7 +142,7 @@ describe("Expanders", async function () {
     */
     expect(hexLen(compressedBundle)).to.eq(81);
 
-    await receiptOf(fx.blsExpanderDelegator.run(compressedBundle));
+    await fx.processCompressedBundle(compressedBundle);
 
     await expect(fx.provider.getBalance(sendWallet.address)).to.eventually.eq(
       0,
@@ -229,7 +229,7 @@ describe("Expanders", async function () {
     expect(hexLen(compressedBundle)).to.eq(83);
     // Just 2 extra bytes for the tx.origin payment
 
-    await receiptOf(fx.blsExpanderDelegator.run(compressedBundle));
+    await fx.processCompressedBundle(compressedBundle);
 
     await expect(fx.provider.getBalance(sendWallet.address)).to.eventually.eq(
       0,
@@ -290,7 +290,7 @@ describe("Expanders", async function () {
     const compressedBundle = await fx.bundleCompressor.compress(bundle);
     expect(hexLen(compressedBundle)).to.eq(200);
 
-    await receiptOf(fx.processCompressedBundleWithExtraGas(compressedBundle));
+    await fx.processCompressedBundleWithExtraGas(compressedBundle);
 
     await expect(
       fx.fallbackCompressor.addressRegistry.reverseLookup(wallet.address),
@@ -364,7 +364,7 @@ describe("Expanders", async function () {
     const compressedBundle = await fx.bundleCompressor.compress(bundle);
     expect(hexLen(compressedBundle)).to.eq(201);
 
-    await receiptOf(fx.processCompressedBundleWithExtraGas(compressedBundle));
+    await fx.processCompressedBundleWithExtraGas(compressedBundle);
 
     await expect(
       fx.fallbackCompressor.addressRegistry.reverseLookup(wallet.address),
@@ -499,7 +499,8 @@ describe("Expanders", async function () {
       13e9fe34f0ec3465d44718cb6f93697dfbb0000a54287b3acaea5594f36b9aa1
               - signature
     */
-    await receiptOf(fx.blsExpanderDelegator.run(compressedBundle012));
+
+    await fx.processCompressedBundle(compressedBundle012);
 
     await expect(fx.provider.getBalance(wallets[0].address)).to.eventually.eq(
       ethers.utils
@@ -588,7 +589,7 @@ describe("Expanders", async function () {
 
     const compressedBundle = await fx.bundleCompressor.compress(bundle);
 
-    await receiptOf(fx.blsExpanderDelegator.run(compressedBundle));
+    await fx.processCompressedBundle(compressedBundle);
 
     await expect(erc20.balanceOf(sendWallet.address)).to.eventually.eq(
       ethers.utils.parseEther("0.9"),
@@ -666,7 +667,7 @@ describe("Expanders", async function () {
       erc20.allowance(sendWallet.address, recvWallet.address),
     ).to.eventually.eq(0);
 
-    await receiptOf(fx.blsExpanderDelegator.run(compressedBundle));
+    await fx.processCompressedBundle(compressedBundle);
 
     await expect(
       erc20.allowance(sendWallet.address, recvWallet.address),

--- a/extension/package.json
+++ b/extension/package.json
@@ -37,7 +37,7 @@
     "assert-browserify": "^2.0.0",
     "async-mutex": "^0.3.2",
     "axios": "^0.27.2",
-    "bls-wallet-clients": "0.8.3-c34db60",
+    "bls-wallet-clients": "0.8.3-0d52ddb",
     "browser-passworder": "^2.0.3",
     "bs58check": "^2.1.2",
     "crypto-browserify": "^3.12.0",

--- a/extension/yarn.lock
+++ b/extension/yarn.lock
@@ -1791,6 +1791,16 @@
   version "5.7.0"
   resolved "https://registry.yarnpkg.com/@ethersproject/transactions/-/transactions-5.7.0.tgz#91318fc24063e057885a6af13fdb703e1f993d3b"
   integrity sha512-kmcNicCp1lp8qanMTC3RIikGgoJ80ztTyvtsFvCYpSCfkjhD0jZ2LOrnbcuxuToLIUYYf+4XwD1rP+B/erDIhQ==
+  dependencies:
+    "@ethersproject/address" "^5.7.0"
+    "@ethersproject/bignumber" "^5.7.0"
+    "@ethersproject/bytes" "^5.7.0"
+    "@ethersproject/constants" "^5.7.0"
+    "@ethersproject/keccak256" "^5.7.0"
+    "@ethersproject/logger" "^5.7.0"
+    "@ethersproject/properties" "^5.7.0"
+    "@ethersproject/rlp" "^5.7.0"
+    "@ethersproject/signing-key" "^5.7.0"
 
 "@ethersproject/transactions@^5.5.0", "@ethersproject/transactions@^5.6.2":
   version "5.6.2"
@@ -2888,10 +2898,10 @@ blakejs@^1.1.0:
   resolved "https://registry.yarnpkg.com/blakejs/-/blakejs-1.2.1.tgz#5057e4206eadb4a97f7c0b6e197a505042fc3814"
   integrity sha512-QXUSXI3QVc/gJME0dBpXrag1kbzOqCjCX8/b54ntNyW6sjtoqxqRk3LTmXzaJoh71zMsDCjM+47jS7XiwN/+fQ==
 
-bls-wallet-clients@0.8.3-c34db60:
-  version "0.8.3-c34db60"
-  resolved "https://registry.yarnpkg.com/bls-wallet-clients/-/bls-wallet-clients-0.8.3-c34db60.tgz#85a0c9d335e967723e48d736cc63e13ee17b7dfe"
-  integrity sha512-paXXfQcNGYR9rS9A5TfoCX1W11GQ9MZUvr9z4Vyrj8U98UZvldPvwgI7J2g87RUKJCqKlx//j/Hul7PRjPgBAA==
+bls-wallet-clients@0.8.3-0d52ddb:
+  version "0.8.3-0d52ddb"
+  resolved "https://registry.yarnpkg.com/bls-wallet-clients/-/bls-wallet-clients-0.8.3-0d52ddb.tgz#d8ce03055c196c6e8bc8a7bb0d85949f1829bc0f"
+  integrity sha512-6ltB4/xw7/roU6WaLy5hTP4ofmtqy8dYYY2hnWVqwGrtl75M08ljha39x2GAKmzJz4cnxSPXJcze74xWk3R3Dg==
   dependencies:
     "@thehubbleproject/bls" "^0.5.1"
     ethers "^5.7.2"


### PR DESCRIPTION
## What is this PR doing?

Merges in changes from `contract-updates`.

I needed to add a few changes to make this work:

1. Resolve a merge conflict with `getOperationResults`
2. Fix linting error due to deno deprecating `Deno.run`
3. Update deployments on arbitrum-goerli and optimism-goerli
4. Update `bls-wallet-clients` in aggregator and extension
5. Remove assertions about the `to` address during test-integration (breaking because the aggregator now uses the entry point rather than `VerificationGateway` at the top level, and these tests didn't really need to assert the to address anyway)

You can see the diff for (2)-(5) here:
https://github.com/web3well/bls-wallet/compare/0047f14...merge-in-contract-updates

For (1), this is the merge conflict I resolved:

<details>
<summary>Click to expand</summary>

```merge
/**
 * Gets the results of operations (and actions) run through VerificationGateway.processBundle.
 * Decodes unsuccessful operations into an error message and the index of the action that failed.
 *
 * @param transactionReceipt Transaction receipt from a VerificationGateway.processBundle transaction
 * @returns An array of decoded operation results
 */
export const getOperationResults = (
  txnReceipt: ContractReceipt,
): OperationResult[] => {
<<<<<<< HEAD
  if (!txnReceipt.events?.length) {
    throw new Error(
      `no events found in transaction ${txnReceipt.transactionHash}, are you sure it is a ContractReceipt from a VerificationGateway.processBundle transaction?`,
    );
  }

  const walletOpProcessedEvents = txnReceipt.events?.filter(
    (e) => e.event === "WalletOperationProcessed",
  );
  if (!walletOpProcessedEvents?.length) {
||||||| 638e1a1f
  const walletOpProcessedEvents = txnReceipt.events?.filter(
    (e) => e.event === "WalletOperationProcessed",
  );
  if (!walletOpProcessedEvents?.length) {
=======
  let walletOpProcessedEvents: Result[];

  if (txnReceipt.events !== undefined) {
    walletOpProcessedEvents = txnReceipt.events
      .filter((e) => e.event === "WalletOperationProcessed")
      .map(({ args }) => {
        if (!args) {
          throw new Error("WalletOperationProcessed event missing args");
        }

        return args;
      });
  } else if (txnReceipt.logs !== undefined) {
    const vgInterface = VerificationGatewayFactory.createInterface();

    const WalletOperationProcessed = vgInterface.getEvent(
      "WalletOperationProcessed",
    );

    walletOpProcessedEvents = txnReceipt.logs
      .filter(
        (log) =>
          log.topics[0] === vgInterface.getEventTopic(WalletOperationProcessed),
      )
      .map((log) =>
        vgInterface.decodeEventLog(
          WalletOperationProcessed,
          log.data,
          log.topics,
        ),
      );
  } else {
    walletOpProcessedEvents = [];
  }

  if (walletOpProcessedEvents.length === 0) {
>>>>>>> origin/contract-updates
    throw new Error(
      `no WalletOperationProcessed events found in transaction ${txnReceipt.transactionHash}`,
    );
  }

  return walletOpProcessedEvents.reduce<OperationResult[]>(
    (opResults, { wallet, nonce, actions: rawActions, success, results }) => {
      const actions = rawActions.map(
        ({
          ethValue,
          contractAddress,
          encodedFunction,
        }: {
          ethValue: BigNumber;
          contractAddress: string;
          encodedFunction: string;
        }) => ({
          ethValue,
          contractAddress,
          encodedFunction,
        }),
      );
      const error = getError(success, results);

      const ret = [
        ...opResults,
        {
          walletAddress: wallet,
          nonce,
          actions,
          success,
          results,
          error,
        },
      ];

      return ret;
    },
    [],
  );
};
```

</details>

I resolved this by clicking 'Accept Incoming Change' and also deleting the test `fails if no events are in transaction`.

The reason for this conflict is that I ran into a similar issue to this one: https://github.com/web3well/bls-wallet/pull/583 (during compression work, which has already been reviewed+merged into contract-updates). The problem in my case was that using `sendTransaction` directly (instead of `.processBundle`) doesn't generate the `.events` property on the `ContractReceipt`. I implemented a more complete fix to this problem by processing the `.logs` property to get the same information, which is still there when using this lower-level API.

For this reason, it isn't appropriate to throw an error when `.events` is missing, which is what the test I deleted was checking for. There is still a similar test called `fails if no WalletOperationProcessed events are in transaction` which didn't need any modification.

## How can these changes be manually tested?

Run all the tests (covered by CI), also run an aggregator and the extension and make sure you can do an ETH transfer.

(EDIT: We found out these instructions are **wrong**. Oops.)
Additionally, you could check that I resolved the merge conflict as stated above like this:
1. `git fetch origin`
2. `git checkout 'origin/main@{2023-05-03T06:32:14.306Z}'` (checks out the commit from `main` at that timestamp)
3. `git merge 'origin/contract-updates@{2023-05-03T06:32:14.306Z}'`
4. Resolve the conflict in `OperationResults.ts` by clicking 'Accept Incoming Change' in vs code (or by manually accepting the `origin/contract-updates@{2023-05-03T06:32:14.306Z}` version, deleting the other section(s))
5. Delete the test called `fails if no events are in transaction`
6. `git add .`
7. `git commit`
8. Now run `git diff 0047f14` and verify that the output is empty

This confirms that `0047f14` was formed from merging `contract-updates` into `main` (and all those changes have already been reviewed) plus the merge resolution that I specified.

It is therefore appropriate to review this PR as the validity of that merge resolution plus the diff generated by `git diff 0047f14...origin/merge-in-contract-updates` (also viewable on github using [this link](https://github.com/web3well/bls-wallet/compare/0047f14...merge-in-contract-updates) provided previously).

## Does this PR resolve or contribute to any issues?

Nope.

## Checklist
- [x] I have manually tested these changes
- [x] Post a link to the PR in the group chat

## Guidelines
- If your PR is not ready, mark it as a draft
- The `resolve conversation` button is for reviewers, not authors
  - (But add a 'done' comment or similar)
