### PR TITLE
Add ability to blsWalletSigner to verify multiple addresses

### DIFF
--- a/aggregator-proxy/package.json
+++ b/aggregator-proxy/package.json
@@ -21,7 +21,7 @@
     "@types/koa__cors": "^3.3.0",
     "@types/koa__router": "^8.0.11",
     "@types/node-fetch": "^2.6.1",
-    "bls-wallet-clients": "0.9.0",
+    "bls-wallet-clients": "0.8.3-a9c0b22",
     "fp-ts": "^2.12.1",
     "io-ts": "^2.2.16",
     "io-ts-reporters": "^2.0.1",

--- a/aggregator-proxy/package.json
+++ b/aggregator-proxy/package.json
@@ -21,7 +21,7 @@
     "@types/koa__cors": "^3.3.0",
     "@types/koa__router": "^8.0.11",
     "@types/node-fetch": "^2.6.1",
-    "bls-wallet-clients": "0.8.3-a9c0b22",
+    "bls-wallet-clients": "0.9.0-1620721",
     "fp-ts": "^2.12.1",
     "io-ts": "^2.2.16",
     "io-ts-reporters": "^2.0.1",

--- a/aggregator-proxy/yarn.lock
+++ b/aggregator-proxy/yarn.lock
@@ -887,10 +887,10 @@ bech32@1.1.4:
   resolved "https://registry.yarnpkg.com/bech32/-/bech32-1.1.4.tgz#e38c9f37bf179b8eb16ae3a772b40c356d4832e9"
   integrity sha512-s0IrSOzLlbvX7yp4WBfPITzpAU8sqQcpsmwXDiKwrG4r491vwCO/XpejasRNl0piBMe/DvP4Tz0mIS/X1DPJBQ==
 
-bls-wallet-clients@0.8.3-a9c0b22:
-  version "0.8.3-a9c0b22"
-  resolved "https://registry.yarnpkg.com/bls-wallet-clients/-/bls-wallet-clients-0.8.3-a9c0b22.tgz#b214ae72993280b0faab51caedcf95171878f158"
-  integrity sha512-P7Kad9ylcRO5truvGMp+lkDr8rLgFtH6DdTdrWeE41zQLg++5XQj7SMZofe/2EPOPRSAfyF6HJscmH10VCdH4A==
+bls-wallet-clients@0.9.0-1620721:
+  version "0.9.0-1620721"
+  resolved "https://registry.yarnpkg.com/bls-wallet-clients/-/bls-wallet-clients-0.9.0-1620721.tgz#572798d10fa6246ab44bbd0e11b97df11abd6d15"
+  integrity sha512-ekSrK2bCiWoTuhnqdKTp0kXDuIUmE3lc9pqtonOAZC/6ReU2cVbW+F6U1/echtagdWL6GBArJgB2JnVQVznRpg==
   dependencies:
     "@thehubbleproject/bls" "^0.5.1"
     ethers "^5.7.2"

--- a/aggregator-proxy/yarn.lock
+++ b/aggregator-proxy/yarn.lock
@@ -887,10 +887,10 @@ bech32@1.1.4:
   resolved "https://registry.yarnpkg.com/bech32/-/bech32-1.1.4.tgz#e38c9f37bf179b8eb16ae3a772b40c356d4832e9"
   integrity sha512-s0IrSOzLlbvX7yp4WBfPITzpAU8sqQcpsmwXDiKwrG4r491vwCO/XpejasRNl0piBMe/DvP4Tz0mIS/X1DPJBQ==
 
-bls-wallet-clients@0.9.0:
-  version "0.9.0"
-  resolved "https://registry.yarnpkg.com/bls-wallet-clients/-/bls-wallet-clients-0.9.0.tgz#edfbdb24011856b52d9b438af174b6acbeda27ec"
-  integrity sha512-ebEifAPkGfTft6xdVVgQfC6HEXzgw+wX2d76w2K1OUsB4FeKiAYRLMXtnKtl7tdQoMknHElD6xrLChKaCACYLQ==
+bls-wallet-clients@0.8.3-a9c0b22:
+  version "0.8.3-a9c0b22"
+  resolved "https://registry.yarnpkg.com/bls-wallet-clients/-/bls-wallet-clients-0.8.3-a9c0b22.tgz#b214ae72993280b0faab51caedcf95171878f158"
+  integrity sha512-P7Kad9ylcRO5truvGMp+lkDr8rLgFtH6DdTdrWeE41zQLg++5XQj7SMZofe/2EPOPRSAfyF6HJscmH10VCdH4A==
   dependencies:
     "@thehubbleproject/bls" "^0.5.1"
     ethers "^5.7.2"

--- a/aggregator/deps.ts
+++ b/aggregator/deps.ts
@@ -54,7 +54,7 @@ export type {
   PublicKey,
   Signature,
   VerificationGateway,
-} from "https://esm.sh/bls-wallet-clients@0.9.0";
+} from "https://esm.sh/bls-wallet-clients@0.8.3-a9c0b22";
 
 export {
   Aggregator as AggregatorClient,
@@ -70,10 +70,10 @@ export {
   getConfig,
   MockERC20Factory,
   VerificationGatewayFactory,
-} from "https://esm.sh/bls-wallet-clients@0.9.0";
+} from "https://esm.sh/bls-wallet-clients@0.8.3-a9c0b22";
 
 // Workaround for esbuild's export-star bug
-import blsWalletClients from "https://esm.sh/bls-wallet-clients@0.9.0";
+import blsWalletClients from "https://esm.sh/bls-wallet-clients@0.8.3-a9c0b22";
 const { bundleFromDto, bundleToDto, initBlsWalletSigner } = blsWalletClients;
 export { bundleFromDto, bundleToDto, initBlsWalletSigner };
 

--- a/aggregator/deps.ts
+++ b/aggregator/deps.ts
@@ -54,7 +54,7 @@ export type {
   PublicKey,
   Signature,
   VerificationGateway,
-} from "https://esm.sh/bls-wallet-clients@0.8.3-a9c0b22";
+} from "https://esm.sh/bls-wallet-clients@0.9.0-1620721";
 
 export {
   Aggregator as AggregatorClient,
@@ -70,10 +70,10 @@ export {
   getConfig,
   MockERC20Factory,
   VerificationGatewayFactory,
-} from "https://esm.sh/bls-wallet-clients@0.8.3-a9c0b22";
+} from "https://esm.sh/bls-wallet-clients@0.9.0-1620721";
 
 // Workaround for esbuild's export-star bug
-import blsWalletClients from "https://esm.sh/bls-wallet-clients@0.8.3-a9c0b22";
+import blsWalletClients from "https://esm.sh/bls-wallet-clients@0.9.0-1620721";
 const { bundleFromDto, bundleToDto, initBlsWalletSigner } = blsWalletClients;
 export { bundleFromDto, bundleToDto, initBlsWalletSigner };
 

--- a/aggregator/src/app/BundleService.ts
+++ b/aggregator/src/app/BundleService.ts
@@ -156,14 +156,15 @@ export default class BundleService {
 
     const failures: TransactionFailure[] = [];
 
-    for (const walletAddr of walletAddresses) {
-      const signedCorrectly = this.blsWalletSigner.verify(bundle, walletAddr);
-      if (!signedCorrectly) {
-        failures.push({
-          type: "invalid-signature",
-          description: `invalid signature for wallet address ${walletAddr}`,
-        });
-      }
+    const signedCorrectly = this.blsWalletSigner.verify(
+      bundle,
+      walletAddresses,
+    );
+    if (!signedCorrectly) {
+      failures.push({
+        type: "invalid-signature",
+        description: `invalid bundle signature for signature ${bundle.signature}`,
+      });
     }
 
     failures.push(...await this.ethereumService.checkNonces(bundle));

--- a/contracts/clients/package.json
+++ b/contracts/clients/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bls-wallet-clients",
-  "version": "0.8.3-a9c0b22",
+  "version": "0.9.0-1620721",
   "description": "Client libraries for interacting with BLS Wallet components",
   "main": "dist/src/index.js",
   "types": "dist/src/index.d.ts",

--- a/contracts/clients/package.json
+++ b/contracts/clients/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bls-wallet-clients",
-  "version": "0.9.0",
+  "version": "0.8.3-a9c0b22",
   "description": "Client libraries for interacting with BLS Wallet components",
   "main": "dist/src/index.js",
   "types": "dist/src/index.d.ts",

--- a/contracts/clients/src/signer/verify.ts
+++ b/contracts/clients/src/signer/verify.ts
@@ -6,7 +6,7 @@ import type { Bundle } from "./types";
 import isValidEmptyBundle from "./isValidEmptyBundle";
 
 export default (domain: Uint8Array) =>
-  (bundle: Bundle, walletAddress: string): boolean => {
+  (bundle: Bundle, walletAddresses: Array<string>): boolean => {
     // hubbleBls verifier incorrectly rejects empty bundles
     if (isValidEmptyBundle(bundle)) {
       return true;
@@ -25,8 +25,8 @@ export default (domain: Uint8Array) =>
         BigNumber.from(n2).toHexString(),
         BigNumber.from(n3).toHexString(),
       ]),
-      bundle.operations.map((op) =>
-        encodeMessageForSigning()(op, walletAddress),
+      bundle.operations.map((op, i) =>
+        encodeMessageForSigning()(op, walletAddresses[i]),
       ),
     );
   };

--- a/contracts/clients/test/index.test.ts
+++ b/contracts/clients/test/index.test.ts
@@ -65,7 +65,7 @@ describe("index", () => {
       "0x2f90b24bbc03de665816b3a632e0c7b5fb837c87541d9337480671613cf1359c",
     ]);
 
-    expect(verify(bundle, walletAddress)).to.equal(true);
+    expect(verify(bundle, [walletAddress])).to.equal(true);
 
     const { sign: signWithOtherPrivateKey } = await initBlsWalletSigner({
       chainId: 123,
@@ -79,7 +79,7 @@ describe("index", () => {
         .signature,
     };
 
-    expect(verify(bundleBadSig, walletAddress)).to.equal(false);
+    expect(verify(bundleBadSig, [walletAddress])).to.equal(false);
 
     const bundleBadMessage: Bundle = {
       senderPublicKeys: bundle.senderPublicKeys,
@@ -99,7 +99,7 @@ describe("index", () => {
       signature: bundle.signature,
     };
 
-    expect(verify(bundleBadMessage, walletAddress)).to.equal(false);
+    expect(verify(bundleBadMessage, [walletAddress])).to.equal(false);
   });
 
   it("aggregates transactions", async () => {
@@ -131,11 +131,11 @@ describe("index", () => {
       "0x0235a99bcd1f0793efb7f3307cd349f211a433f60cfab795f5f976298f17a768",
     ]);
 
-    expect(verify(bundle1, walletAddress)).to.equal(true);
-    expect(verify(bundle2, otherWalletAddress)).to.equal(true);
+    expect(verify(bundle1, [walletAddress])).to.equal(true);
+    expect(verify(bundle2, [otherWalletAddress])).to.equal(true);
 
-    expect(verify(bundle1, otherWalletAddress)).to.equal(false);
-    expect(verify(bundle2, walletAddress)).to.equal(false);
+    expect(verify(bundle1, [otherWalletAddress])).to.equal(false);
+    expect(verify(bundle2, [walletAddress])).to.equal(false);
 
     const aggBundleBadMessage: Bundle = {
       ...aggBundle,
@@ -156,8 +156,12 @@ describe("index", () => {
       ],
     };
 
-    expect(verify(aggBundleBadMessage, walletAddress)).to.equal(false);
-    expect(verify(aggBundleBadMessage, otherWalletAddress)).to.equal(false);
+    expect(
+      verify(aggBundleBadMessage, [walletAddress, otherWalletAddress]),
+    ).to.equal(false);
+    expect(
+      verify(aggBundleBadMessage, [otherWalletAddress, walletAddress]),
+    ).to.equal(false);
   });
 
   it("can aggregate transactions which already have multiple subTransactions", async () => {
@@ -188,8 +192,9 @@ describe("index", () => {
     const aggBundle2 = aggregate(bundles.slice(2, 4));
 
     const aggAggBundle = aggregate([aggBundle1, aggBundle2]);
+    const walletAddresses = new Array(4).fill(walletAddress);
 
-    expect(verify(aggAggBundle, walletAddress)).to.equal(true);
+    expect(verify(aggAggBundle, walletAddresses)).to.equal(true);
   });
 
   it("generates expected publicKeyStr", async () => {
@@ -238,6 +243,6 @@ describe("index", () => {
 
     const emptyBundle = aggregate([]);
 
-    expect(verify(emptyBundle, samples.walletAddress)).to.equal(true);
+    expect(verify(emptyBundle, [samples.walletAddress])).to.equal(true);
   });
 });

--- a/contracts/clients/test/index.test.ts
+++ b/contracts/clients/test/index.test.ts
@@ -137,6 +137,10 @@ describe("index", () => {
     expect(verify(bundle1, [otherWalletAddress])).to.equal(false);
     expect(verify(bundle2, [walletAddress])).to.equal(false);
 
+    expect(verify(aggBundle, [walletAddress, otherWalletAddress])).to.equal(
+      true,
+    );
+
     const aggBundleBadMessage: Bundle = {
       ...aggBundle,
       operations: [
@@ -195,6 +199,36 @@ describe("index", () => {
     const walletAddresses = new Array(4).fill(walletAddress);
 
     expect(verify(aggAggBundle, walletAddresses)).to.equal(true);
+  });
+
+  it("should fail to verify bundle with wallet address mismatches", async () => {
+    const {
+      bundleTemplate,
+      privateKey,
+      otherPrivateKey,
+      walletAddress,
+      otherWalletAddress,
+      verificationGatewayAddress,
+    } = samples;
+
+    const { sign, aggregate, verify } = await initBlsWalletSigner({
+      chainId: 123,
+      verificationGatewayAddress,
+      privateKey,
+    });
+    const { sign: signWithOtherPrivateKey } = await initBlsWalletSigner({
+      chainId: 123,
+      verificationGatewayAddress,
+      privateKey: otherPrivateKey,
+    });
+
+    const bundle1 = sign(bundleTemplate, walletAddress);
+    const bundle2 = signWithOtherPrivateKey(bundleTemplate, otherWalletAddress);
+    const aggBundle = aggregate([bundle1, bundle2]);
+
+    expect(verify(aggBundle, [otherWalletAddress, walletAddress])).to.equal(
+      false,
+    );
   });
 
   it("generates expected publicKeyStr", async () => {

--- a/contracts/test-integration/BlsProvider.test.ts
+++ b/contracts/test-integration/BlsProvider.test.ts
@@ -116,8 +116,6 @@ describe("BlsProvider", () => {
 
   it("should throw an error when sending a modified signed transaction", async () => {
     // Arrange
-    const address = await blsSigner.getAddress();
-
     const signedTransaction = await blsSigner.signTransaction({
       value: parseEther("1"),
       to: ethers.Wallet.createRandom().address,
@@ -134,7 +132,7 @@ describe("BlsProvider", () => {
     // Assert
     await expect(result()).to.be.rejectedWith(
       Error,
-      `[{"type":"invalid-signature","description":"invalid signature for wallet address ${address}"}]`,
+      `[{"type":"invalid-signature","description":"invalid bundle signature for signature ${userBundle.signature}"}]`,
     );
   });
 
@@ -286,8 +284,6 @@ describe("BlsProvider", () => {
 
   it("should throw an error when sending a modified signed transaction", async () => {
     // Arrange
-    const address = await blsSigner.getAddress();
-
     const signedTransaction = await blsSigner.signTransactionBatch({
       transactions: [
         {
@@ -309,7 +305,7 @@ describe("BlsProvider", () => {
     // Assert
     await expect(result()).to.be.rejectedWith(
       Error,
-      `[{"type":"invalid-signature","description":"invalid signature for wallet address ${address}"}]`,
+      `[{"type":"invalid-signature","description":"invalid bundle signature for signature ${userBundle.signature}"}]`,
     );
   });
 

--- a/extension/package.json
+++ b/extension/package.json
@@ -37,7 +37,7 @@
     "assert-browserify": "^2.0.0",
     "async-mutex": "^0.3.2",
     "axios": "^0.27.2",
-    "bls-wallet-clients": "0.8.3-a9c0b22",
+    "bls-wallet-clients": "0.9.0-1620721",
     "browser-passworder": "^2.0.3",
     "bs58check": "^2.1.2",
     "crypto-browserify": "^3.12.0",

--- a/extension/package.json
+++ b/extension/package.json
@@ -37,7 +37,7 @@
     "assert-browserify": "^2.0.0",
     "async-mutex": "^0.3.2",
     "axios": "^0.27.2",
-    "bls-wallet-clients": "0.9.0",
+    "bls-wallet-clients": "0.8.3-a9c0b22",
     "browser-passworder": "^2.0.3",
     "bs58check": "^2.1.2",
     "crypto-browserify": "^3.12.0",

--- a/extension/yarn.lock
+++ b/extension/yarn.lock
@@ -2898,10 +2898,10 @@ blakejs@^1.1.0:
   resolved "https://registry.yarnpkg.com/blakejs/-/blakejs-1.2.1.tgz#5057e4206eadb4a97f7c0b6e197a505042fc3814"
   integrity sha512-QXUSXI3QVc/gJME0dBpXrag1kbzOqCjCX8/b54ntNyW6sjtoqxqRk3LTmXzaJoh71zMsDCjM+47jS7XiwN/+fQ==
 
-bls-wallet-clients@0.9.0:
-  version "0.9.0"
-  resolved "https://registry.yarnpkg.com/bls-wallet-clients/-/bls-wallet-clients-0.9.0.tgz#edfbdb24011856b52d9b438af174b6acbeda27ec"
-  integrity sha512-ebEifAPkGfTft6xdVVgQfC6HEXzgw+wX2d76w2K1OUsB4FeKiAYRLMXtnKtl7tdQoMknHElD6xrLChKaCACYLQ==
+bls-wallet-clients@0.8.3-a9c0b22:
+  version "0.8.3-a9c0b22"
+  resolved "https://registry.yarnpkg.com/bls-wallet-clients/-/bls-wallet-clients-0.8.3-a9c0b22.tgz#b214ae72993280b0faab51caedcf95171878f158"
+  integrity sha512-P7Kad9ylcRO5truvGMp+lkDr8rLgFtH6DdTdrWeE41zQLg++5XQj7SMZofe/2EPOPRSAfyF6HJscmH10VCdH4A==
   dependencies:
     "@thehubbleproject/bls" "^0.5.1"
     ethers "^5.7.2"

--- a/extension/yarn.lock
+++ b/extension/yarn.lock
@@ -2898,10 +2898,10 @@ blakejs@^1.1.0:
   resolved "https://registry.yarnpkg.com/blakejs/-/blakejs-1.2.1.tgz#5057e4206eadb4a97f7c0b6e197a505042fc3814"
   integrity sha512-QXUSXI3QVc/gJME0dBpXrag1kbzOqCjCX8/b54ntNyW6sjtoqxqRk3LTmXzaJoh71zMsDCjM+47jS7XiwN/+fQ==
 
-bls-wallet-clients@0.8.3-a9c0b22:
-  version "0.8.3-a9c0b22"
-  resolved "https://registry.yarnpkg.com/bls-wallet-clients/-/bls-wallet-clients-0.8.3-a9c0b22.tgz#b214ae72993280b0faab51caedcf95171878f158"
-  integrity sha512-P7Kad9ylcRO5truvGMp+lkDr8rLgFtH6DdTdrWeE41zQLg++5XQj7SMZofe/2EPOPRSAfyF6HJscmH10VCdH4A==
+bls-wallet-clients@0.9.0-1620721:
+  version "0.9.0-1620721"
+  resolved "https://registry.yarnpkg.com/bls-wallet-clients/-/bls-wallet-clients-0.9.0-1620721.tgz#572798d10fa6246ab44bbd0e11b97df11abd6d15"
+  integrity sha512-ekSrK2bCiWoTuhnqdKTp0kXDuIUmE3lc9pqtonOAZC/6ReU2cVbW+F6U1/echtagdWL6GBArJgB2JnVQVznRpg==
   dependencies:
     "@thehubbleproject/bls" "^0.5.1"
     ethers "^5.7.2"


### PR DESCRIPTION
## What is this PR doing?
1. Fixes the `blsWalletSigner.verify` bug which means it cannot verify bundles with more than one address 
2. Updates the BundleService to use the updated API

## How can these changes be manually tested?
- Run new tests

## Does this PR resolve or contribute to any issues?
Resolves #392 

## Checklist
- [x] I have manually tested these changes
- [x] Post a link to the PR in the group chat

## Guidelines
- If your PR is not ready, mark it as a draft
- The `resolve conversation` button is for reviewers, not authors
  - (But add a 'done' comment or similar)
